### PR TITLE
Change query_name rule for projects

### DIFF
--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -4,13 +4,12 @@ import getpass
 import itertools
 import logging
 import shutil
-from collections import defaultdict
 from pathlib import Path
 from typing import Union, List, Dict
 
 from prettytable import PrettyTable
 
-from dsgrid.dimension.base_models import DimensionType, check_timezone_in_base_geography
+from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import (
     DSGInvalidDataset,
     DSGInvalidDimensionAssociation,
@@ -373,7 +372,7 @@ class ProjectRegistryManager(RegistryManagerBase):
                 DimensionModel,
                 filename=str(Path(_SUPPLEMENTAL_TMP_DIR) / dim_record_file.name),
                 name=dt_plural_dash,
-                display_name="None",
+                display_name=dt_plural_formal,
                 dimension_type=dimension_type,
                 module=dim_config.model.module,
                 class_name=dim_config.model.class_name,
@@ -441,19 +440,9 @@ class ProjectRegistryManager(RegistryManagerBase):
 
     @track_timing(timer_stats_collector)
     def _run_checks(self, config: ProjectConfig):
-        dims = []
-        dims_by_type = defaultdict(list)
-        for dim in config.iter_dimensions():
-            dims.append(dim)
-            dims_by_type[dim.model.dimension_type].append(dim)
-
-        for dim in config.model.dimensions.base_dimensions:
-            if dim.model.dimension_type == DimensionType.GEOGRAPHY:
-                check_timezone_in_base_geography(dim)
-
+        dims = [x for x in config.iter_dimensions()]
         check_uniqueness((x.model.name for x in dims), "dimension name")
-        for dims in dims_by_type.values():
-            check_uniqueness((x.model.display_name for x in dims), "dimension display name")
+        check_uniqueness((x.model.display_name for x in dims), "dimension display name")
         check_uniqueness(
             (getattr(x.model, "cls") for x in config.model.dimensions.base_dimensions),
             "dimension cls",

--- a/tests/test_filter_registry.py
+++ b/tests/test_filter_registry.py
@@ -62,9 +62,7 @@ def test_filter_registry():
         assert len(records) == 1
         assert records[0].id == COUNTY_ID
 
-        supp_dim = project.config.get_dimension_records(
-            DimensionType.GEOGRAPHY, QUERY_NAME
-        ).collect()
+        supp_dim = project.config.get_dimension_records(QUERY_NAME).collect()
         assert len(supp_dim) == 1
         assert supp_dim[0].id == STATE_ID
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -32,7 +32,7 @@ def test_project_load():
     assert config.has_base_to_supplemental_dimension_mapping_types(DimensionType.SECTOR)
     assert config.has_base_to_supplemental_dimension_mapping_types(DimensionType.SUBSECTOR)
 
-    records = project.config.get_dimension_records(DimensionType.SUBSECTOR, "none").collect()
+    records = project.config.get_dimension_records("all_subsectors").collect()
     assert len(records) == 1
     assert records[0].id == "all_subsectors"
 
@@ -62,7 +62,7 @@ def test_dataset_load():
 
     query_names = sorted(project.config.list_dimension_query_names(DimensionType.GEOGRAPHY))
     assert query_names == ["census_division", "census_region", "county", "state"]
-    records = project.config.get_dimension_records(DimensionType.GEOGRAPHY, "state")
+    records = project.config.get_dimension_records("state")
     assert records.filter("id = 'CO'").count() > 0
 
     project.unload_dataset(DATASET_ID)

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -11,6 +11,7 @@ from semver import VersionInfo
 from dsgrid.exceptions import (
     DSGDuplicateValueRegistered,
     DSGInvalidDataset,
+    DSGInvalidDimension,
     DSGInvalidDimensionMapping,
     DSGValueNotRegistered,
 )
@@ -141,7 +142,7 @@ def test_duplicate_project_dimension_display_names(make_test_project_dir):
             if dim["display_name"] == "State":
                 dim["display_name"] = "County"
         dump_data(data, project_file)
-        with pytest.raises(ValueError):
+        with pytest.raises(DSGInvalidDimension):
             manager.project_manager.register(project_file, user, log_message)
 
 


### PR DESCRIPTION
Require that query_name be unique across all dimensions in a project
instead of per dimension type. This is needed to allow query
functionality.
