### PR TITLE
Dt/fix dataset path handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = main
+	branch = dt/fix-dataset-path-handling

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -45,7 +45,7 @@ Step 3: Register dataset
 ------------------------
 .. code-block:: bash
     
-    dsgrid registry datasets register {path-to-dataset.toml} -l "{log message}”
+    dsgrid registry datasets register {path-to-dataset.toml} {directory-containing-load-data} -l "{log message}”
 
 
 Step 4: Generate dimension mappings (to map dataset to project)

--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -33,6 +33,12 @@ def _version_update_callback(ctx, param, val):
     return VersionUpdateType(val)
 
 
+def _path_callback(ctx, param, val):
+    if val is None:
+        return val
+    return Path(val)
+
+
 """
 Click Group Definitions
 """
@@ -187,7 +193,7 @@ def dump_dimension(registry_manager, dimension_id, version, directory, force):
 
 
 @click.command(name="update")
-@click.argument("dimension-config-file")
+@click.argument("dimension-config-file", type=click.Path(exists=True), callback=_path_callback)
 @click.option(
     "-d",
     "--dimension-id",
@@ -309,7 +315,9 @@ def dump_dimension_mapping(registry_manager, dimension_mapping_id, version, dire
 
 
 @click.command(name="update")
-@click.argument("dimension-mapping-config-file")
+@click.argument(
+    "dimension-mapping-config-file", type=click.Path(exists=True), callback=_path_callback
+)
 @click.option(
     "-d",
     "--dimension-mapping-id",
@@ -472,7 +480,7 @@ def dump_project(registry_manager, project_id, version, directory, force):
 
 
 @click.command(name="update")
-@click.argument("project-config-file")
+@click.argument("project-config-file", type=click.Path(exists=True), callback=_path_callback)
 @click.option(
     "-p",
     "--project-id",
@@ -540,6 +548,7 @@ def list_datasets(registry_manager, filter):
 
 @click.command(name="register")
 @click.argument("dataset-config-file")
+@click.argument("dataset-path", type=click.Path(exists=True), callback=_path_callback)
 @click.option(
     "-l",
     "--log-message",
@@ -547,11 +556,11 @@ def list_datasets(registry_manager, filter):
     help="reason for submission",
 )
 @click.pass_obj
-def register_dataset(registry_manager, dataset_config_file, log_message):
+def register_dataset(registry_manager, dataset_config_file, dataset_path, log_message):
     """Register a new dataset with the dsgrid repository."""
     manager = registry_manager.dataset_manager
     submitter = getpass.getuser()
-    manager.register(dataset_config_file, submitter, log_message)
+    manager.register(dataset_config_file, dataset_path, submitter, log_message)
 
 
 @click.command(name="dump")
@@ -584,7 +593,14 @@ def dump_dataset(registry_manager, dataset_id, version, directory, force):
 
 
 @click.command(name="update")
-@click.argument("dataset-config-file")
+@click.argument("dataset-config-file", type=click.Path(exists=True), callback=_path_callback)
+@click.option(
+    "-d",
+    "--dataset-id",
+    required=True,
+    type=str,
+    help="dataset ID",
+)
 @click.option(
     "-l",
     "--log-message",
@@ -599,12 +615,23 @@ def dump_dataset(registry_manager, dataset_id, version, directory, force):
     type=click.Choice([x.value for x in VersionUpdateType]),
     callback=_version_update_callback,
 )
+@click.option(
+    "-v",
+    "--version",
+    required=True,
+    callback=_version_info_required_callback,
+    help="Version to update; must be the current version.",
+)
 @click.pass_obj
-def update_dataset(registry_manager, dataset_config_file, log_message, update_type):
+def update_dataset(
+    registry_manager, dataset_config_file, dataset_id, log_message, update_type, version
+):
     """Update an existing dataset registry."""
     manager = registry_manager.dataset_manager
     submitter = getpass.getuser()
-    manager.update_from_file(dataset_config_file, submitter, update_type, log_message)
+    manager.update_from_file(
+        dataset_config_file, dataset_id, submitter, update_type, log_message, version
+    )
 
 
 @click.command()

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -401,9 +401,9 @@ class DatasetConfig(ConfigBase):
         return DatasetConfigModel
 
     @classmethod
-    def load_from_registry(cls, config_file, dimension_manager, registry_path):
+    def load_from_registry(cls, config_file, dimension_manager, registry_data_path):
         config = cls._load(config_file)
-        dataset_path = registry_path / config.config_id / config.model.dataset_version
+        dataset_path = registry_data_path / config.config_id / config.model.dataset_version
         return cls.load(config, dimension_manager, dataset_path)
 
     @classmethod

--- a/dsgrid/dataset/dataset_schema_handler_one_table.py
+++ b/dsgrid/dataset/dataset_schema_handler_one_table.py
@@ -24,7 +24,7 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
 
     @classmethod
     def load(cls, config: DatasetConfig, *args, **kwargs):
-        path = Path(config.model.path)
+        path = Path(config.dataset_path)
         load_data_df = read_dataframe(check_load_data_filename(path))
         load_data_df = config.add_trivial_dimensions(load_data_df)
         return cls(load_data_df, config, *args, **kwargs)

--- a/dsgrid/dataset/dataset_schema_handler_one_table.py
+++ b/dsgrid/dataset/dataset_schema_handler_one_table.py
@@ -24,9 +24,7 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
 
     @classmethod
     def load(cls, config: DatasetConfig, *args, **kwargs):
-        path = Path(config.dataset_path)
-        load_data_df = read_dataframe(check_load_data_filename(path))
-        load_data_df = config.add_trivial_dimensions(load_data_df)
+        load_data_df = config.add_trivial_dimensions(read_dataframe(config.load_data_path))
         return cls(load_data_df, config, *args, **kwargs)
 
     @track_timing(timer_stats_collector)

--- a/dsgrid/registry/registry_manager.py
+++ b/dsgrid/registry/registry_manager.py
@@ -200,7 +200,7 @@ class RegistryManager:
                 )
 
         params = RegistryManagerParams(
-            path, remote_path, fs_interface, cloud_interface, offline_mode, dry_run_mode
+            Path(path), remote_path, fs_interface, cloud_interface, offline_mode, dry_run_mode
         )
         path = Path(path)
         for dir_name in (

--- a/dsgrid/tests/make_standard_scenarios_registry.py
+++ b/dsgrid/tests/make_standard_scenarios_registry.py
@@ -115,9 +115,9 @@ def make_standard_scenarios_registry(
         dataset_path = Path(dataset_path)
         for dataset_id, ddir in zip(dataset_ids, dataset_dirs):
             dataset_config_file = src_dir / dataset_dir / ddir / "dataset.toml"
-            replace_dataset_path(dataset_config_file, dataset_path=dataset_path)
-
-            manager.dataset_manager.register(dataset_config_file, user, log_message)
+            manager.dataset_manager.register(
+                dataset_config_file, dataset_path / dataset_id, user, log_message
+            )
             manager.project_manager.submit_dataset(
                 project_id,
                 dataset_id,
@@ -126,14 +126,6 @@ def make_standard_scenarios_registry(
                 log_message,
             )
     return manager
-
-
-def replace_dataset_path(dataset_config_file, dataset_path):
-    config = load_data(dataset_config_file)
-    src_data = Path(dataset_path) / config["dataset_id"]
-    config["path"] = str(src_data)
-    dump_data(config, dataset_config_file)
-    logger.info("Replaced dataset path in %s with %s", dataset_config_file, src_data)
 
 
 @click.command()

--- a/dsgrid/utils/timing.py
+++ b/dsgrid/utils/timing.py
@@ -110,10 +110,10 @@ class Timer:
         self._timer_stat = timer_stats.get_stat(name)
 
     def __enter__(self):
-        self._start = time.time()
+        self._start = time.perf_counter()
 
     def __exit__(self, exc, value, tb):
-        self._timer_stat.update(time.time() - self._start)
+        self._timer_stat.update(time.perf_counter() - self._start)
 
 
 def track_timing(collector):

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -15,7 +15,6 @@ from dsgrid.tests.common import (
     replace_dimension_mapping_uuids_from_registry,
     replace_dimension_uuids_from_registry,
 )
-from dsgrid.tests.make_us_data_registry import replace_dataset_path
 
 
 def test_register_project_and_dataset(make_test_project_dir):
@@ -53,14 +52,14 @@ def test_register_project_and_dataset(make_test_project_dir):
         project_id = load_data(project_config)["project_id"]
         dataset_config = make_test_project_dir / dataset_dir / "dataset.toml"
         dataset_id = load_data(dataset_config)["dataset_id"]
-        replace_dataset_path(dataset_config, TEST_DATASET_DIRECTORY)
         replace_dimension_mapping_uuids_from_registry(
             path, (project_config, dimension_mapping_refs)
         )
         replace_dimension_uuids_from_registry(path, (project_config, dataset_config))
 
+        dataset_path = TEST_DATASET_DIRECTORY / dataset_id
         check_run_command(
-            f"dsgrid registry --path={path} --offline datasets register {dataset_config} -l log"
+            f"dsgrid registry --path={path} --offline datasets register {dataset_config} {dataset_path} -l log"
         )
         check_run_command(
             f"dsgrid registry --path={path} --offline projects register {project_config} -l log"

--- a/tests/test_aeo_dataset_registration.py
+++ b/tests/test_aeo_dataset_registration.py
@@ -69,21 +69,11 @@ def make_registry_for_aeo(
     dim_mgr.register(src_dir / dataset_dir / "dimensions.toml", user, log_message)
 
     dataset_config_file = src_dir / dataset_dir / "dataset.toml"
-    dataset_id = load_data(dataset_config_file)["dataset_id"]
-    replace_dataset_path(dataset_config_file, dataset_path=dataset_path)
     replace_dimension_uuids_from_registry(path, (dataset_config_file,))
 
-    manager.dataset_manager.register(dataset_config_file, user, log_message)
+    manager.dataset_manager.register(dataset_config_file, dataset_path, user, log_message)
     logger.info(f"dataset={dataset_name} registered successfully!\n")
     return manager
-
-
-def replace_dataset_path(dataset_config_file, dataset_path):
-    config = load_data(dataset_config_file)
-    src_data = Path(dataset_path)
-    config["path"] = str(src_data)
-    dump_data(config, dataset_config_file)
-    logger.info("Replaced dataset path in %s with %s", dataset_config_file, src_data)
 
 
 ### set up tests for AEO data ###

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -31,7 +31,7 @@ from dsgrid.tests.common import (
     replace_dimension_mapping_uuids_from_registry,
     replace_dimension_uuids_from_registry,
 )
-from dsgrid.tests.make_us_data_registry import make_test_data_registry, replace_dataset_path
+from dsgrid.tests.make_us_data_registry import make_test_data_registry
 
 
 def test_register_project_and_dataset(make_test_project_dir):
@@ -56,6 +56,7 @@ def test_register_project_and_dataset(make_test_project_dir):
         dimension_mapping_id = dimension_mapping_ids[0]
         user = getpass.getuser()
         log_message = "initial registration"
+        dataset_path = TEST_DATASET_DIRECTORY / dataset_id
 
         project_config = project_mgr.get_by_id(project_id, VersionInfo.parse("1.1.0"))
         assert project_config.model.status == ProjectRegistryStatus.COMPLETE
@@ -75,7 +76,7 @@ def test_register_project_and_dataset(make_test_project_dir):
             dataset_config_file = (
                 make_test_project_dir / "datasets/sector_models/comstock/dataset.toml"
             )
-            dataset_mgr.register(dataset_config_file, user, log_message)
+            dataset_mgr.register(dataset_config_file, dataset_path, user, log_message)
 
         with pytest.raises(DSGDuplicateValueRegistered):
             dim_config_file = make_test_project_dir / "dimensions.toml"

--- a/tests/test_tempo_registration.py
+++ b/tests/test_tempo_registration.py
@@ -64,7 +64,6 @@ def make_registry_for_tempo(registry_path, src_dir, dataset_path=None) -> Regist
     project_id = load_data(project_config_file)["project_id"]
     dataset_config_file = src_dir / dataset_dir / "dataset.toml"
     dataset_id = load_data(dataset_config_file)["dataset_id"]
-    replace_dataset_path(dataset_config_file, dataset_path=dataset_path)
     replace_dimension_uuids_from_registry(path, (project_config_file, dataset_config_file))
     replace_dimension_uuids_from_registry(path, (dataset_config_file,))
 
@@ -78,11 +77,3 @@ def make_registry_for_tempo(registry_path, src_dir, dataset_path=None) -> Regist
         log_message,
     )
     return manager
-
-
-def replace_dataset_path(dataset_config_file, dataset_path):
-    config = load_data(dataset_config_file)
-    src_data = Path(dataset_path) / config["dataset_id"]
-    config["path"] = str(src_data)
-    dump_data(config, dataset_config_file)
-    logger.info("Replaced dataset path in %s with %s", dataset_config_file, src_data)

--- a/tests/test_trivial_dimensions.py
+++ b/tests/test_trivial_dimensions.py
@@ -7,7 +7,7 @@ from dsgrid.exceptions import DSGInvalidDimension
 from dsgrid.tests.common import create_local_test_registry, make_test_project_dir
 from dsgrid.utils.files import load_data, dump_data
 from dsgrid.tests.common import make_test_project_dir, make_test_data_dir, TEST_DATASET_DIRECTORY
-from dsgrid.tests.make_us_data_registry import make_test_data_registry, replace_dataset_path
+from dsgrid.tests.make_us_data_registry import make_test_data_registry
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -30,8 +30,12 @@ def test_trivial_dimension_bad(make_test_project_dir, make_test_data_dir):
         config = load_data(dataset_config_file)
         config["trivial_dimensions"] = config["trivial_dimensions"] + ["geography"]
         dump_data(config, dataset_config_file)
+        dataset_path = make_test_data_dir / config["dataset_id"]
 
         with pytest.raises(DSGInvalidDimension):
             manager.dataset_manager.register(
-                config_file=dataset_config_file, submitter="test", log_message="test"
+                config_file=dataset_config_file,
+                dataset_path=dataset_path,
+                submitter="test",
+                log_message="test",
             )


### PR DESCRIPTION
Fixes an issue where the dataset path is not correctly handled. We were not correctly handling the case the user passes an absolute path to the local registry when registering a dataset in offline mode.

While trying to fix this issue I came to the conclusion that we made a design mistake by including the path to the load_data.parquet inside the dataset.toml file. This was very tricky to deal with in particular scenarios, especially when handling updates. We don't actually need the path in the file. Instead:
- When the user registers the dataset they can pass the path in the CLI command.
- Once the dataset is registered our code can look up the path. The DatasetConfigModel specifies `dataset_id` and `dataset_version`. This is sufficient to get us to the correct registry path.
