### PR TITLE
rename sector_models to modeled

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = main
+	branch = mm/update_sector_models_to_modeled

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = mm/update_sector_models_to_modeled
+	branch = main

--- a/dev/README.md
+++ b/dev/README.md
@@ -251,8 +251,8 @@ app = RegistrationGui(
     defaults={
        "local_registry": "/my-local-registry",
         "project_file": "/repos/dsgrid-project-StandardScenarios/dsgrid_project/project.toml",
-        "dataset_file": "/repos/dsgrid-project-StandardScenarios/dsgrid_project/datasets/sector_models/comstock/dataset.toml",
-        "dimension_mapping_file": "/repos/dsgrid-project-StandardScenarios/dsgrid_project/datasets/sector_models/comstock/dimension_mappings.toml",
+        "dataset_file": "/repos/dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/comstock/dataset.toml",
+        "dimension_mapping_file": "/repos/dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/comstock/dimension_mappings.toml",
         "dataset_path": "/dsgrid-data/data-StandardScenarios/conus_2022_reference_comstock",
         "log_message": "log message",
     }

--- a/docs/make_example_configs.py
+++ b/docs/make_example_configs.py
@@ -9,7 +9,7 @@ from pathlib import Path
 PROJECT_REPO = Path(__file__).resolve().parent.parent / "dsgrid-test-data" / "test_efs"
 
 base_dir = PROJECT_REPO / "dsgrid_project"
-dataset_dir = base_dir / "datasets" / "sector_models" / "comstock"
+dataset_dir = base_dir / "datasets" / "modeled" / "comstock"
 
 project_config = base_dir / "project.toml"
 dimensions_config = base_dir / "dimensions.toml"

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -101,7 +101,7 @@ We recommend that dsgrid project repositories use the following directory organi
             ├── datasets
             │   ├── benchmark
             │   ├── historical
-            │   └── sector_models
+            │   └── modeled
             │       ├── comstock
             │       │   ├── dimension_mappings
             │       │   ├── dimensions
@@ -115,7 +115,7 @@ We recommend that dsgrid project repositories use the following directory organi
 
 In the directory structure above, all project files are stored in the ``dsgrid_project`` root directory. And within this root directory we have:
 
-    * ``datasets``: This is where we define input datasets, oranized first by type (i.e., ``datasets/historical``, ``datasets/benchmark``, ``datasets/sector_models``) and then by source (e.g., ``datasets/sector_models/comstock``) for the dsgrid project
+    * ``datasets``: This is where we define input datasets, oranized first by type (i.e., ``datasets/historical``, ``datasets/benchmark``, ``datasets/modeled``) and then by source (e.g., ``datasets/modeled/comstock``) for the dsgrid project
     * ``dimension_mappings``: This where we store :under:`project-level` dimension mapping records (csv or json)
     * ``dimensons``: This is where we store :under:`project-level` dimension records (csv or json)
     * ``project.toml``: This is the main project configuration file. See ::ref

--- a/dsgrid/apps/registration_gui.py
+++ b/dsgrid/apps/registration_gui.py
@@ -16,7 +16,7 @@ from dsgrid.loggers import setup_logging
 from dsgrid.utils.spark import init_spark
 
 SS_PROJECT = "https://github.com/dsgrid/dsgrid-project-StandardScenarios/blob/main/dsgrid_project/project.toml"
-RS_DATASET = "https://github.com/dsgrid/dsgrid-project-StandardScenarios/blob/main/dsgrid_project/datasets/sector_models/resstock/dataset.toml"
+RS_DATASET = "https://github.com/dsgrid/dsgrid-project-StandardScenarios/blob/main/dsgrid_project/datasets/modeled/resstock/dataset.toml"
 
 logger = logging.getLogger(__name__)
 

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -94,7 +94,7 @@ def check_load_data_lookup_filename(path: str):
 
 
 class InputDatasetType(DSGEnum):
-    SECTOR_MODEL = "sector_model"
+    MODELED = "modeled"
     HISTORICAL = "historical"
     BENCHMARK = "benchmark"
 

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -166,27 +166,6 @@ class DataClassificationType(DSGEnum):
     )
 
 
-# TODO will need to rename this as it really should be more generic inputs
-#   and not just sector inputs. "InputSectorDataset" is already taken in
-#   project_config.py
-# TODO: this already assumes that the data is formatted for DSG, however,
-#       we may want the dataset config to be "before" any DSG parquets get
-#       formatted.
-class InputSectorDataset(DSGBaseModel):
-    """Input dataset configuration class"""
-
-    data_type: DSGDatasetParquetType = Field(
-        title="data_type",
-        alias="type",
-        description="DSG parquet input dataset type",
-        options=DSGDatasetParquetType.format_for_docs(),
-    )
-    directory: str = Field(
-        title="directory",
-        description="Directory with parquet files",
-    )
-
-
 class StandardDataSchemaModel(DSGBaseModel):
     load_data_column_dimension: DimensionType = Field(
         title="load_data_column_dimension",
@@ -247,6 +226,11 @@ class DatasetConfigModel(DSGBaseModel):
     dataset_qualifier_metadata: Optional[GrowthRateModel] = Field(
         title="dataset_qualifier_metadata",
         description="Additional metadata to include related to the dataset_qualifier",
+    )
+    sector_description: Optional[str] = Field(
+        title="sector_description",
+        description="Sectoral description (e.g., residential, commercial, industrial, "
+        "transportation, electricity)",
     )
     data_source: str = Field(
         title="data_source",

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -182,12 +182,13 @@ class InputDatasetModel(DSGBaseModel):
     )
     # TODO this model_sector must be validated in the dataset_config
     # TODO: this is only necessary for input_model types
-    model_sector: str = Field(  # TODO: should this be data_source instead?
+    model_sector: str = Field(  # TODO: should this be data_source instead? -- still relevant?
         # TODO: need to discuss with team why this is needed. One potential reason is because it is
         # helpful to query at some point which datasets have not yet been registered. Dataset_id may
         # not be all that descriptive, but the data_source is. We may also want the metric_type here too.
         title="model_sector",
         description="Model sector ID, required only if dataset type is ``sector_model``.",
+        # -- still relevant?
         optional=True,
         updateable=False,
     )
@@ -198,6 +199,7 @@ class InputDatasetModel(DSGBaseModel):
 
     @validator("model_sector")
     def check_model_sector(cls, model_sector, values):
+        # TODO: how does change to "modeled" get set here? is this validator still relevant?
         if "dataset_type" in values:
             if not values["dataset_type"] == InputDatasetType.SECTOR_MODEL:
                 raise ValueError("model_sector is only required if dataset_type is 'sector_model'")

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -180,30 +180,10 @@ class InputDatasetModel(DSGBaseModel):
         notes=("status is "),
         updateable=False,
     )
-    # TODO this model_sector must be validated in the dataset_config
-    # TODO: this is only necessary for input_model types
-    model_sector: str = Field(  # TODO: should this be data_source instead? -- still relevant?
-        # TODO: need to discuss with team why this is needed. One potential reason is because it is
-        # helpful to query at some point which datasets have not yet been registered. Dataset_id may
-        # not be all that descriptive, but the data_source is. We may also want the metric_type here too.
-        title="model_sector",
-        description="Model sector ID, required only if dataset type is ``sector_model``.",
-        # -- still relevant?
-        optional=True,
-        updateable=False,
-    )
 
     @validator("version")
     def check_version(cls, version):
         return handle_version_or_str(version)
-
-    @validator("model_sector")
-    def check_model_sector(cls, model_sector, values):
-        # TODO: how does change to "modeled" get set here? is this validator still relevant?
-        if "dataset_type" in values:
-            if not values["dataset_type"] == InputDatasetType.SECTOR_MODEL:
-                raise ValueError("model_sector is only required if dataset_type is 'sector_model'")
-        return model_sector
 
 
 class DimensionMappingsModel(DSGBaseModel):

--- a/dsgrid/tests/make_standard_scenarios_registry.py
+++ b/dsgrid/tests/make_standard_scenarios_registry.py
@@ -44,7 +44,7 @@ def make_standard_scenarios_registry(
 
     path = create_local_test_registry(registry_path)
     project_config_file = src_dir / "project.toml"
-    dataset_base = Path("datasets/sector_models")
+    dataset_base = Path("datasets/modeled")
     dataset_ids = (
         "conus_2022_reference_comstock",
         "conus_2022_reference_resstock",

--- a/dsgrid/tests/make_us_data_registry.py
+++ b/dsgrid/tests/make_us_data_registry.py
@@ -54,7 +54,7 @@ def make_test_data_registry(
         dataset_path = os.environ.get("DSGRID_LOCAL_DATA_DIRECTORY", TEST_DATASET_DIRECTORY)
     dataset_path = Path(dataset_path)
     path = create_local_test_registry(registry_path)
-    dataset_dir = Path("datasets/sector_models/comstock")
+    dataset_dir = Path("datasets/modeled/comstock")
 
     user = getpass.getuser()
     log_message = "Initial registration"

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -38,7 +38,7 @@ def test_register_project_and_dataset(make_test_project_dir):
     with TemporaryDirectory() as tmpdir:
         path = Path(tmpdir) / "registry"
         check_run_command(f"dsgrid-admin create-registry {path}")
-        dataset_dir = Path("datasets/sector_models/comstock")
+        dataset_dir = Path("datasets/modeled/comstock")
 
         src_dir = make_test_project_dir
         project_config = src_dir / "project.toml"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -37,7 +37,7 @@ def test_invalid_datasets(make_test_project_dir, make_test_data_dir):
             dataset_path=make_test_data_dir,
             include_datasets=False,
         )
-        dataset_dir = make_test_project_dir / "datasets" / "sector_models" / "comstock"
+        dataset_dir = make_test_project_dir / "datasets" / "modeled" / "comstock"
         assert dataset_dir.exists()
         dataset_config_file = dataset_dir / "dataset.toml"
         dataset_id = load_data(dataset_config_file)["dataset_id"]

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -68,7 +68,7 @@ def test_register_project_and_dataset(make_test_project_dir):
 
         with pytest.raises(DSGDuplicateValueRegistered):
             dataset_config_file = (
-                make_test_project_dir / "datasets" / "sector_models" / "comstock" / "dataset.toml"
+                make_test_project_dir / "datasets" / "modeled" / "comstock" / "dataset.toml"
             )
             dataset_mgr.register(dataset_config_file, dataset_path, user, log_message)
 
@@ -181,7 +181,7 @@ def test_register_and_submit_rollback_on_failure(make_test_project_dir):
         manager = RegistryManager.load(path, offline_mode=True)
         project_file = src_dir / "project.toml"
         project_id = load_data(project_file)["project_id"]
-        dataset_dir = src_dir / "datasets" / "sector_models" / "comstock"
+        dataset_dir = src_dir / "datasets" / "modeled" / "comstock"
         dataset_config_file = dataset_dir / "dataset.toml"
         dataset_id = load_data(dataset_config_file)["dataset_id"]
         dataset_mapping_file = dataset_dir / "dimension_mappings.toml"
@@ -365,7 +365,7 @@ def test_register_submit_dataset_long_workflow(make_test_project_dir):
         project_id = load_data(project_config_file)["project_id"]
         project_dimension_mapping_config = src_dir / "dimension_mappings_with_ids.toml"
         project_dimension_file = src_dir / "dimensions.toml"
-        dataset_dir = src_dir / "datasets" / "sector_models" / "comstock"
+        dataset_dir = src_dir / "datasets" / "modeled" / "comstock"
         dataset_config_file = dataset_dir / "dataset_with_dimension_ids.toml"
         dataset_id = load_data(dataset_config_file)["dataset_id"]
         dataset_dimension_file = dataset_dir / "dimensions.toml"

--- a/tests/test_tempo_registration.py
+++ b/tests/test_tempo_registration.py
@@ -52,7 +52,7 @@ def make_registry_for_tempo(registry_path, src_dir, dataset_path=None) -> Regist
     if dataset_path is None:
         dataset_path = os.environ["DSGRID_LOCAL_DATA_DIRECTORY"]
     path = create_local_test_registry(registry_path)
-    dataset_dir = Path("datasets/sector_models/tempo_standard_scenarios_2021")
+    dataset_dir = Path("datasets/modeled/tempo_standard_scenarios_2021")
     user = getpass.getuser()
     log_message = "Initial registration"
     manager = RegistryManager.load(path, offline_mode=True)

--- a/tests/test_trivial_dimensions.py
+++ b/tests/test_trivial_dimensions.py
@@ -24,7 +24,7 @@ def test_trivial_dimension_bad(make_test_project_dir, make_test_data_dir):
         project_config_file = make_test_project_dir / "project.toml"
         manager.project_manager.register(project_config_file, "user", "log")
 
-        dataset_dir = make_test_project_dir / "datasets" / "sector_models" / "comstock"
+        dataset_dir = make_test_project_dir / "datasets" / "modeled" / "comstock"
         assert dataset_dir.exists()
         dataset_config_file = dataset_dir / "dataset.toml"
         replace_dimension_uuids_from_registry(base_dir, (dataset_config_file,))

--- a/tests_aws/test_registry/test_aws_registry_workflow_online_mode.py
+++ b/tests_aws/test_registry/test_aws_registry_workflow_online_mode.py
@@ -40,7 +40,7 @@ def test_aws_registry_workflow_online_mode(make_test_project_dir, make_test_data
                 include_datasets=True,
                 offline_mode=False,
             )
-            dataset_dir = make_test_project_dir / "datasets" / "sector_models" / "comstock"
+            dataset_dir = make_test_project_dir / "datasets" / "modeled" / "comstock"
             assert dataset_dir.exists()
             dimension_mapping_refs = dataset_dir / "dimension_mapping_references.toml"
             assert dimension_mapping_refs.exists()


### PR DESCRIPTION
Refactor dsgrid code to use `modeled` instead of `sector_models`. 


....
Completes JIRA Story DSGRID-
Closes GitHub Issue #

## Description

## Checklist

- [ ] Tests exercising the new feature or bug fix
- [x] All tests pass
- [x] At least one code review approval
- [x] Consider transferring TODOs to JIRA or GitHub
