### PR TITLE
Ll/rename year in annualtime

### DIFF
--- a/dsgrid/config/annual_time_dimension_config.py
+++ b/dsgrid/config/annual_time_dimension_config.py
@@ -24,21 +24,29 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
     @track_timing(timer_stats_collector)
     def check_dataset_time_consistency(self, load_data_df):
         logger.info("Check AnnualTimeDimensionConfig dataset time consistency.")
+        time_col = self.get_timestamp_load_data_columns()
+        if len(time_col) > 1:
+            raise ValueError(
+                "AnnualTimeDimensionConfig expects only one column from "
+                f"get_timestamp_load_data_columns, but has {time_col}"
+            )
+        time_col = time_col[0]
         time_ranges = self.get_time_ranges()
         assert len(time_ranges) == 1, len(time_ranges)
         time_range = time_ranges[0]
         # TODO: need to support validation of multiple time ranges: DSGRID-173
+
         expected_timestamps = time_range.list_time_range()
         actual_timestamps = [
-            pd.Timestamp(str(x.year)).to_pydatetime()
-            for x in load_data_df.select("year").distinct().sort("year").collect()
+            pd.Timestamp(str(x[time_col])).to_pydatetime()
+            for x in load_data_df.select(time_col).distinct().sort(time_col).collect()
         ]
         if expected_timestamps != actual_timestamps:
             mismatch = sorted(
                 set(expected_timestamps).symmetric_difference(set(actual_timestamps))
             )
             raise DSGInvalidDataset(
-                f"load_data timestamps do not match expected times. mismatch={mismatch}"
+                f"load_data {time_col}s do not match expected times. mismatch={mismatch}"
             )
 
     def convert_dataframe(self, df):
@@ -67,7 +75,7 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
         return ranges
 
     def get_timestamp_load_data_columns(self):
-        return ["year"]
+        return list(AnnualTimestampType._fields)
 
     def get_tzinfo(self):
         return None

--- a/dsgrid/config/representative_period_time_dimension_config.py
+++ b/dsgrid/config/representative_period_time_dimension_config.py
@@ -131,12 +131,10 @@ class OneWeekPerMonthByHourHandler(RepresentativeTimeFormatHandlerBase):
 
     def check_dataset_time_consistency(self, expected_timestamps, load_data_df):
         logger.info("Check OneWeekPerMonthByHourHandler dataset time consistency.")
+        time_cols = self.get_timestamp_load_data_columns()
         actual_timestamps = [
-            OneWeekPerMonthByHourType(month=x.month, day_of_week=x.day_of_week, hour=x.hour)
-            for x in load_data_df.select("month", "day_of_week", "hour")
-            .distinct()
-            .sort("month", "day_of_week", "hour")
-            .collect()
+            OneWeekPerMonthByHourType(*x.asDict().values())
+            for x in load_data_df.select(*time_cols).distinct().sort(*time_cols).collect()
         ]
         if expected_timestamps != actual_timestamps:
             mismatch = sorted(
@@ -179,7 +177,7 @@ class OneWeekPerMonthByHourHandler(RepresentativeTimeFormatHandlerBase):
 
     @staticmethod
     def get_timestamp_load_data_columns():
-        return ["month", "day_of_week", "hour"]
+        return list(OneWeekPerMonthByHourType._fields)
 
     def list_expected_dataset_timestamps(self, ranges):
         timestamps = []

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -171,13 +171,15 @@ class DatasetSchemaHandlerBase(abc.ABC):
         distinct_counts = counts.select("count").distinct().collect()
         if len(distinct_counts) != 1:
             raise DSGInvalidDataset(
-                f"All time arrays must have the same times: unique timestamp counts = {len(distinct_counts)}"
+                "All time arrays must be repeated the same number of times: "
+                f"unique timestamp repeats = {len(distinct_counts)}"
             )
-        unique_ta_counts = load_data_df.select(*unique_array_cols).distinct().count()
-        if unique_ta_counts != distinct_counts[0]["count"]:
+        ta_counts = load_data_df.groupBy(*unique_array_cols).count().select("count")
+        distinct_ta_counts = ta_counts.select("count").distinct().collect()
+        if len(distinct_ta_counts) != 1:
             raise DSGInvalidDataset(
-                f"dataset has invalid timestamp counts, expected {unique_ta_counts} count for "
-                f"each timestamp in {time_cols} but found {distinct_counts[0]['count']} instead"
+                "All combinations of non-time dimensions must have the same time array length: "
+                f"unique time array lengths = {len(distinct_ta_counts)}"
             )
 
     @track_timing(timer_stats_collector)

--- a/dsgrid/time/types.py
+++ b/dsgrid/time/types.py
@@ -26,7 +26,7 @@ class Season(DSGEnum):
 
 DatetimeTimestampType = namedtuple("DatetimeTimestampType", ["timestamp"])
 
-AnnualTimestampType = namedtuple("AnnualTimestampType", ["year"])
+AnnualTimestampType = namedtuple("AnnualTimestampType", ["time_year"])
 
 OneWeekPerMonthByHourType = namedtuple(
     "OneWeekPerMonthByHourType", ["month", "day_of_week", "hour"]

--- a/tests/data/dimension_models/minimal/dimension_test_time.toml
+++ b/tests/data/dimension_models/minimal/dimension_test_time.toml
@@ -63,6 +63,7 @@ str_format = "%Y"
 include_leap_day = true
 measurement_type = "mean"
 
+
 [[dimensions]] #[5]
 class = "Time"
 type = "time"

--- a/tests/data/dimension_models/minimal/dimension_test_time.toml
+++ b/tests/data/dimension_models/minimal/dimension_test_time.toml
@@ -62,3 +62,16 @@ ranges = [{start = "2020", end = "2050"}]
 str_format = "%Y"
 include_leap_day = true
 measurement_type = "mean"
+
+[[dimensions]] #[5]
+class = "Time"
+type = "time"
+name = "Time of Week by Month"
+display_name = "Hourly for Representative Weeks"
+ranges = [{start = 1, end = 12}]
+time_interval_type = "period_ending"
+time_type = "representative_period"
+measurement_type = "total"
+format = "one_week_per_month_by_hour"
+description = """
+TEMPO Time - Month (representing seasons), day of week, and hour of day."""

--- a/tests/test_aeo_dataset_registration.py
+++ b/tests/test_aeo_dataset_registration.py
@@ -95,8 +95,6 @@ def test_aeo_datasets_registration(make_test_project_dir, make_test_data_dir):
         logger.info("3. with a duplicated dimension: ")
         _modify_data_file(data_dir, duplicate_col="subsector")
         with pytest.raises((ValueError, DSGInvalidDimension)):
-            # (ValueError,  match=r"*is not a valid DimensionType"),
-            # (DSGInvalidDimension,  match=r"column.*is not expected or of a known dimension type")
             _test_dataset_registration(make_test_project_dir, data_dir, dataset)
 
         logger.info("4. with a duplicated pivot col: ")
@@ -111,7 +109,7 @@ def test_aeo_datasets_registration(make_test_project_dir, make_test_data_dir):
             _modify_data_file(data_dir, drop_first_row=True)
             with pytest.raises(
                 DSGInvalidDataset,
-                match=r"All time arrays must have the same times.*unique timestamp counts",
+                match=r"All time arrays must be repeated the same number of times: unique timestamp repeats =.*",
             ):
                 _test_dataset_registration(make_test_project_dir, data_dir, dataset)
 

--- a/tests/test_create_time_dimensions.py
+++ b/tests/test_create_time_dimensions.py
@@ -8,6 +8,9 @@ from dsgrid.config.dimensions_config import DimensionsConfigModel
 from dsgrid.utils.files import load_data
 from tests.data.dimension_models.minimal.models import DIMENSION_CONFIG_FILE_TIME
 from dsgrid.config.date_time_dimension_config import DateTimeDimensionConfig
+from dsgrid.config.representative_period_time_dimension_config import (
+    RepresentativePeriodTimeDimensionConfig,
+)
 from dsgrid.dimension.time import LeapDayAdjustmentType
 
 
@@ -44,6 +47,14 @@ def annual_time_dimension_model():
     config_as_dict = load_data(file)
     model = DimensionsConfigModel(**config_as_dict)
     yield model.dimensions[3]  # AnnualTimeDimensionModel (annual time, correct format)
+
+
+@pytest.fixture
+def representative_time_dimension_model():
+    file = DIMENSION_CONFIG_FILE_TIME
+    config_as_dict = load_data(file)
+    model = DimensionsConfigModel(**config_as_dict)
+    yield model.dimensions[4]  # RepresentativeTimeDimensionModel
 
 
 def check_date_range_creation(time_dimension_model):
@@ -143,6 +154,12 @@ def test_time_dimension_model3(time_dimension_model3):
 
 def test_time_dimension_model4(annual_time_dimension_model):
     check_register_annual_time(annual_time_dimension_model)
+
+
+def test_time_dimension_model5(representative_time_dimension_model):
+    config = RepresentativePeriodTimeDimensionConfig(representative_time_dimension_model)
+    config.list_expected_dataset_timestamps()
+    config.get_time_ranges()
 
 
 def test_time_dimension_model_lead_day_adj(time_dimension_model1):

--- a/tests/test_create_time_dimensions.py
+++ b/tests/test_create_time_dimensions.py
@@ -158,8 +158,12 @@ def test_time_dimension_model4(annual_time_dimension_model):
 
 def test_time_dimension_model5(representative_time_dimension_model):
     config = RepresentativePeriodTimeDimensionConfig(representative_time_dimension_model)
-    config.list_expected_dataset_timestamps()
-    config.get_time_ranges()
+    if config.model.format.value == "one_week_per_month_by_hour":
+        n_times = len(config.list_expected_dataset_timestamps())
+        assert n_times == 24 * 7 * 12, n_times
+        assert config.get_frequency() == datetime.timedelta(hours=1)
+
+    config.get_time_ranges()  # TODO: this is not correct yet in terms of year, maybe this functionality should exist in project instead
 
 
 def test_time_dimension_model_lead_day_adj(time_dimension_model1):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -167,7 +167,10 @@ def _setup_invalid_load_data_id_missing_timestamp(data_dir):
     # Remove one row/timestamp for one load data array.
     text = "\n".join(data_file.read_text().splitlines()[:-1])
     data_file.write_text(text)
-    return DSGInvalidDataset, r"All time arrays must have the same times.*unique timestamp counts"
+    return (
+        DSGInvalidDataset,
+        r"All time arrays must be repeated the same number of times: unique timestamp repeats =.*",
+    )
 
 
 def _setup_invalid_load_data_id_extra_timestamp(data_dir):


### PR DESCRIPTION
Completes JIRA Story DSGRID-
Closes GitHub Issue #

- AnnualTime Class and Config now takes `time_year` instead of `year`
- Minor tweaks to TimeConfig so they are more connected to dsgrid.time.types
- Includes a time check fix per Issue #143 (@mooneyme - please test your EIA861 sales registration with this branch, don't forget to change the "year" column in your data to "time_year" per this PR)

dsgrid-test-data companion PR: https://github.com/dsgrid/dsgrid-test-data/pull/22

## Checklist

- [ ] Tests exercising the new feature or bug fix
- [x] All tests pass
- [x] At least one code review approval
- [ ] Consider transferring TODOs to JIRA or GitHub
