### PR TITLE
Add functionality to make a filtered registry for testing

### DIFF
--- a/dsgrid/cli/dsgrid_admin.py
+++ b/dsgrid/cli/dsgrid_admin.py
@@ -195,7 +195,7 @@ def _path_cb(_, __, val):
     default=False,
     is_flag=True,
     show_default=True,
-    help="Overwrite dst_registry_path if it already exists. Only applies if use_rsync is False.",
+    help="Overwrite dst_registry_path if it already exists. Does not apply if using rsync.",
 )
 def make_filtered_registry(
     src_registry_path: Path,

--- a/dsgrid/config/config_base.py
+++ b/dsgrid/config/config_base.py
@@ -1,4 +1,5 @@
 import abc
+import filecmp
 import logging
 import os
 import shutil
@@ -187,7 +188,9 @@ class ConfigWithDataFilesBase(ConfigBase, abc.ABC):
                     raise DSGInvalidOperation(
                         f"{dst_data_file} exists. Set force=True to overwrite."
                     )
-                shutil.copyfile(self._src_dir / orig_file, dst_data_file)
+                src_data_file = self._src_dir / orig_file
+                if not dst_data_file.exists() or not filecmp.cmp(src_data_file, dst_data_file):
+                    shutil.copyfile(self._src_dir / orig_file, dst_data_file)
                 new_files.append(Path(orig_file).name)
             model_data[field] = new_files
 

--- a/dsgrid/config/simple_models.py
+++ b/dsgrid/config/simple_models.py
@@ -1,0 +1,54 @@
+"""Defines simplified data models for testing and filtering."""
+
+from typing import List, Optional
+
+from pydantic import root_validator, validator, Field
+
+from dsgrid.data_models import DSGBaseModel
+from dsgrid.dimension.base_models import DimensionType
+
+
+class DimensionSimpleModel(DSGBaseModel):
+
+    dimension_type: DimensionType
+    query_name: Optional[str]
+    record_ids: List[str]
+
+
+class DimensionsSimpleModel(DSGBaseModel):
+
+    base_dimensions: List[DimensionSimpleModel]
+    supplemental_dimensions: List[DimensionSimpleModel] = Field(default=[])
+
+    @validator("base_dimensions")
+    def check_base_dimensions(cls, base_dimensions):
+        dimension_types = {x.dimension_type for x in base_dimensions}
+        if len(dimension_types) != len(base_dimensions):
+            raise ValueError("base_dimensions cannot contain duplicate dimension types")
+        return base_dimensions
+
+    @root_validator
+    def check_supplemental_dimensions(cls, values):
+        for dim in values["supplemental_dimensions"]:
+            if dim.query_name is None:
+                raise ValueError(f"supplemental dimensions must define query_name: {dim}")
+        return values
+
+
+class DatasetSimpleModel(DSGBaseModel):
+
+    dataset_id: str
+    dimensions: List[DimensionSimpleModel]
+
+
+class ProjectSimpleModel(DSGBaseModel):
+
+    project_id: str
+    dimensions: DimensionsSimpleModel
+
+
+class RegistrySimpleModel(DSGBaseModel):
+
+    name: str
+    projects: List[ProjectSimpleModel]
+    datasets: List[DatasetSimpleModel]

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -2,10 +2,12 @@ import abc
 import logging
 import os
 from collections import defaultdict
+from typing import List
 
 import pyspark.sql.functions as F
 
 from dsgrid.config.dataset_config import DatasetConfig
+from dsgrid.config.simple_models import DatasetSimpleModel
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import DSGInvalidDataset, DSGInvalidDimensionMapping, DSGInvalidField
 from dsgrid.dimension.time import TimeDimensionType
@@ -54,6 +56,13 @@ class DatasetSchemaHandlerBase(abc.ABC):
         -------
         pyspark.sql.DataFrame
 
+        """
+
+    @abc.abstractmethod
+    def filter_data(self, dimensions: List[DatasetSimpleModel]):
+        """Filter the load data by dimensions and rewrite the files.
+
+        dimensions : List[DimensionSimpleModel]
         """
 
     @property

--- a/dsgrid/dataset/dataset_schema_handler_one_table.py
+++ b/dsgrid/dataset/dataset_schema_handler_one_table.py
@@ -1,8 +1,10 @@
 import logging
+from typing import List
 
 from dsgrid.config.dataset_config import (
     DatasetConfig,
 )
+from dsgrid.config.simple_models import DatasetSimpleModel
 from dsgrid.utils.spark import read_dataframe, get_unique_values
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.dataset.dataset_schema_handler_base import DatasetSchemaHandlerBase
@@ -96,3 +98,7 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
         self._check_null_value_in_unique_dimension_rows(dim_table)
 
         return dim_table
+
+    @track_timing(timer_stats_collector)
+    def filter_data(self, dimensions: List[DatasetSimpleModel]):
+        assert False, "not supported yet"

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -1,7 +1,11 @@
 import logging
+from typing import List
+
+import pyspark.sql.functions as F
 
 from dsgrid.config.dataset_config import DatasetConfig
-from dsgrid.utils.spark import read_dataframe, get_unique_values
+from dsgrid.config.simple_models import DatasetSimpleModel
+from dsgrid.utils.spark import read_dataframe, get_unique_values, overwrite_dataframe_file
 from dsgrid.utils.timing import Timer, timer_stats_collector, track_timing
 from dsgrid.dataset.dataset_schema_handler_base import DatasetSchemaHandlerBase
 from dsgrid.dimension.base_models import DimensionType
@@ -156,3 +160,31 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
             raise DSGInvalidDataset(
                 f"load_data is missing {missing} columns for dimension={dim_type.value} based on records."
             )
+
+    @track_timing(timer_stats_collector)
+    def filter_data(self, dimensions: List[DatasetSimpleModel]):
+        lookup = self._load_data_lookup
+        pivot_dimension_type = self.get_pivot_dimension_type()
+        pivoted_columns = set(self.get_pivot_dimension_columns())
+        pivoted_columns_to_keep = set()
+        lookup_columns = set(lookup.columns)
+        for dim in dimensions:
+            column = dim.dimension_type.value
+            if column in lookup_columns:
+                lookup = lookup.filter(lookup[column].isin(dim.record_ids))
+            elif dim.dimension_type == pivot_dimension_type:
+                pivoted_columns_to_keep.update(set(dim.record_ids))
+            # else trivial dimension
+
+        # Bring it all into memory so that we can delete the original file.
+        lookup2 = lookup.coalesce(1).cache()
+        lookup2.count()
+        overwrite_dataframe_file(self._config.load_data_lookup_path, lookup2)
+        logger.info("Rewrote simplified %s", self._config.load_data_lookup_path)
+        ids = next(iter(lookup2.select("id").distinct().select(F.collect_list("id")).first()))
+
+        load_df = self._load_data.filter(self._load_data.id.isin(ids))
+        pivoted_columns_to_remove = list(pivoted_columns.difference(pivoted_columns_to_keep))
+        load_df = load_df.drop(*pivoted_columns_to_remove)
+        overwrite_dataframe_file(self._config.load_data_path, load_df)
+        logger.info("Rewrote simplified %s", self._config.load_data_path)

--- a/dsgrid/registry/filter_registry_manager.py
+++ b/dsgrid/registry/filter_registry_manager.py
@@ -1,0 +1,96 @@
+import logging
+
+from dsgrid.config.simple_models import RegistrySimpleModel
+from dsgrid.config.dataset_schema_handler_factory import make_dataset_schema_handler
+from dsgrid.utils.timing import track_timing, timer_stats_collector
+from .registry_manager import RegistryManager
+
+
+logger = logging.getLogger(__name__)
+
+
+class FilterRegistryManager(RegistryManager):
+    """Specialized RegistryManager that performs filtering operations."""
+
+    @track_timing(timer_stats_collector)
+    def filter(self, simple_model: RegistrySimpleModel):
+        """Filter the registry as described by simple_model.
+
+        Parameters
+        ----------
+        simple_model : RegistrySimpleModel
+            Filter all configs and data according to this model.
+
+        """
+        project_ids_to_keep = {x.project_id for x in simple_model.projects}
+        to_remove = [x for x in self._project_mgr.list_ids() if x not in project_ids_to_keep]
+        for project_id in to_remove:
+            self._project_mgr.remove(project_id)
+
+        dataset_ids_to_keep = {x.dataset_id for x in simple_model.datasets}
+        to_remove = [x for x in self._dataset_mgr.list_ids() if x not in dataset_ids_to_keep]
+        for dataset_id in to_remove:
+            self._dataset_mgr.remove(dataset_id)
+
+        modified_dims = set()
+        modified_dim_records = {}
+
+        # Note: Use pandas to write CSVs because Spark produces directories.
+
+        def handle_dimension(simple_dim, dim):
+            records = dim.get_records_dataframe()
+            filename = dim.src_dir / dim.model.filename
+            df = records.filter(records.id.isin(simple_dim.record_ids))
+            df.toPandas().to_csv(filename, index=False)
+            modified_dims.add(dim.model.dimension_id)
+            modified_dim_records[dim.model.dimension_id] = {
+                x.id for x in df.select("id").distinct().collect()
+            }
+
+        logger.info("Filter project dimensions")
+        for project in simple_model.projects:
+            project_config = self._project_mgr.get_by_id(project.project_id)
+            for simple_dim in project.dimensions.base_dimensions:
+                dim = project_config.get_base_dimension(simple_dim.dimension_type)
+                handle_dimension(simple_dim, dim)
+
+            for simple_dim in project.dimensions.supplemental_dimensions:
+                for dim in project_config.get_supplemental_dimensions(simple_dim.dimension_type):
+                    if dim.model.query_name == simple_dim.query_name:
+                        handle_dimension(simple_dim, dim)
+
+        logger.info("Filter dataset dimensions")
+        for dataset in simple_model.datasets:
+            logger.info("Filter dataset %s", dataset.dataset_id)
+            dataset_config = self._dataset_mgr.get_by_id(dataset.dataset_id)
+            for simple_dim in dataset.dimensions:
+                dim = dataset_config.get_dimension(simple_dim.dimension_type)
+                handle_dimension(simple_dim, dim)
+            handler = make_dataset_schema_handler(
+                dataset_config, self._dimension_mgr, self._dimension_mapping_mgr
+            )
+            handler.filter_data(dataset.dimensions)
+
+        logger.info("Filter dimension mapping records")
+        for mapping in self._dimension_mapping_mgr.iter_configs():
+            records = None
+            from_id = mapping.model.from_dimension.dimension_id
+            to_id = mapping.model.to_dimension.dimension_id
+            if from_id in modified_dims or to_id in modified_dims:
+                records = mapping.get_records_dataframe()
+                if from_id in modified_dims:
+                    records = records.filter(records.from_id.isin(modified_dim_records[from_id]))
+                if to_id in modified_dims:
+                    records = records.filter(records.to_id.isin(modified_dim_records[to_id]))
+            if records is not None:
+                filename = mapping.src_dir / mapping.model.filename
+                records.toPandas().to_csv(filename, index=False)
+                logger.info("Filtered dimension mapping records from %s", filename)
+
+        for project in simple_model.projects:
+            project_config = self._project_mgr.get_by_id(project.project_id)
+            project_config.serialize(project_config.src_dir, force=True)
+
+        for dataset in simple_model.datasets:
+            dataset_config = self._dataset_mgr.get_by_id(dataset.dataset_id)
+            dataset_config.serialize(dataset_config.src_dir, force=True)

--- a/dsgrid/registry/registry_manager.py
+++ b/dsgrid/registry/registry_manager.py
@@ -509,11 +509,8 @@ class RegistryManager:
         mode : str
             Controls whether to copy all data, make symlinks to data files, or sync data with the
             rsync utility (not available on Windows). Options: 'copy', 'data-symlinks', 'rsync'
-        use_rsync : bool
-            If True, use rsync instead of copy. Useful for testing when the method is called many
-            times. Not available on Windows.
         force : bool
-            Overwrite dst if it already exists. Only applies if use_rsync is False.
+            Overwrite dst if it already exists. Does not apply if using rsync.
 
         Raises
         ------

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import AnyStr, List, Union
 
@@ -251,6 +252,22 @@ def check_for_nulls(df, exclude_columns=None):
             )
     finally:
         sql("DROP VIEW tmp_table")
+
+
+def overwrite_dataframe_file(filename, df):
+    suffix = Path(filename).suffix
+    tmp = str(filename) + ".tmp"
+    if suffix == ".parquet":
+        df.write.parquet(tmp)
+    elif suffix == ".csv":
+        df.write.csv(tmp, header=True)
+    elif suffix == ".json":
+        df.write.json(tmp)
+    if os.path.isfile(filename):
+        os.unlink(filename)
+    else:
+        shutil.rmtree(filename)
+    os.rename(tmp, str(filename))
 
 
 def sql(query):

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -263,7 +263,7 @@ def overwrite_dataframe_file(filename, df):
         df.write.csv(tmp, header=True)
     elif suffix == ".json":
         df.write.json(tmp)
-    if os.path.isfile(filename):
+    if os.path.isfile(filename) or os.path.islink(filename):
         os.unlink(filename)
     else:
         shutil.rmtree(filename)

--- a/tests/test_filter_registry.py
+++ b/tests/test_filter_registry.py
@@ -1,0 +1,84 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+from dsgrid.config.simple_models import RegistrySimpleModel
+from dsgrid.dimension.base_models import DimensionType
+from dsgrid.project import Project
+from dsgrid.registry.registry_manager import RegistryManager
+from dsgrid.registry.filter_registry_manager import FilterRegistryManager
+from dsgrid.tests.common import TEST_REGISTRY
+
+
+PROJECT_ID = "test_efs"
+DATASET_ID = "test_efs_comstock"
+COUNTY_ID = "08031"
+STATE_ID = "CO"
+QUERY_NAME = "state"
+FILTER_CONFIG = {
+    "name": "test-registry",
+    "projects": [
+        {
+            "project_id": PROJECT_ID,
+            "dimensions": {
+                "base_dimensions": [{"dimension_type": "geography", "record_ids": [COUNTY_ID]}],
+                "supplemental_dimensions": [
+                    {
+                        "query_name": QUERY_NAME,
+                        "dimension_type": "geography",
+                        "record_ids": [STATE_ID],
+                    }
+                ],
+            },
+        }
+    ],
+    "datasets": [
+        {
+            "dataset_id": DATASET_ID,
+            "dimensions": [{"dimension_type": "geography", "record_ids": [COUNTY_ID]}],
+        }
+    ],
+}
+
+
+def test_filter_registry():
+    simple_model = RegistrySimpleModel(**FILTER_CONFIG)
+    dst = Path(tempfile.gettempdir()) / "test-dsgrid-registry"
+    RegistryManager.copy(TEST_REGISTRY, dst, force=True)
+    try:
+        FilterRegistryManager.load(dst, offline_mode=True).filter(simple_model)
+        project = Project.load(PROJECT_ID, offline_mode=True, registry_path=dst)
+
+        # Verify that the dataset, dimensions, and dimension mappings are all filtered.
+        project.load_dataset(DATASET_ID)
+        dataset = project.get_dataset(DATASET_ID)
+        load_data = dataset.load_data.join(dataset.load_data_lookup, on="id").drop("id")
+        dataset_geos = load_data.select("geography").distinct().collect()
+        assert len(dataset_geos) == 1
+        assert dataset_geos[0].geography == COUNTY_ID
+
+        base_dim = project.config.get_base_dimension(DimensionType.GEOGRAPHY)
+        records = base_dim.get_records_dataframe().collect()
+        assert len(records) == 1
+        assert records[0].id == COUNTY_ID
+
+        supp_dim = project.config.get_dimension_records(
+            DimensionType.GEOGRAPHY, QUERY_NAME
+        ).collect()
+        assert len(supp_dim) == 1
+        assert supp_dim[0].id == STATE_ID
+
+        found_mapping_records = False
+        for dim in project.config.get_supplemental_dimensions(DimensionType.GEOGRAPHY):
+            if dim.model.query_name == QUERY_NAME:
+                for mapping in project.config.get_base_to_supplemental_dimension_mappings_by_types(
+                    DimensionType.GEOGRAPHY
+                ):
+                    if mapping.model.to_dimension.dimension_id == dim.model.dimension_id:
+                        records = mapping.get_records_dataframe().collect()
+                        assert len(records) == 1
+                        assert records[0].from_id == COUNTY_ID and records[0].to_id == STATE_ID
+                        found_mapping_records = True
+        assert found_mapping_records
+    finally:
+        shutil.rmtree(dst)


### PR DESCRIPTION
The purpose of this PR is to create datasets that are small enough to allow fast tests of queries.

There is a test that demonstrates the functionality in tests/test_filtered_registry.py. I have a more complete example on Eagle at /projects/dsgrid/filtered-registries/simple-standard-scenarios/. That directory has a config file that controls the filtering as well as a filtered version of the StandardScenarios project. The data reduction is ~60 GB -> 6 MB.
