### PR TITLE
rename project_dimension to base_dimension

### DIFF
--- a/doc/data_format.md
+++ b/doc/data_format.md
@@ -6,12 +6,12 @@ Dataset registration is required before it can be ingested into `dsgrid`. Regist
 - `dataset.toml`: 
     - configuration file that holds all other metadata details
 - `project.toml`:
-    - defines project requirements and any mapping required to map datasets to project dimensions
+    - defines project requirements and any mapping required to map datasets to Base Dimensions
 	- For mapping options, select from `no mapping`, `association table`, or `association table with a scaling factor`
-	- If `no mapping`, project dimensions must match dataset dimensions.
+	- If `no mapping`, Base Dimensions must match dataset dimensions.
 	- Submit `association table` as an input .toml file for `dataset-submit`.
 - `project_mapping.toml`: 
-    - defines `association table` to map dataset to project dimensions
+    - defines `association table` to map dataset to Base Dimensions
 
 ### Data Tables
 - `load_data`: contains load time series by end use columns indexed by a dataframe index, as shown below:
@@ -43,7 +43,7 @@ Dataset registration is required before it can be ingested into `dsgrid`. Regist
 ```
 
 - `dataset_dimension_mapping` (optional): defines the conversion mapping from base data file dimensions to dataset dimensions (e.g., ComStock locational multipliers)
-- `Project_dimension_mapping` (optional): defines the conversion mapping from dataset dimensions to project dimensions <span style="color:red">(is this a type of association table?)</span> (e.g., mapping to convert from dataset spatial resolution to project spatial resolution)
+- `Project_dimension_mapping` (optional): defines the conversion mapping from dataset dimensions to Base Dimensions <span style="color:red">(is this a type of association table?)</span> (e.g., mapping to convert from dataset spatial resolution to project spatial resolution)
 - `scaling_factor_table(s)` (optional): store scaling factors for data disaggregation from one dimension to another
 
 ### Data Partitioning

--- a/doc/data_format.rst
+++ b/doc/data_format.rst
@@ -15,18 +15,18 @@ Registration entries are stored on S3.
 -  ``project.toml``:
 
    -  defines project requirements and any mapping required to map
-      datasets to project dimensions
+      datasets to Base Dimensions
    -  For mapping options, select from ``no mapping``,
       ``association table``, or
       ``association table with a scaling factor``
-   -  If ``no mapping``, project dimensions must match dataset
+   -  If ``no mapping``, Base Dimensions must match dataset
       dimensions.
    -  Submit ``association table`` as an input .toml file for
       ``dataset-submit``.
 
 -  ``project_mapping.toml``:
 
-   -  defines ``association table`` to map dataset to project dimensions
+   -  defines ``association table`` to map dataset to Base Dimensions
 
 Data Tables
 ~~~~~~~~~~~
@@ -65,7 +65,7 @@ Data Tables
    mapping from base data file dimensions to dataset dimensions (e.g.,
    ComStock locational multipliers)
 -  ``Project_dimension_mapping`` (optional): defines the conversion
-   mapping from dataset dimensions to project dimensions (is this a type
+   mapping from dataset dimensions to Base Dimensions (is this a type
    of association table?) (e.g., mapping to convert from dataset spatial
    resolution to project spatial resolution)
 -  ``scaling_factor_table(s)`` (optional): store scaling factors for

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -141,7 +141,7 @@ class DimensionModel(DimensionBaseModel):
     )
     # TODO: I think we may remove mappings altogether in favor of associations
     # TODO: I think we need to add the association table to
-    #   dimensions.associations.project_dimensions in the config
+    #   dimensions.associations.base_dimensions in the config
     association_table: Optional[str] = Field(
         title="association_table",
         description="optional table that provides mappings of foreign keys",

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -57,7 +57,7 @@ class Project:
 
         project_dimension_store = DimensionStore.load(
             itertools.chain(
-                config.project_dimensions.values(), config.supplemental_dimensions.values()
+                config.base_dimensions.values(), config.supplemental_dimensions.values()
             ),
         )
         dataset_dim_stores = {}
@@ -128,8 +128,8 @@ class Project:
     The code below is subject to change.
     """
 
-    def _iter_project_dimensions(self):
-        for dimension in self.config.dimensions.project_dimensions:
+    def _iter_base_dimensions(self):
+        for dimension in self.config.dimensions.base_dimensions:
             yield dimension
 
     def _iter_input_datasets(self):
@@ -140,7 +140,7 @@ class Project:
         return [x.dataset_id for x in self._iter_input_datasets()]
 
     def get_project_dimension(self, dimension_type):
-        for dimension in self._iter_project_dimensions():
+        for dimension in self._iter_base_dimensions():
             if dimension.dimension_type == dimension_type:
                 return dimension
         raise DSGInvalidField(f"{dimension_type} is not stored")

--- a/dsgrid/submit/submit_dataset.py
+++ b/dsgrid/submit/submit_dataset.py
@@ -169,13 +169,13 @@ class SubmitDataset(DSGBaseModel):
         if not association_tables:
             project_config = cls.get_config("project", values["project_version"])
             dataset_config = cls.get_config("dataset", values["dataset_version"])
-            project_dimensions = [p for p in project_config.dimensions.project_dimensions]
+            base_dimensions = [p for p in project_config.dimensions.base_dimensions]
             mappings = []
             for dimension in dataset_config.dimensions:
                 data_dim_type = dimension.dimension_type
                 # TODO: @dthom do we have a wrapper tohelp with getting
                 #   dimensions of a certain type?
-                for i, pdimension in enumerate(project_dimensions):
+                for i, pdimension in enumerate(base_dimensions):
                     if pdimension.dimension_type == data_dim_type:
                         mappings.append(
                             {

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -24,26 +24,26 @@ def test_good_project_config(dimension_manager):
 
 
 def test_project_invalid_id(config_as_dict, dimension_manager):
-    dimensions = config_as_dict["dimensions"]["project_dimensions"]
+    dimensions = config_as_dict["dimensions"]["base_dimensions"]
     first = dimensions[0]
     first["dimension_id"] = "invalid"
     model = ProjectConfigModel(**config_as_dict)
     with pytest.raises(DSGValueNotRegistered):
-        dimension_manager.load_dimensions(model.dimensions.project_dimensions)
+        dimension_manager.load_dimensions(model.dimensions.base_dimensions)
 
 
 def test_project_config_missing_dimension(config_as_dict):
-    for i, dimension in enumerate(config_as_dict["dimensions"]["project_dimensions"]):
+    for i, dimension in enumerate(config_as_dict["dimensions"]["base_dimensions"]):
         if dimension["dimension_id"].startswith("county"):
             break
-    config_as_dict["dimensions"]["project_dimensions"].pop(i)
+    config_as_dict["dimensions"]["base_dimensions"].pop(i)
     with pytest.raises(ValueError):
         ProjectConfigModel(**config_as_dict)
 
 
 def test_project_duplicate_dimension(config_as_dict, dimension_manager):
-    first = config_as_dict["dimensions"]["project_dimensions"][0]
-    config_as_dict["dimensions"]["project_dimensions"].append(first)
+    first = config_as_dict["dimensions"]["base_dimensions"][0]
+    config_as_dict["dimensions"]["base_dimensions"].append(first)
     with pytest.raises(ValueError):
         ProjectConfigModel(**config_as_dict)
 
@@ -54,7 +54,7 @@ def test_project_duplicate_type(config_as_dict, dimension_manager):
     for i, dim in enumerate(config_as_dict["dimensions"]["supplemental_dimensions"]):
         if dim["dimension_id"].startswith("us_states"):
             index = i
-            config_as_dict["dimensions"]["project_dimensions"].append(dim)
+            config_as_dict["dimensions"]["base_dimensions"].append(dim)
     assert index is not None
     config_as_dict["dimensions"]["supplemental_dimensions"].pop(index)
 


### PR DESCRIPTION
Renaming `project_dimension` to `base_dimension` per @elainethale 's suggestion in a previous TEMPO meeting.