### PR TITLE
Support registration of TEMPO dataset

### DIFF
--- a/dsgrid/config/annual_time_dimension_config.py
+++ b/dsgrid/config/annual_time_dimension_config.py
@@ -1,11 +1,18 @@
+from dsgrid.utils.timing import track_timing
+import logging
 from datetime import datetime, timedelta
 
 import pandas as pd
 
 from dsgrid.dimension.time import make_time_range
 from dsgrid.exceptions import DSGInvalidDataset
+from dsgrid.time.types import AnnualTimestampType
+from dsgrid.utils.timing import timer_stats_collector, track_timing
 from .dimensions import AnnualTimeDimensionModel
 from .time_dimension_base_config import TimeDimensionBaseConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
@@ -15,7 +22,9 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
     def model_class():
         return AnnualTimeDimensionModel
 
+    @track_timing(timer_stats_collector)
     def check_dataset_time_consistency(self, load_data_df):
+        logger.info("Check AnnualTimeDimensionConfig dataset time consistency.")
         time_ranges = self.get_time_ranges()
         assert len(time_ranges) == 1, len(time_ranges)
         time_range = time_ranges[0]
@@ -63,3 +72,9 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
 
     def get_tzinfo(self):
         return None
+
+    def list_expected_dataset_timestamps(self):
+        # TODO: need to support validation of multiple time ranges: DSGRID-173
+        assert len(self.model.ranges) == 1, self.model.ranges
+        start, end = (int(self.model.ranges[0].start), int(self.model.ranges[0].end))
+        return [AnnualTimestampType(x) for x in range(start, end + 1)]

--- a/dsgrid/config/noop_time_dimension_config.py
+++ b/dsgrid/config/noop_time_dimension_config.py
@@ -39,3 +39,6 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
 
     def get_tzinfo(self):
         return None
+
+    def list_expected_dataset_timestamps(self):
+        return []

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -1,9 +1,7 @@
 import itertools
 import logging
 import os
-import shutil
-from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 from pydantic import Field
 from pydantic import root_validator, validator
@@ -11,35 +9,23 @@ from semver import VersionInfo
 
 from .config_base import ConfigWithDataFilesBase
 from .dataset_config import InputDatasetType
-from .dataset_config import DatasetConfig
 from .dimension_associations import DimensionAssociations
 from .dimension_mapping_base import DimensionMappingReferenceModel
 from .dimensions import (
     DimensionReferenceModel,
     DimensionType,
 )
-from dsgrid.exceptions import (
-    DSGInvalidField,
-    DSGInvalidDimension,
-    DSGInvalidDimensionAssociation,
-    DSGInvalidDimensionMapping,
-    DSGInvalidOperation,
-    DSGInvalidRegistryState,
-    DSGMissingDimensionMapping,
-)
-from dsgrid.data_models import DSGBaseModel, serialize_model
+from dsgrid.exceptions import DSGInvalidField
+from dsgrid.data_models import DSGBaseModel
 from dsgrid.dimension.base_models import check_required_dimensions
 from dsgrid.registry.common import (
     ProjectRegistryStatus,
     DatasetRegistryStatus,
     check_config_id_strict,
 )
-from dsgrid.dimension.store import DimensionStore
 from dsgrid.registry.dimension_registry_manager import DimensionRegistryManager
 from dsgrid.registry.dimension_mapping_registry_manager import DimensionMappingRegistryManager
 
-from dsgrid.utils.files import dump_data
-from dsgrid.utils.spark import read_dataframe
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.utils.utilities import check_uniqueness
 from dsgrid.utils.versioning import handle_version_or_str

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -40,6 +40,7 @@ from dsgrid.registry.dimension_mapping_registry_manager import DimensionMappingR
 
 from dsgrid.utils.files import dump_data
 from dsgrid.utils.spark import read_dataframe
+from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.utils.utilities import check_uniqueness
 from dsgrid.utils.versioning import handle_version_or_str
 
@@ -437,6 +438,7 @@ class ProjectConfig(ConfigWithDataFilesBase):
         self._base_to_supplemental_mappings.update(base_to_supp)
         # TODO: Once we start using these we may need to store by (from, to) as key instead.
 
+    @track_timing(timer_stats_collector)
     def add_dataset_dimension_mappings(self, dataset_config, references):
         """Add a dataset's dimension mappings to the project.
 

--- a/dsgrid/config/representative_period_time_dimension_config.py
+++ b/dsgrid/config/representative_period_time_dimension_config.py
@@ -151,25 +151,11 @@ class OneWeekPerMonthByHourHandler(RepresentativeTimeFormatHandlerBase):
             )
         logger.info("Verified that expected_timestamps equal actual_timestamps")
 
-        lengths = (
-            load_data_df.select("month", "day_of_week", "hour", "id")
-            .groupby("id")
-            .agg(F.countDistinct("month", "day_of_week", "hour").alias("distinct_timestamps"))
-            .select("distinct_timestamps")
-            .distinct()
-            .collect()
-        )
-        count = len(lengths)
-        if count != 1:
-            raise DSGInvalidDataset(
-                f"All time arrays must have the same times: unique times={count}"
-            )
-
+        actual_len = len(actual_timestamps)
         expected_len = len(expected_timestamps)
-        actual = lengths[0].distinct_timestamps
-        if actual != expected_len:
+        if actual_len != expected_len:
             raise DSGInvalidDataset(
-                f"Length of time arrays is incorrect: actual={actual} expected={expected_len}"
+                f"Length of time arrays is incorrect: actual={actual_len} expected={expected_len}"
             )
         logger.info("Verified that all time arrays have the same, correct length.")
 

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -75,3 +75,14 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         tzinfo | None
 
         """
+
+    @abc.abstractmethod
+    def list_expected_dataset_timestamps(self):
+        """Return a list of the timestamps expected in the load_data table.
+
+        Returns
+        -------
+        list
+            List of tuples of columns representing time in the load_data table.
+
+        """

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -166,7 +166,10 @@ class DatasetSchemaHandlerBase(abc.ABC):
             )
         unique_ta_counts = load_data_df.select(*unique_array_cols).distinct().count()
         if unique_ta_counts != distinct_counts[0]["count"]:
-            raise DSGInvalidDataset("dataset has invalid counts")
+            raise DSGInvalidDataset(
+                f"dataset has invalid timestamp counts, expected {unique_ta_counts} count for "
+                f"each timestamp in {time_cols} but found {distinct_counts[0]['count']} instead"
+            )
 
     @track_timing(timer_stats_collector)
     def _remap_dimension_columns(self, df):

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -9,7 +9,7 @@ from dsgrid.config.dataset_config import DatasetConfig
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import DSGInvalidDataset, DSGInvalidDimensionMapping
 from dsgrid.dimension.time import TimeDimensionType
-from dsgrid.utils.spark import models_to_dataframe
+from dsgrid.utils.spark import models_to_dataframe, sql
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 
 logger = logging.getLogger(__name__)
@@ -244,15 +244,25 @@ class DatasetSchemaHandlerBase(abc.ABC):
             logger.warning("Skip _check_null_value_in_unique_dimension_rows")
             return
 
-        dim_with_null = set()
         cols_to_check = {x for x in dim_table.columns if x != "id"}
+        cols_str = ", ".join(cols_to_check)
+        filter_str = " OR ".join((f"{x} is NULL" for x in cols_to_check))
+        dim_table.createOrReplaceTempView("dim_table")
 
-        for col in cols_to_check:
-            if not dim_table.select(col).filter(f"{col} is NULL").rdd.isEmpty():
-                dim_with_null.add(col)
+        try:
+            # Avoid iterating with many checks unless we know there is at least one failure.
+            nulls = sql(f"SELECT {cols_str} FROM dim_table WHERE {filter_str}")
+            if not nulls.rdd.isEmpty():
+                dims_with_null = set()
+                for col in cols_to_check:
+                    if not nulls.select(col).filter(f"{col} is NULL").rdd.isEmpty():
+                        dims_with_null.add(col)
+                assert dims_with_null, "Did not find any dimensions with NULL values"
 
-        if dim_with_null:
-            raise DSGInvalidDimensionMapping(
-                "Invalid dimension mapping application. "
-                f"Combination of remapped dataset dimensions contain NULL value(s) for dimension(s): \n{dim_with_null}"
-            )
+                raise DSGInvalidDimensionMapping(
+                    "Invalid dimension mapping application. "
+                    "Combination of remapped dataset dimensions contain NULL value(s) for "
+                    f"dimension(s): \n{dims_with_null}"
+                )
+        finally:
+            sql("DROP VIEW dim_table")

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -1,19 +1,14 @@
 from pathlib import Path
 import logging
-import itertools
 
 import pyspark.sql.functions as F
 
-from dsgrid.config.dataset_config import (
-    DatasetConfig,
-    check_load_data_filename,
-    check_load_data_lookup_filename,
-)
+from dsgrid.config.dataset_config import DatasetConfig
 from dsgrid.utils.spark import read_dataframe, get_unique_values
-from dsgrid.utils.timing import timer_stats_collector, Timer
+from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.dataset.dataset_schema_handler_base import DatasetSchemaHandlerBase
 from dsgrid.dimension.base_models import DimensionType
-from dsgrid.exceptions import DSGInvalidDataset, DSGInvalidDimension
+from dsgrid.exceptions import DSGInvalidDataset
 
 logger = logging.getLogger(__name__)
 
@@ -28,34 +23,33 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
 
     @classmethod
     def load(cls, config: DatasetConfig, *args, **kwargs):
-        path = Path(config.model.path)
         load_data_df = read_dataframe(config.load_data_path)
         load_data_lookup = read_dataframe(config.load_data_lookup_path, cache=True)
         load_data_lookup = config.add_trivial_dimensions(load_data_lookup)
         return cls(load_data_df, load_data_lookup, config, *args, **kwargs)
 
+    @track_timing(timer_stats_collector)
     def check_consistency(self):
-        with Timer(timer_stats_collector, "check_lookup_data_consistency"):
-            self._check_lookup_data_consistency()
-        with Timer(timer_stats_collector, "check_dataset_time_consistency"):
-            self._check_dataset_time_consistency(self._load_data)
-        with Timer(timer_stats_collector, "check_dataset_internal_consistency"):
-            self._check_dataset_internal_consistency()
+        self._check_lookup_data_consistency()
+        self._check_dataset_time_consistency(self._load_data)
+        self._check_dataset_internal_consistency()
 
+    @track_timing(timer_stats_collector)
     def get_unique_dimension_rows(self):
         """Get distinct combinations of remapped dimensions, including id.
         Check each col in combination for null value."""
-        path = Path(self._config.model.path)
         dim_table = self._remap_dimension_columns(self._load_data_lookup).distinct()
         self._check_null_value_in_unique_dimension_rows(dim_table)
 
         return dim_table
 
+    @track_timing(timer_stats_collector)
     def _check_lookup_data_consistency(self):
         """Dimension check in load_data_lookup, excludes time:
         * check that data matches record for each dimension.
         * check that all data dimension combinations exist. Time is handled separately.
         """
+        logger.info("Check lookup data consistency.")
         found_id = False
         dimension_types = set()
         for col in self._load_data_lookup.columns:
@@ -93,8 +87,10 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
                     f"load_data_lookup records do not match dimension records for {name}"
                 )
 
+    @track_timing(timer_stats_collector)
     def _check_dataset_internal_consistency(self):
         """ Check load_data dimensions and id series. """
+        logger.info("Check dataset internal consistency.")
         self._check_load_data_columns()
         data_ids = []
         for row in self._load_data.select("id").distinct().sort("id").collect():
@@ -107,10 +103,10 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
             self._load_data_lookup.select("id")
             .distinct()
             .filter("id IS NOT NULL")
-            .sort("id")
             .agg(F.collect_list("id"))
             .collect()[0][0]
         )
+        lookup_data_ids.sort()
 
         if data_ids != lookup_data_ids:
             logger.error(
@@ -123,7 +119,9 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
                 f"Data IDs for {self._config.config_id} data/lookup are inconsistent"
             )
 
+    @track_timing(timer_stats_collector)
     def _check_load_data_columns(self):
+        logger.info("Check load data columns.")
         dim_type = self._config.model.data_schema.load_data_column_dimension
         dimension_records = set(self.get_pivot_dimension_columns())
         time_dim = self._config.get_dimension(DimensionType.TIME)

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -77,6 +77,10 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
             dimension = self._config.get_dimension(dimension_type)
             dim_records = dimension.get_unique_ids()
             lookup_records = get_unique_values(self._load_data_lookup, name)
+            if None in lookup_records:
+                raise DSGInvalidDataset(
+                    f"{self._config.config_id} has a NULL value for {dimension_type}"
+                )
             if dim_records != lookup_records:
                 logger.error(
                     "Mismatch in load_data_lookup records. dimension=%s mismatched=%s",

--- a/dsgrid/dimension/time.py
+++ b/dsgrid/dimension/time.py
@@ -208,7 +208,6 @@ class DatetimeRange:
         datetime
 
         """
-
         cur = self.start.to_pydatetime()
         end = self.end.to_pydatetime() + self.frequency  # to make end time inclusive
 

--- a/dsgrid/registry/dimension_mapping_registry_manager.py
+++ b/dsgrid/registry/dimension_mapping_registry_manager.py
@@ -27,6 +27,7 @@ from .registry_manager_base import RegistryManagerBase
 from dsgrid.utils.filters import transform_and_validate_filters, matches_filters
 from dsgrid.utils.files import dump_data
 from dsgrid.utils.spark import models_to_dataframe
+from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.config.dimension_mapping_base import DimensionMappingArchetype
 
 
@@ -269,6 +270,7 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
 
         return mappings
 
+    @track_timing(timer_stats_collector)
     def register(self, config_file, submitter, log_message, force=False):
         lock_file_path = self.get_registry_lock_file(None)
         with self.cloud_interface.make_lock_file(lock_file_path):
@@ -365,6 +367,7 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
         self._check_update(config, config_id, version)
         self.update(config, update_type, log_message, submitter=submitter)
 
+    @track_timing(timer_stats_collector)
     def update(self, config, update_type, log_message, submitter=None):
         if submitter is None:
             submitter = getpass.getuser()

--- a/dsgrid/registry/dimension_registry_manager.py
+++ b/dsgrid/registry/dimension_registry_manager.py
@@ -32,6 +32,7 @@ from dsgrid.registry.common import (
 from .registry_manager_base import RegistryManagerBase
 from .dimension_registry import DimensionRegistry, DimensionRegistryModel
 from dsgrid.utils.filters import transform_and_validate_filters, matches_filters
+from dsgrid.utils.timing import timer_stats_collector, track_timing
 
 
 logger = logging.getLogger(__name__)
@@ -217,6 +218,7 @@ class DimensionRegistryManager(RegistryManagerBase):
 
         return dimensions
 
+    @track_timing(timer_stats_collector)
     def register(self, config_file, submitter, log_message, force=False):
         lock_file_path = self.get_registry_lock_file(None)
         with self.cloud_interface.make_lock_file(lock_file_path):
@@ -357,6 +359,7 @@ class DimensionRegistryManager(RegistryManagerBase):
         self._check_update(config, config_id, version)
         self.update(config, update_type, log_message, submitter=submitter)
 
+    @track_timing(timer_stats_collector)
     def update(self, config, update_type, log_message, submitter=None):
         if submitter is None:
             submitter = getpass.getuser()

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -317,12 +317,15 @@ class ProjectRegistryManager(RegistryManagerBase):
         )
         diff = project_table.exceptAll(dim_table.select(*cols).distinct())
         if not diff.rdd.isEmpty():
-            out_file = f"{dataset_config.config_id}__missing_dimension_record_combinations.csv"
+            dataset_id = dataset_config.config_id
+            project_id = project_config.config_id
+            out_file = f"{dataset_id}__{project_id}___missing_dimension_record_combinations.csv"
             diff.write.options(header=True).mode("overwrite").csv(out_file)
             logger.error(
-                "Dataset {dataset_config.config_id} is missing required dimension "
-                "records from project %s. Recorded missing records in %s.",
-                project_config.config_id,
+                "Dataset %s is missing required dimension records from project %s. "
+                "Recorded missing records in %s.",
+                dataset_id,
+                project_id,
                 out_file,
             )
             raise DSGInvalidDataset(

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -230,7 +230,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         submitter,
         log_message,
     ):
-        logger.info("Submit dataset=%s to project=%s.", project_config.config_id, dataset_id)
+        logger.info("Submit dataset=%s to project=%s.", dataset_id, project_config.config_id)
         self._check_if_not_registered(project_config.config_id)
         dataset_config = self._dataset_mgr.get_by_id(dataset_id)
         dataset_model = project_config.get_dataset(dataset_id)

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -230,7 +230,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         submitter,
         log_message,
     ):
-        logger.info("Submit dataset=%s to project=%s.")
+        logger.info("Submit dataset=%s to project=%s.", project_config.config_id, dataset_id)
         self._check_if_not_registered(project_config.config_id)
         dataset_config = self._dataset_mgr.get_by_id(dataset_id)
         dataset_model = project_config.get_dataset(dataset_id)

--- a/dsgrid/tests/make_standard_scenarios_registry.py
+++ b/dsgrid/tests/make_standard_scenarios_registry.py
@@ -188,9 +188,9 @@ def run(registry_path, force, project_dir, dataset_path, verbose):
             dataset_path=dataset_path,
             include_datasets=include_datasets,
         )
-        timer_stats_collector.log_stats()
     finally:
         shutil.rmtree(tmp_project_dir)
+        timer_stats_collector.log_stats()
 
 
 if __name__ == "__main__":

--- a/dsgrid/tests/make_standard_scenarios_registry.py
+++ b/dsgrid/tests/make_standard_scenarios_registry.py
@@ -60,8 +60,12 @@ def make_standard_scenarios_registry(
     path = create_local_test_registry(registry_path)
     project_config_file = src_dir / "project.toml"
     dataset_dir = Path("datasets/sector_models")
-    dataset_ids = ("conus_2022_reference_comstock", "conus_2022_reference_resstock")
-    dataset_dirs = ("comstock", "resstock")
+    dataset_ids = (
+        "conus_2022_reference_comstock",
+        "conus_2022_reference_resstock",
+        "tempo_conus_2022",
+    )
+    dataset_dirs = ("comstock", "resstock", "tempo")
     project_dimension_mapping_config = src_dir / "dimension_mappings.toml"
 
     user = getpass.getuser()

--- a/dsgrid/tests/make_us_data_registry.py
+++ b/dsgrid/tests/make_us_data_registry.py
@@ -170,8 +170,10 @@ def run(registry_path, force, project_dir, dataset_dir, verbose):
     if tmp_project_dir.exists():
         shutil.rmtree(tmp_project_dir)
     shutil.copytree(project_dir, tmp_project_dir)
-    make_test_data_registry(registry_path, tmp_project_dir / "dsgrid_project", dataset_dir)
-    timer_stats_collector.log_stats()
+    try:
+        make_test_data_registry(registry_path, tmp_project_dir / "dsgrid_project", dataset_dir)
+    finally:
+        timer_stats_collector.log_stats()
 
 
 if __name__ == "__main__":

--- a/dsgrid/time/types.py
+++ b/dsgrid/time/types.py
@@ -1,5 +1,7 @@
 """Types related to time"""
 
+from collections import namedtuple
+
 from dsgrid.data_models import DSGEnum
 
 
@@ -18,3 +20,14 @@ class Season(DSGEnum):
     SUMMER = "summer"
     AUTUMN = "autumn"
     FALL = "autumn"
+
+
+# The types below represent the timestamps that exist as columns in all datasets.
+
+DatetimeTimestampType = namedtuple("DatetimeTimestampType", ["timestamp"])
+
+AnnualTimestampType = namedtuple("AnnualTimestampType", ["year"])
+
+OneWeekPerMonthByHourType = namedtuple(
+    "OneWeekPerMonthByHourType", ["month", "day_of_week", "hour"]
+)

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -1,9 +1,7 @@
 """Spark helper functions"""
 
 import csv
-import itertools
 import logging
-import multiprocessing
 import os
 from pathlib import Path
 from typing import AnyStr, List, Union
@@ -26,7 +24,6 @@ def init_spark(name="dsgrid"):
     if cluster is not None:
         logger.info("Create SparkSession %s on existing cluster %s", name, cluster)
         conf = SparkConf().setAppName(name).setMaster(cluster)
-        sc = SparkContext(conf=conf)
         spark = SparkSession.builder.config(conf=conf).getOrCreate()
     else:
         logger.info("Create SparkSession %s in local-mode cluster", name)

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -215,6 +215,7 @@ def sql(query):
     pyspark.sql.DataFrame
 
     """
+    logger.debug("Run SQL query [%s]", query)
     return SparkSession.getActiveSession().sql(query)
 
 

--- a/dsgrid/utils/timing.py
+++ b/dsgrid/utils/timing.py
@@ -135,7 +135,7 @@ def track_timing(collector):
 
 
 def _timed_func(timer_stats, func, *args, **kwargs):
-    with Timer(timer_stats, func.__name__):
+    with Timer(timer_stats, func.__qualname__):
         return func(*args, **kwargs)
 
 

--- a/tests/test_aeo_dataset_registration.py
+++ b/tests/test_aeo_dataset_registration.py
@@ -127,7 +127,8 @@ def test_aeo_datasets_registration(make_test_project_dir, make_test_data_dir):
         if "End_Uses" in dataset:
             _modify_data_file(data_dir, drop_first_row=True)
             with pytest.raises(
-                DSGInvalidDataset, match=r"One or more arrays do not have.*timestamps"
+                DSGInvalidDataset,
+                match=r"All time arrays must have the same times: unique timestamp lengths",
             ):
                 _test_dataset_registration(make_test_project_dir, data_dir, dataset)
 

--- a/tests/test_aeo_dataset_registration.py
+++ b/tests/test_aeo_dataset_registration.py
@@ -128,7 +128,7 @@ def test_aeo_datasets_registration(make_test_project_dir, make_test_data_dir):
             _modify_data_file(data_dir, drop_first_row=True)
             with pytest.raises(
                 DSGInvalidDataset,
-                match=r"All time arrays must have the same times: unique timestamp lengths",
+                match=r"All time arrays must have the same times.*unique timestamp counts",
             ):
                 _test_dataset_registration(make_test_project_dir, data_dir, dataset)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -51,7 +51,9 @@ def test_invalid_datasets(make_test_project_dir, make_test_data_dir):
             _setup_invalid_load_data_id_missing_timestamp,
             _setup_invalid_load_data_id_extra_timestamp,
             _setup_invalid_load_data_lookup_mismatched_ids,
+            _setup_invalid_load_data_lookup_null_id,
             _setup_invalid_load_data_extra_column,
+            _setup_invalid_load_data_null_id,
         )
         # This is arranged in this way to avoid having to re-create the registry every time,
         # which is quite slow. There is one downside: if one test is able to register the
@@ -149,7 +151,7 @@ def _setup_invalid_load_data_id_missing_timestamp(data_dir):
     # Remove one row/timestamp for one load data array.
     text = "\n".join(data_file.read_text().splitlines()[:-1])
     data_file.write_text(text)
-    return DSGInvalidDataset, r"All time arrays must have the same times: unique timestamp lengths"
+    return DSGInvalidDataset, r"All time arrays must have the same times.*unique timestamp counts"
 
 
 def _setup_invalid_load_data_id_extra_timestamp(data_dir):
@@ -194,6 +196,16 @@ def _setup_invalid_load_data_lookup_mismatched_ids(data_dir):
     data[0]["id"] += 999999999
     dump_line_delimited_json(data, lookup_file)
     return DSGInvalidDataset, r"Data IDs for .*data.lookup are inconsistent"
+
+
+def _setup_invalid_load_data_lookup_null_id(data_dir):
+    lookup_file = data_dir / "test_efs_comstock" / "load_data_lookup.json"
+    data = load_line_delimited_json(lookup_file)
+    item = copy.deepcopy(data[0])
+    item["geography"] = None
+    data.append(item)
+    dump_line_delimited_json(data, lookup_file)
+    return DSGInvalidDataset, r"has a NULL value"
 
 
 def _setup_invalid_load_data_extra_column(data_dir):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -96,7 +96,9 @@ def test_invalid_datasets(make_test_project_dir, make_test_data_dir):
             finally:
                 if test_dir.exists():
                     shutil.rmtree(test_dir)
-                missing_record_file = Path(f"{DATASET_ID}__missing_dimension_record_combinations.csv")
+                missing_record_file = Path(
+                    f"{DATASET_ID}__{PROJECT_ID}__missing_dimension_record_combinations.csv"
+                )
                 if missing_record_file.exists():
                     shutil.rmtree(missing_record_file)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -96,6 +96,9 @@ def test_invalid_datasets(make_test_project_dir, make_test_data_dir):
             finally:
                 if test_dir.exists():
                     shutil.rmtree(test_dir)
+                missing_record_file = Path(f"{DATASET_ID}__missing_dimension_record_combinations.csv")
+                if missing_record_file.exists():
+                    shutil.rmtree(missing_record_file)
 
 
 def _setup_invalid_load_data_lookup_column_name(data_dir):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -129,7 +129,7 @@ def _setup_invalid_load_data_lookup_missing_records(data_dir):
     data = load_line_delimited_json(lookup_file)
     bad_data = [x for x in data if x["id"] is not None]
     dump_line_delimited_json(bad_data, lookup_file)
-    return DSGInvalidDataset, r"is missing dimension association records"
+    return DSGInvalidDataset, r"missing required dimension records"
 
 
 def _setup_invalid_load_data_missing_timestamp(data_dir):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -149,7 +149,7 @@ def _setup_invalid_load_data_id_missing_timestamp(data_dir):
     # Remove one row/timestamp for one load data array.
     text = "\n".join(data_file.read_text().splitlines()[:-1])
     data_file.write_text(text)
-    return DSGInvalidDataset, r"One or more arrays do not have.*timestamps"
+    return DSGInvalidDataset, r"All time arrays must have the same times: unique timestamp lengths"
 
 
 def _setup_invalid_load_data_id_extra_timestamp(data_dir):


### PR DESCRIPTION
This PR allows TEMPO datasets to be registered and submitted to the StandardScenarios project with checks enabled.

There are still some issues related to Spark memory management for which I don't have a reliable solution. The in-memory checks of dimension combinations are extremely problematic. I have been able to run through each piece of code to submit the TEMPO dataset, but not all at once.

I added lots of timer stats in this PR to see how long operations take. I do expect that we will eventually make these debug log messages or at least only log them to the file (no console). For now, I think we need them.