### PR TITLE
Allow access to remote data paths

### DIFF
--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -21,9 +21,11 @@ from .dimensions import (
 )
 
 
+# Note that there is special handling for S3 at use sites.
 ALLOWED_LOAD_DATA_FILENAMES = ("load_data.parquet", "load_data.csv")
 ALLOWED_LOAD_DATA_LOOKUP_FILENAMES = (
     "load_data_lookup.parquet",
+    # The next two are only used for test data.
     "load_data_lookup.csv",
     "load_data_lookup.json",
 )
@@ -49,6 +51,7 @@ def check_load_data_filename(path: str):
 
     """
     if path.startswith("s3://"):
+        # Only Parquet is supported on AWS.
         return path + "/load_data.parquet"
 
     for allowed_name in ALLOWED_LOAD_DATA_FILENAMES:
@@ -78,6 +81,7 @@ def check_load_data_lookup_filename(path: str):
 
     """
     if path.startswith("s3://"):
+        # Only Parquet is supported on AWS.
         return path + "/load_data_lookup.parquet"
 
     for allowed_name in ALLOWED_LOAD_DATA_LOOKUP_FILENAMES:

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -49,7 +49,7 @@ def check_load_data_filename(path: str):
 
     """
     if path.startswith("s3://"):
-        return path + "load_data.parquet"
+        return path + "/load_data.parquet"
 
     for allowed_name in ALLOWED_LOAD_DATA_FILENAMES:
         filename = Path(path) / allowed_name
@@ -78,7 +78,7 @@ def check_load_data_lookup_filename(path: str):
 
     """
     if path.startswith("s3://"):
-        return path + "load_data_lookup.parquet"
+        return path + "/load_data_lookup.parquet"
 
     for allowed_name in ALLOWED_LOAD_DATA_LOOKUP_FILENAMES:
         filename = Path(path) / allowed_name

--- a/dsgrid/config/dimension_associations.py
+++ b/dsgrid/config/dimension_associations.py
@@ -42,7 +42,7 @@ class DimensionAssociations:
         associations = {}
         for association_file in association_files:
             filename = path / association_file
-            table = read_dataframe(filename, cache=True)
+            table = read_dataframe(filename, cache=True, read_with_spark=False)
             for column in table.columns:
                 tmp = column + "tmp_name"
                 table = (

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -4,6 +4,7 @@ import logging
 
 from pyspark.sql import SparkSession
 
+from dsgrid.common import REMOTE_REGISTRY
 from dsgrid.dataset.dataset import Dataset
 from dsgrid.exceptions import DSGValueNotRegistered
 from dsgrid.registry.registry_manager import RegistryManager, get_registry_path
@@ -24,19 +25,37 @@ class Project:
         self._dimension_mapping_mgr = dimension_mapping_mgr
 
     @classmethod
-    def load(cls, project_id, registry_path=None, version=None, offline_mode=False):
+    def load(
+        cls,
+        project_id,
+        registry_path=None,
+        version=None,
+        offline_mode=False,
+        remote_path=REMOTE_REGISTRY,
+        use_remote_data=None,
+    ):
         """Load a project from the registry.
         Parameters
         ----------
         project_id : str
         registry_path : str | None
+        remote_path: str, optional
+            path of the remote registry; default is REMOTE_REGISTRY
+        use_remote_data: bool, None
+            If set, use load data tables from remote_path. If not set, auto-determine what to do
+            based on HPC or AWS EMR environment variables.
         version : str | None
             Use the latest if not specified.
         offline_mode : bool
             If True, don't sync with remote registry
         """
         registry_path = get_registry_path(registry_path=registry_path)
-        manager = RegistryManager.load(registry_path, offline_mode=offline_mode)
+        manager = RegistryManager.load(
+            registry_path,
+            remote_path=remote_path,
+            use_remote_data=use_remote_data,
+            offline_mode=offline_mode,
+        )
         dataset_manager = manager.dataset_manager
         project_manager = manager.project_manager
         config = project_manager.get_by_id(project_id, version=version)

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -39,15 +39,15 @@ class Project:
         ----------
         project_id : str
         registry_path : str | None
+        version : str | None
+            Use the latest if not specified.
+        offline_mode : bool
+            If True, don't sync with remote registry
         remote_path: str, optional
             path of the remote registry; default is REMOTE_REGISTRY
         use_remote_data: bool, None
             If set, use load data tables from remote_path. If not set, auto-determine what to do
             based on HPC or AWS EMR environment variables.
-        version : str | None
-            Use the latest if not specified.
-        offline_mode : bool
-            If True, don't sync with remote registry
         """
         registry_path = get_registry_path(registry_path=registry_path)
         manager = RegistryManager.load(

--- a/dsgrid/registry/common.py
+++ b/dsgrid/registry/common.py
@@ -94,7 +94,7 @@ DimensionKey = namedtuple("DimensionKey", ["type", "id", "version"])
 # Obviates the need to pass parameters to many constructors.
 RegistryManagerParams = namedtuple(
     "RegistryManagerParams",
-    ["base_path", "remote_path", "fs_interface", "cloud_interface", "offline"],
+    ["base_path", "remote_path", "use_remote_data", "fs_interface", "cloud_interface", "offline"],
 )
 
 

--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -113,10 +113,14 @@ class DatasetRegistryManager(RegistryManagerBase):
         if dataset is not None:
             return dataset
 
+        if self._params.use_remote_data:
+            dataset_path = self._params.remote_path + "/data"
+        else:
+            dataset_path = str(self._params.base_path / "data")
         dataset = DatasetConfig.load_from_registry(
             self.get_config_file(key.id, key.version),
             self._dimension_mgr,
-            self._params.base_path / "data",
+            dataset_path,
         )
         self._datasets[key] = dataset
         return dataset
@@ -293,7 +297,7 @@ class DatasetRegistryManager(RegistryManagerBase):
 
     def remove(self, config_id):
         config = self.get_by_id(config_id)
-        self.fs_interface.rm_tree(config.dataset_path.parent)
+        self.fs_interface.rm_tree(Path(config.dataset_path).parent)
         self._remove(config_id)
         for key in [x for x in self._datasets if x.id == config_id]:
             self._datasets.pop(key)

--- a/dsgrid/registry/registry_manager.py
+++ b/dsgrid/registry/registry_manager.py
@@ -543,7 +543,6 @@ def _should_use_remote_data():
         use_remote_data = True
     elif "GITHUB_ACTION" in os.environ:
         logger.info("Do not use remote data on GitHub CI")
-        use_remote_data = False
     else:
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
         try:

--- a/dsgrid/registry/registry_manager.py
+++ b/dsgrid/registry/registry_manager.py
@@ -3,6 +3,7 @@
 import getpass
 import logging
 import os
+import sys
 from pathlib import Path
 import uuid
 
@@ -81,6 +82,10 @@ class RegistryManager:
         Parameters
         ----------
         path : str
+        remote_path : str
+            Path to remote registry.
+        use_remote_data_path : None, str
+            Path to remote registry.
 
         Returns
         -------
@@ -105,7 +110,7 @@ class RegistryManager:
         logger.info("Created registry at %s", path)
         cloud_interface = make_cloud_storage_interface(path, "", offline=True, uuid=uid, user=user)
         params = RegistryManagerParams(
-            Path(path), remote_path, fs_interface, cloud_interface, offline=True
+            Path(path), remote_path, False, fs_interface, cloud_interface, offline=True
         )
         return cls(params)
 
@@ -130,6 +135,7 @@ class RegistryManager:
         cls,
         path,
         remote_path=REMOTE_REGISTRY,
+        use_remote_data=None,
         offline_mode=False,
         user=None,
         no_prompts=False,
@@ -142,6 +148,9 @@ class RegistryManager:
             base path of the local or base registry
         remote_path: str, optional
             path of the remote registry; default is REMOTE_REGISTRY
+        use_remote_data: bool, None
+            If set, use load data tables from remote_path. If not set, auto-determine what to do
+            based on HPC or AWS EMR environment variables.
         offline_mode : bool
             Load registry in offline mode; default is False
         user : str
@@ -161,6 +170,10 @@ class RegistryManager:
         if str(path).startswith("s3"):
             raise Exception(f"S3 is not yet supported as the base path: {path}")
         fs_interface = make_filesystem_interface(path)
+
+        if use_remote_data is None:
+            use_remote_data = _should_use_remote_data()
+
         cloud_interface = make_cloud_storage_interface(
             path, remote_path, offline=offline_mode, uuid=uid, user=user
         )
@@ -196,7 +209,7 @@ class RegistryManager:
                 )
 
         params = RegistryManagerParams(
-            Path(path), remote_path, fs_interface, cloud_interface, offline_mode
+            Path(path), remote_path, use_remote_data, fs_interface, cloud_interface, offline_mode
         )
         path = Path(path)
         for dir_name in (
@@ -514,3 +527,33 @@ _REGISTRY_TYPE_TO_CLASS = {
 def get_registry_class(registry_type):
     """Return the subtype of RegistryBase correlated with registry_type."""
     return _REGISTRY_TYPE_TO_CLASS[registry_type]
+
+
+def _should_use_remote_data():
+    if sys.platform in ("darwin", "win32"):
+        # Local systems need to sync all load data files.
+        use_remote_data = False
+    elif "NREL_CLUSTER" in os.environ:
+        # All Eagle compute nodes have access to the shared load data files.
+        logger.info("Use remote data on NREL_CLUSTER %s", os.environ["NREL_CLUSTER"])
+        use_remote_data = True
+    elif "GITHUB_ACTION" in os.environ:
+        logger.info("Do not use remote data on GitHub CI")
+        use_remote_data = False
+    elif os.environ["USER"] in ("hadoop", "livy"):
+        # Spark on EC2 nodes must read from S3.
+        logger.info("Use remote data on AWS")
+        use_remote_data = True
+    else:
+        logger.warning("Unknown environment. Do not use remote data.")
+        use_remote_data = False
+    # This link describes how we could authoritatively check for an EC2 instance.
+    # However, it hangs on a local computer.
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+    # cmd = "curl http://169.254.169.254/latest/dynamic/instance-identity/document"
+    # output = {}
+    # ret = run_command(cmd, output=output)
+    # if ret == 0 and "instanceId" in json.loads(output["stdout"].strip()):
+    #     logger.info("Use remote data on AWS")
+    #     use_remote_data = True
+    return use_remote_data

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -99,11 +99,12 @@ def read_dataframe(filename, cache=False, require_unique=None, read_with_spark=T
 
 def _read_with_spark(filename):
     spark = SparkSession.getActiveSession()
-    if filename.endswith(".csv"):
+    suffix = Path(filename).suffix
+    if suffix == ".csv":
         df = spark.read.csv(filename, inferSchema=True, header=True)
-    elif Path(filename).suffix == ".parquet":
+    elif suffix == ".parquet":
         df = spark.read.parquet(filename)
-    elif Path(filename).suffix == ".json":
+    elif suffix == ".json":
         df = spark.read.json(filename, mode="FAILFAST")
     else:
         assert False, f"Unsupported file extension: {filename}"
@@ -111,14 +112,15 @@ def _read_with_spark(filename):
 
 
 def _read_natively(filename):
-    if Path(filename).suffix == ".csv":
+    suffix = Path(filename).suffix
+    if suffix == ".csv":
         # Reading the file is faster with pandas. Converting a list of Row to spark df
         # is a tiny bit faster. Pandas is likely scales better with bigger files.
         # Keep the code in case we ever want to revert.
         # with open(filename, encoding="utf-8-sig") as f_in:
         #     rows = [Row(**x) for x in csv.DictReader(f_in)]
         obj = pd.read_csv(filename)
-    elif Path(filename).suffix == ".json":
+    elif suffix == ".json":
         obj = load_data(filename)
     else:
         assert False, f"Unsupported file extension: {filename}"

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "prettytable",
         "pydantic",
         "pyspark==3.2.0",  # Keep this synced with the spark version in Dockerfile.
+        "requests",
         "s3path",
         "semver",
         "sqlalchemy",


### PR DESCRIPTION
This will allow AWS EC2 nodes to read Parquet files directly from S3. It will also allows HPC users to skip data-syncing.

Completes JIRA Story DSGRID-248