### PR TITLE
Point to a different link for Windows spark instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dsgrid uses [Apache Spark](#https://spark.apache.org/) to manage big data.
 
 #### Windows
 
-To install Apache Spark on Windows, follow [these instructions](https://sparkbyexamples.com/pyspark-tutorial/#pyspark-installation).
+To install Apache Spark on Windows, follow [these instructions](https://towardsdatascience.com/installing-apache-pyspark-on-windows-10-f5f0c506bea1).
 
 #### Mac
 


### PR DESCRIPTION
Completes JIRA Story DSGRID-
Closes GitHub Issue #

## Description

The new link for pyspark on windows instructions (https://towardsdatascience.com/installing-apache-pyspark-on-windows-10-f5f0c506bea1) is simpler and seems to have a better suggestion for how to install Java compared to the old link (https://sparkbyexamples.com/pyspark-tutorial/#pyspark-installation).

## Checklist

- [ ] Tests exercising the new feature or bug fix
- [ ] All tests pass
- [ ] At least one code review approval
- [ ] Consider transferring TODOs to JIRA or GitHub
