### PR TITLE
Sync configs after performing updates

### DIFF
--- a/dsgrid/cloud/s3_storage_interface.py
+++ b/dsgrid/cloud/s3_storage_interface.py
@@ -12,6 +12,7 @@ from dsgrid.exceptions import DSGMakeLockError, DSGRegistryLockError
 from dsgrid.filesystem.local_filesystem import LocalFilesystem
 from dsgrid.filesystem.s3_filesystem import S3Filesystem
 from dsgrid.utils.run_command import check_run_command
+from dsgrid.utils.timing import Timer, track_timing, timer_stats_collector
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +129,7 @@ class S3StorageInterface(CloudStorageInterface):
                 )
             filepath.unlink()
 
+    @track_timing(timer_stats_collector)
     def sync_pull(self, remote_path, local_path, exclude=None, delete_local=False, is_file=False):
         if delete_local:
             local_contents = self._local_filesystem.rglob(local_path)
@@ -142,5 +144,6 @@ class S3StorageInterface(CloudStorageInterface):
                     logger.info("delete: %s because it is not in %s", relcontent, remote_path)
         self._sync(remote_path, local_path, exclude, is_file)
 
+    @track_timing(timer_stats_collector)
     def sync_push(self, remote_path, local_path, exclude=None):
         self._sync(local_path, remote_path, exclude)

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -121,6 +121,7 @@ class InputDatasetModel(DSGBaseModel):
         title="dataset_type",
         description="Dataset type.",
         options=InputDatasetType.format_for_docs(),
+        updateable=False,
     )
     version: Union[str, None, VersionInfo] = Field(
         title="version",
@@ -134,6 +135,7 @@ class InputDatasetModel(DSGBaseModel):
             "The version string must be in semver format (e.g., '1.0.0') and it must be a valid/"
             "existing version in the registry.",
         ),
+        updateable=False,
         # TODO: add notes about warnings for outdated versions? DSGRID-189.
     )
     mapping_references: List[DimensionMappingReferenceModel] = Field(
@@ -158,6 +160,7 @@ class InputDatasetModel(DSGBaseModel):
         title="model_sector",
         description="Model sector ID, required only if dataset type is ``sector_model``.",
         optional=True,
+        updateable=False,
     )
 
     @validator("version")

--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -193,6 +193,12 @@ class DatasetRegistryManager(RegistryManagerBase):
         self._datasets.pop(old_key, None)
         self._datasets[new_key] = config
 
+        if not self.offline_mode:
+            self.sync_push(self.get_registry_directory(config.config_id))
+            self.sync_push(self.get_registry_data_directory(config.config_id))
+
+        return version
+
     def remove(self, config_id):
         self._remove(config_id)
         for key in [x for x in self._datasets if x.id == config_id]:

--- a/dsgrid/registry/dimension_mapping_registry_manager.py
+++ b/dsgrid/registry/dimension_mapping_registry_manager.py
@@ -313,6 +313,10 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
         new_key = ConfigKey(config.config_id, version)
         self._mappings.pop(old_key, None)
         self._mappings[new_key] = config
+
+        if not self.offline_mode:
+            self.sync_push(self._path)
+
         return version
 
     def remove(self, config_id):

--- a/dsgrid/registry/dimension_registry_manager.py
+++ b/dsgrid/registry/dimension_registry_manager.py
@@ -374,6 +374,10 @@ class DimensionRegistryManager(RegistryManagerBase):
         new_key = DimensionKey(config.model.dimension_type, config.config_id, version)
         self._dimensions.pop(old_key, None)
         self._dimensions[new_key] = config
+
+        if not self.offline_mode:
+            self.sync_push(self._path)
+
         return version
 
     def remove(self, config_id):

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -394,6 +394,10 @@ class ProjectRegistryManager(RegistryManagerBase):
         new_key = ConfigKey(config.config_id, version)
         self._projects.pop(old_key, None)
         self._projects[new_key] = config
+
+        if not self.offline_mode:
+            self.sync_push(self.get_registry_directory(config.config_id))
+
         return version
 
     def remove(self, config_id):

--- a/dsgrid/tests/common.py
+++ b/dsgrid/tests/common.py
@@ -1,4 +1,5 @@
 import fileinput
+import getpass
 import os
 import re
 import shutil
@@ -7,8 +8,12 @@ from tempfile import gettempdir
 
 import pytest
 
+from dsgrid.exceptions import DSGInvalidParameter, DSGInvalidOperation
 from dsgrid.filesystem.local_filesystem import LocalFilesystem
+from dsgrid.registry.dimension_registry_manager import DimensionRegistryManager
 from dsgrid.registry.registry_manager import RegistryManager
+from dsgrid.registry.common import VersionUpdateType
+from dsgrid.utils.files import dump_data, load_data
 
 TEST_PROJECT_PATH = Path(__file__).absolute().parent.parent.parent / "dsgrid-test-data"
 TEST_PROJECT_REPO = TEST_PROJECT_PATH / "test_efs"
@@ -151,3 +156,98 @@ def replace_dimension_uuids(filename, uuids):
                 dimension_type = match.groupdict()["dimension_type"]
                 new_uuid = uuids[dimension_type]
                 print(f'dimension_id = "{dimension_type}__{new_uuid}"')
+
+
+def check_configs_update(base_dir, manager):
+    """Runs an update on one of each type of config.
+
+    Parameters
+    ----------
+    base_dir : Path
+    manager : RegistryManager
+
+    Returns
+    -------
+    list
+        Each updated config and new version: [(Updated ID, new version)]
+        For the dimension element the tuple is (Updated ID, dimension type, new version).
+        Order is dimension ID, dimension mapping ID, dataset ID, project ID
+
+    """
+    update_dir = base_dir / "updates"
+    user = getpass.getuser()
+
+    updated_ids = []
+    for mgr in (
+        manager.dimension_manager,
+        manager.dimension_mapping_manager,
+        manager.dataset_manager,
+        manager.project_manager,
+    ):
+        config_id = mgr.list_ids()[0]
+        version = mgr.get_current_version(config_id)
+        check_config_update(update_dir, mgr, config_id, user, version)
+        new_version = mgr.get_current_version(config_id)
+        if isinstance(mgr, DimensionRegistryManager):
+            config = mgr.get_by_id(config_id)
+            updated_ids.append((config_id, config.model.dimension_type, new_version))
+        else:
+            updated_ids.append((config_id, new_version))
+
+    return updated_ids
+
+
+def check_config_update(base_dir, mgr, config_id, user, version):
+    """Runs basic positive and negative update tests for the config.
+
+    Parameters
+    ----------
+    base_dir : str
+    mgr : RegistryManagerBase
+    config_id : str
+    user : str
+    version : VersionInfo
+
+    """
+    config_file = Path(base_dir) / mgr.registry_class().config_filename()
+    assert not config_file.exists()
+    try:
+        mgr.dump(config_id, base_dir)
+        with pytest.raises(DSGInvalidOperation):
+            mgr.dump(config_id, base_dir)
+        mgr.dump(config_id, base_dir, force=True)
+        assert config_file.exists()
+        config_data = load_data(config_file)
+        config_data["description"] += "; updated description"
+        dump_data(config_data, config_file)
+        with pytest.raises(DSGInvalidParameter):
+            mgr.update_from_file(
+                config_file,
+                "invalid_config_id",
+                user,
+                VersionUpdateType.PATCH,
+                "update to description",
+                version,
+            )
+        with pytest.raises(DSGInvalidParameter):
+            mgr.update_from_file(
+                config_file,
+                config_id,
+                user,
+                VersionUpdateType.PATCH,
+                "update to description",
+                version.bump_patch(),
+            )
+
+        mgr.update_from_file(
+            config_file,
+            config_id,
+            user,
+            VersionUpdateType.PATCH,
+            "update to description",
+            version,
+        )
+        assert mgr.get_current_version(config_id) == version.bump_patch()
+    finally:
+        if config_file.exists():
+            os.remove(config_file)


### PR DESCRIPTION
The current code does not sync to the AWS registry after performing `dsgrid registry * update` commands. This PR adds that functionality.
