### PR TITLE
Auto-generate all-in-one supplemental dimensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = main
+	branch = dt/display-name

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = dt/autogen-dims
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = dt/display-name
+	branch = dt/autogen-dims

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -348,11 +348,6 @@ class DatasetConfigModel(DSGBaseModel):
         ),
     )
 
-    @root_validator(pre=True)
-    def handle_legacy_fields(cls, values):
-        values.pop("path", None)
-        return values
-
     @validator("dataset_qualifier_metadata", pre=True)
     def check_dataset_qualifier_metadata(cls, metadata, values):
         if "dataset_qualifier" in values:
@@ -424,7 +419,7 @@ class DatasetConfig(ConfigBase):
 
     def __init__(self, model):
         super().__init__(model)
-        self._dimensions = {}
+        self._dimensions = {}  # DimensionKey to DimensionConfig
         self._dataset_path = None
         self._src_dir = None
 
@@ -497,6 +492,10 @@ class DatasetConfig(ConfigBase):
 
         """
         self._dimensions.update(dimension_manager.load_dimensions(self.model.dimension_references))
+        check_uniqueness((x.model.name for x in self._dimensions.values()), "dimension name")
+        check_uniqueness(
+            (x.model.query_name for x in self._dimensions.values()), "dimension query name"
+        )
 
     @property
     def dimensions(self):

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -492,7 +492,6 @@ class DatasetConfig(ConfigBase):
 
         """
         self._dimensions.update(dimension_manager.load_dimensions(self.model.dimension_references))
-        check_uniqueness((x.model.name for x in self._dimensions.values()), "dimension name")
 
     @property
     def dimensions(self):

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Optional, Dict, Union, Any
 
 from pydantic import Field
-from pydantic import validator, root_validator
+from pydantic import validator
 import pyspark.sql.functions as F
 from semver import VersionInfo
 
@@ -493,9 +493,6 @@ class DatasetConfig(ConfigBase):
         """
         self._dimensions.update(dimension_manager.load_dimensions(self.model.dimension_references))
         check_uniqueness((x.model.name for x in self._dimensions.values()), "dimension name")
-        check_uniqueness(
-            (x.model.query_name for x in self._dimensions.values()), "dimension query name"
-        )
 
     @property
     def dimensions(self):

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -47,8 +47,15 @@ class DimensionBaseModel(DSGBaseModel):
     display_name: str = Field(
         title="display_name",
         description="Display name. Source for auto-generated query_name.",
-        note="Dimension display names should be singular, concise names that are common across "
-        "projects and datasets. Must be unique within a project or dataset.",
+        note="Dimension display names should be singular noun phrases that are concise and "
+        "distinguish the dimension across all dimensions within a project, inclusive of dataset "
+        "dimensions, project base dimensions, and project supplemental dimensions. This uniqueness "
+        "requirement applies unless the dimension is trivial, that is, contains only a single "
+        "record. For trivial dimensions, if the dimension represents an aggregation of everything, "
+        "e.g., all of the sectors, then the convention is to list the display name as 'None'; "
+        "if the dimension represents a single slice of the data, e.g., all electricity use or "
+        "model year 2018, then the convention is to list that 'record' name as the display name, "
+        "e.g.,'Electricity Use' or '2018'.",
         notes=(
             "Only alphanumeric characters, underscores, and spaces are supported (no dashes or "
             "special characters).",

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -50,9 +50,10 @@ class DimensionBaseModel(DSGBaseModel):
         note="Dimension display names should be singular, concise names that are common across "
         "projects and datasets. Must be unique within a project or dataset.",
         notes=(
-            "Only alphanumeric characters and spaces are supported (no dashes or special characters).",
-            "The :meth:`~dsgrid.config.dimensions.check_display_name` validator is used to enforce valid"
-            " dimension display names.",
+            "Only alphanumeric characters, underscores, and spaces are supported (no dashes or "
+            "special characters).",
+            "The :meth:`~dsgrid.config.dimensions.check_display_name` validator is used to "
+            "enforce valid dimension display names.",
         ),
     )
     query_name: Optional[str] = Field(

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -57,7 +57,7 @@ class DimensionBaseModel(DSGBaseModel):
         "model year 2018, then the convention is to list that 'record' name as the display name, "
         "e.g.,'Electricity Use' or '2018'.",
         notes=(
-            "Only alphanumeric characters, underscores, and spaces are supported (no dashes or "
+            "Only alphanumeric characters, underscores, and spaces are supported (no "
             "special characters).",
             "The :meth:`~dsgrid.config.dimensions.check_display_name` validator is used to "
             "enforce valid dimension display names.",

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -51,11 +51,9 @@ class DimensionBaseModel(DSGBaseModel):
         "distinguish the dimension across all dimensions within a project, inclusive of dataset "
         "dimensions, project base dimensions, and project supplemental dimensions. This uniqueness "
         "requirement applies unless the dimension is trivial, that is, contains only a single "
-        "record. For trivial dimensions, if the dimension represents an aggregation of everything, "
-        "e.g., all of the sectors, then the convention is to list the display name as 'None'; "
-        "if the dimension represents a single slice of the data, e.g., all electricity use or "
-        "model year 2018, then the convention is to list that 'record' name as the display name, "
-        "e.g.,'Electricity Use' or '2018'.",
+        "record. For trivial dimensions, if the dimension represents a single slice of the data, "
+        "e.g., all electricity use or model year 2018, then the convention is to list that "
+        "'record' name as the display name, e.g.,'Electricity Use' or '2018'.",
         notes=(
             "Only alphanumeric characters, underscores, and spaces are supported (no "
             "special characters).",

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -166,7 +166,7 @@ class DimensionBaseModel(DSGBaseModel):
             return query_name
         if query_name is not None:
             return query_name
-        return values["display_name"].lower().replace(" ", "_")
+        return values["display_name"].lower().replace(" ", "_").replace("-", "_")
 
     @validator("module", always=True)
     def check_module(cls, module):

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -162,9 +162,13 @@ class DimensionBaseModel(DSGBaseModel):
     def check_query_name(cls, query_name, values):
         if "display_name" not in values:
             return query_name
-        if query_name is not None:
-            return query_name
-        return values["display_name"].lower().replace(" ", "_").replace("-", "_")
+
+        generated_query_name = values["display_name"].lower().replace(" ", "_").replace("-", "_")
+
+        if query_name is not None and query_name != generated_query_name:
+            raise ValueError(f"query_name cannot be set by the user: {query_name}")
+
+        return generated_query_name
 
     @validator("module", always=True)
     def check_module(cls, module):

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -577,11 +577,11 @@ class ProjectConfig(ConfigWithDataFilesBase):
 
     def list_dimension_query_names(self, dimension_type: DimensionType):
         """List the query names available for a dimension type."""
-        query_names = []
-        for dim_config in self.iter_dimensions():
-            if dim_config.model.dimension_type == dimension_type:
-                query_names.append(dim_config.model.query_name)
-        return query_names
+        return [
+            x.model.query_name
+            for x in self.iter_dimensions()
+            if x.model.dimension_type == dimension_type
+        ]
 
     def list_registered_dataset_ids(self):
         """List registered datasets associated with the project.

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -1,7 +1,6 @@
 import itertools
 import logging
 import os
-from collections import defaultdict
 from typing import Dict, List, Union
 
 from pydantic import Field
@@ -477,18 +476,6 @@ class ProjectConfig(ConfigWithDataFilesBase):
         )
         self._base_dimensions.update(base_dimensions)
         self._supplemental_dimensions.update(supplemental_dimensions)
-
-        dims = []
-        dims_by_type = defaultdict(list)
-        for dim in self.iter_dimensions():
-            dims.append(dim)
-            dims_by_type[dim.model.dimension_type].append(dim)
-        check_uniqueness((x.model.name for x in dims), "dimension name")
-        for dims in dims_by_type.values():
-            check_uniqueness((x.model.display_name for x in dims), "dimension display name")
-        check_uniqueness(
-            (getattr(x.model, "cls") for x in base_dimensions.values()), "dimension cls"
-        )
 
     def load_dimension_mappings(self, dimension_mapping_manager: DimensionMappingRegistryManager):
         """Load all dimension mappings.

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -89,7 +89,8 @@ class DimensionsModel(DSGBaseModel):
     )
     all_in_one_supplemental_dimensions: List[DimensionType] = Field(
         title="all_in_one_supplemental_dimensions",
-        description="dsgrid will auto-generate dimensions containing all records for these dimensions.",
+        description="dsgrid will auto-generate dimensions that aggregate across all records for "
+        "the base dimensions of these types.",
         default=[],
     )
 
@@ -398,7 +399,7 @@ class ProjectConfig(ConfigWithDataFilesBase):
             if model.dimension_type == dimension_type and model.query_name == query_name:
                 return dim_config.get_records_dataframe()
 
-        raise DSGInvalidDimension(f"{dimension_type} is not stored")
+        raise DSGInvalidDimension(f"{dimension_type} with query_name={query_name} is not stored")
 
     def get_supplemental_dimensions(self, dimension_type: DimensionType):
         """Return the supplemental dimensions matching dimension (if any).

--- a/dsgrid/registry/common.py
+++ b/dsgrid/registry/common.py
@@ -18,6 +18,8 @@ from dsgrid.utils.versioning import make_version
 REGISTRY_LOG_FILE = "dsgrid_registry.log"
 # Allows letters, numbers, underscores, spaces, dashes
 REGEX_VALID_REGISTRY_NAME = re.compile(r"^[\w -]+$")
+# Allows letters, numbers, underscores, spaces
+REGEX_VALID_REGISTRY_DISPLAY_NAME = re.compile(r"^[\w ]+$")
 # Allows letters, numbers, underscores, dashes
 REGEX_VALID_REGISTRY_CONFIG_ID_LOOSE = re.compile(r"^[\w-]+$")
 # Allows letters, numbers, underscores

--- a/dsgrid/registry/common.py
+++ b/dsgrid/registry/common.py
@@ -18,8 +18,8 @@ from dsgrid.utils.versioning import make_version
 REGISTRY_LOG_FILE = "dsgrid_registry.log"
 # Allows letters, numbers, underscores, spaces, dashes
 REGEX_VALID_REGISTRY_NAME = re.compile(r"^[\w -]+$")
-# Allows letters, numbers, underscores, spaces
-REGEX_VALID_REGISTRY_DISPLAY_NAME = re.compile(r"^[\w ]+$")
+# Allows letters, numbers, underscores, dashes, spaces
+REGEX_VALID_REGISTRY_DISPLAY_NAME = re.compile(r"^[\w -]+$")
 # Allows letters, numbers, underscores, dashes
 REGEX_VALID_REGISTRY_CONFIG_ID_LOOSE = re.compile(r"^[\w-]+$")
 # Allows letters, numbers, underscores

--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -16,7 +16,7 @@ from dsgrid.dimension.base_models import check_required_dimensions
 from dsgrid.exceptions import DSGValueNotRegistered, DSGInvalidDataset
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.utils.filters import transform_and_validate_filters, matches_filters
-from dsgrid.utils.utilities import display_table
+from dsgrid.utils.utilities import check_uniqueness, display_table
 from .common import (
     make_initial_config_registration,
     ConfigKey,
@@ -57,6 +57,7 @@ class DatasetRegistryManager(RegistryManagerBase):
     def _run_checks(self, config: DatasetConfig):
         logger.info("Run dataset registration checks.")
         check_required_dimensions(config.model.dimension_references, "dataset dimensions")
+        check_uniqueness((x.model.name for x in config.model.dimensions), "dimension name")
         if not os.environ.get("__DSGRID_SKIP_DATASET_CONSISTENCY_CHECKS__"):
             self._check_dataset_consistency(config)
 

--- a/dsgrid/registry/dimension_registry_manager.py
+++ b/dsgrid/registry/dimension_registry_manager.py
@@ -81,7 +81,7 @@ class DimensionRegistryManager(RegistryManagerBase):
             elif dim.file_hash in hashes:
                 existing = hashes[dim.file_hash]
                 if dim.dimension_type == existing.dimension_type:
-                    if dim.name == existing.name:
+                    if dim.name == existing.name and dim.display_name == existing.display_name:
                         replace_dim = True
                     else:
                         logger.info(

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -355,9 +355,9 @@ class ProjectRegistryManager(RegistryManagerBase):
             dt_str = dimension_type.value
             dt_plural = f"all_{dt_str}s"
             dt_plural_dash = f"all-{dt_str}s"
-            dt_plural_formal = f"All {dt_str[0].upper()}{dt_str[1:]}"
+            dt_plural_formal = f"All {dt_str.title()}s"
             dim_record_file = supp_dir / f"{dt_plural}.csv"
-            dim_text = f"id,name\nall_{dt_str}s,{dt_plural_formal}\n"
+            dim_text = f"id,name\n{dt_plural},{dt_plural_formal}\n"
             dim_record_file.write_text(dim_text)
             map_record_file = supp_dir / f"lookup_{dt_str}_to_{dt_plural}.csv"
             with open(map_record_file, "w") as f_out:

--- a/dsgrid/registry/registry_manager_base.py
+++ b/dsgrid/registry/registry_manager_base.py
@@ -523,9 +523,6 @@ class RegistryManagerBase(abc.ABC):
         # TODO: Do we want to handle specific versions? This removes all configs.
 
     def _remove(self, config_id):
-        if not self.offline_mode:
-            # TODO: DSGRID-145
-            raise Exception("sync-push of config removal is currently not supported")
         self._check_if_not_registered(config_id)
         self.fs_interface.rm_tree(self.get_registry_directory(config_id))
         self._registry_configs.pop(config_id, None)

--- a/tests/data/dimension_models/minimal/dimension_test_time.toml
+++ b/tests/data/dimension_models/minimal/dimension_test_time.toml
@@ -7,6 +7,7 @@ Time dimension, 2012 hourly EST, period-beginning, no DST, no Leap Day Adjustmen
 """
 frequency = "01:00:00"
 name = "Time-2012-EST-hourly-periodBeginning-noDST-noLeapDayAdjustment-total"
+display_name = "Timestamp"
 time_interval_type = "period_beginning"
 ranges = [{start = "2012-01-01 00:00:00", end = "2012-12-31 23:00:00"}]
 str_format = "%Y-%m-%d %H:%M:%S"
@@ -23,6 +24,7 @@ Annual time 2018-2050
 """
 frequency = "P1D" #"P365D"
 name = "annual_time_2018_to_2020"
+display_name = "Timestamp"
 time_interval_type = "instantaneous"
 ranges = [{start = "2018-01-01", end = "2020-01-01"}]
 str_format = "%Y-%m-%d"
@@ -39,6 +41,7 @@ Time dimension, 2016 hourly EPT, period-ending, no Leap Day Adjustment, total va
 """
 frequency = "06:00:00"
 name = "Time-2016-EPT-hourly-periodEnding-noLeapDayAdjustment-total"
+display_name = "Timestamp"
 time_interval_type = "period_ending"
 ranges = [{start = "2016-01-01 00:00:00", end = "2017-01-01 00:00:00"}]
 str_format = "%Y-%m-%d %H:%M:%S"
@@ -54,6 +57,7 @@ time_type = "annual"
 description = """Annual time"""
 module = "dsgrid.dimension.standard"
 name = "Annual-time-with-leap-year"
+display_name = "Timestamp"
 ranges = [{start = "2020", end = "2050"}]
 str_format = "%Y"
 include_leap_day = true

--- a/tests/data/dimension_models/minimal/dimension_test_time.toml
+++ b/tests/data/dimension_models/minimal/dimension_test_time.toml
@@ -7,7 +7,7 @@ Time dimension, 2012 hourly EST, period-beginning, no DST, no Leap Day Adjustmen
 """
 frequency = "01:00:00"
 name = "Time-2012-EST-hourly-periodBeginning-noDST-noLeapDayAdjustment-total"
-display_name = "Timestamp"
+display_name = "2012 Hourly EST"
 time_interval_type = "period_beginning"
 ranges = [{start = "2012-01-01 00:00:00", end = "2012-12-31 23:00:00"}]
 str_format = "%Y-%m-%d %H:%M:%S"
@@ -24,7 +24,7 @@ Annual time 2018-2050
 """
 frequency = "P1D" #"P365D"
 name = "annual_time_2018_to_2020"
-display_name = "Timestamp"
+display_name = "Daily"
 time_interval_type = "instantaneous"
 ranges = [{start = "2018-01-01", end = "2020-01-01"}]
 str_format = "%Y-%m-%d"
@@ -41,7 +41,7 @@ Time dimension, 2016 hourly EPT, period-ending, no Leap Day Adjustment, total va
 """
 frequency = "06:00:00"
 name = "Time-2016-EPT-hourly-periodEnding-noLeapDayAdjustment-total"
-display_name = "Timestamp"
+display_name = "2016 6-Hour Timestep EPT"
 time_interval_type = "period_ending"
 ranges = [{start = "2016-01-01 00:00:00", end = "2017-01-01 00:00:00"}]
 str_format = "%Y-%m-%d %H:%M:%S"
@@ -57,7 +57,7 @@ time_type = "annual"
 description = """Annual time"""
 module = "dsgrid.dimension.standard"
 name = "Annual-time-with-leap-year"
-display_name = "Timestamp"
+display_name = "Annual"
 ranges = [{start = "2020", end = "2050"}]
 str_format = "%Y"
 include_leap_day = true

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -28,7 +28,12 @@ def test_project_load():
     assert config.has_base_to_supplemental_dimension_mapping_types(DimensionType.GEOGRAPHY)
     mappings = config.get_base_to_supplemental_dimension_mappings_by_types(DimensionType.GEOGRAPHY)
     assert len(mappings) == 3
-    assert not config.has_base_to_supplemental_dimension_mapping_types(DimensionType.SECTOR)
+    assert config.has_base_to_supplemental_dimension_mapping_types(DimensionType.SECTOR)
+    assert config.has_base_to_supplemental_dimension_mapping_types(DimensionType.SUBSECTOR)
+
+    records = project.config.get_dimension_records(DimensionType.SUBSECTOR, "none").collect()
+    assert len(records) == 1
+    assert records[0].id == "all_subsectors"
 
     with pytest.raises(DSGValueNotRegistered):
         project = Project.load(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -50,6 +50,11 @@ def test_dataset_load():
     assert "subsector" in lookup.columns
     assert "id" in lookup.columns
 
+    query_names = sorted(project.config.list_dimension_query_names(DimensionType.GEOGRAPHY))
+    assert query_names == ["census_division", "census_region", "county", "state"]
+    records = project.config.get_dimension_records(DimensionType.GEOGRAPHY, "state")
+    assert records.filter("id = 'CO'").count() > 0
+
     project.unload_dataset(DATASET_ID)
     assert spark.sql("show tables").rdd.isEmpty()
 

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -67,7 +67,7 @@ def test_register_project_and_dataset(make_test_project_dir):
 
         with pytest.raises(DSGDuplicateValueRegistered):
             dataset_config_file = (
-                make_test_project_dir / "datasets/sector_models/comstock/dataset.toml"
+                make_test_project_dir / "datasets" / "sector_models" / "comstock" / "dataset.toml"
             )
             dataset_mgr.register(dataset_config_file, dataset_path, user, log_message)
 
@@ -126,6 +126,46 @@ def test_duplicate_dimensions(make_test_project_dir):
 
         dimension_mgr.register(dim_config_file, user, log_message)
         assert len(dimension_mgr.list_ids()) == len(dimension_ids) + 2
+
+
+def test_duplicate_project_dimension_display_names(make_test_project_dir):
+    with TemporaryDirectory() as tmpdir:
+        path = create_local_test_registry(Path(tmpdir))
+        user = getpass.getuser()
+        log_message = "Initial registration"
+        manager = RegistryManager.load(path, offline_mode=True)
+
+        project_file = make_test_project_dir / "project.toml"
+        data = load_data(project_file)
+        for dim in data["dimensions"]["supplemental_dimensions"]:
+            if dim["display_name"] == "State":
+                dim["display_name"] = "County"
+        dump_data(data, project_file)
+        with pytest.raises(ValueError):
+            manager.project_manager.register(project_file, user, log_message)
+
+
+def test_duplicate_dataset_dimension_display_names(make_test_project_dir):
+    with TemporaryDirectory() as tmpdir:
+        path = create_local_test_registry(Path(tmpdir))
+        user = getpass.getuser()
+        log_message = "Initial registration"
+        manager = RegistryManager.load(path, offline_mode=True)
+
+        dataset_file = (
+            make_test_project_dir / "datasets" / "sector_models" / "comstock" / "dataset.toml"
+        )
+        manager.project_manager.register(make_test_project_dir / "project.toml", user, log_message)
+        replace_dimension_uuids_from_registry(path, (dataset_file,))
+
+        data = load_data(dataset_file)
+        for dim in data["dimensions"]:
+            if dim["display_name"] == "Detailed Subsector":
+                dim["display_name"] = "Sector"
+        dump_data(data, dataset_file)
+        dataset_path = TEST_DATASET_DIRECTORY / data["dataset_id"]
+        with pytest.raises(ValueError):
+            manager.dataset_manager.register(dataset_file, dataset_path, user, log_message)
 
 
 def test_register_duplicate_project_rollback_dimensions(make_test_project_dir):

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -145,29 +145,6 @@ def test_duplicate_project_dimension_display_names(make_test_project_dir):
             manager.project_manager.register(project_file, user, log_message)
 
 
-def test_duplicate_dataset_dimension_display_names(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        path = create_local_test_registry(Path(tmpdir))
-        user = getpass.getuser()
-        log_message = "Initial registration"
-        manager = RegistryManager.load(path, offline_mode=True)
-
-        dataset_file = (
-            make_test_project_dir / "datasets" / "sector_models" / "comstock" / "dataset.toml"
-        )
-        manager.project_manager.register(make_test_project_dir / "project.toml", user, log_message)
-        replace_dimension_uuids_from_registry(path, (dataset_file,))
-
-        data = load_data(dataset_file)
-        for dim in data["dimensions"]:
-            if dim["display_name"] == "Detailed Subsector":
-                dim["display_name"] = "Sector"
-        dump_data(data, dataset_file)
-        dataset_path = TEST_DATASET_DIRECTORY / data["dataset_id"]
-        with pytest.raises(ValueError):
-            manager.dataset_manager.register(dataset_file, dataset_path, user, log_message)
-
-
 def test_register_duplicate_project_rollback_dimensions(make_test_project_dir):
     src_dir = make_test_project_dir
     with TemporaryDirectory() as tmpdir:
@@ -342,7 +319,7 @@ def test_invalid_dimension_mapping(make_test_project_dir):
         record_file = (
             make_test_project_dir
             / "dimension_mappings"
-            / "base-to-supplemental"
+            / "base_to_supplemental"
             / "lookup_county_to_state.csv"
         )
         orig_text = record_file.read_text()


### PR DESCRIPTION
This is a super-set of #122. It removes some of the complexity of display_name by auto-generating dimensions and mappings for things like `all-sectors` and `all-subsectors`.

I also
- Changed the display_name requirement for uniqueness to be for a dimension type instead of globally for a project.
- Allow dashes in display_name.