### PR TITLE
Refactor dimension association tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ poetry.lock
 tests/data/registry/*
 emr/running_cluster_id.txt
 emr/emr_config.yml
+spark-warehouse

--- a/dsgrid/config/dimension_association_manager.py
+++ b/dsgrid/config/dimension_association_manager.py
@@ -1,0 +1,75 @@
+"""
+Caches project dimension association tables in the Spark warehouse.
+One table per project can be stored. Multiple versions of one project can share the same table.
+The purpose is to allow dataset submissions to reuse existing tables.
+"""
+
+
+import logging
+
+import pyspark
+
+from dsgrid.utils.spark import (
+    try_load_stored_table,
+    save_table,
+    list_tables,
+    drop_table,
+)
+
+
+logger = logging.getLogger(__name__)
+
+_ASSOCIATIONS_DATA_TABLE = "dimension_associations_data"
+
+
+def try_load_dimension_associations(project_id, data_source) -> pyspark.sql.DataFrame | None:
+    """Load a project's dimension associations table if it exists.
+
+    Parameters
+    ----------
+    project_id : str
+    data_source : str
+
+    Returns
+    -------
+    pyspark.sql.DataFrame | None
+
+    """
+    return try_load_stored_table(_make_dimension_associations_table_name(project_id, data_source))
+
+
+def save_dimension_associations(table, project_id, data_source):
+    """Save a project's dimension association table to the Hive Metastore.
+
+    Parameters
+    ----------
+    table : pyspark.sql.DataFrame
+    project_id : str
+    data_source : str
+
+    """
+    table_name = _make_dimension_associations_table_name(project_id, data_source)
+    save_table(table, table_name)
+    logger.info(
+        "Saved dimension associations for project_id=%s data_source=%s",
+        project_id,
+        data_source,
+    )
+
+
+def remove_project_dimension_associations(project_id):
+    """Remove any stored dimension associations for project_id.
+
+    Parameters
+    ----------
+    project_id : str
+
+    """
+    for table in list_tables():
+        fields = table.split("__")
+        if len(fields) == 3 and fields[0] == project_id and fields[2] == _ASSOCIATIONS_DATA_TABLE:
+            drop_table(table)
+
+
+def _make_dimension_associations_table_name(project_id, data_source):
+    return "__".join((project_id, data_source, _ASSOCIATIONS_DATA_TABLE))

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -3,6 +3,7 @@
 import getpass
 import itertools
 import logging
+import os
 import shutil
 from pathlib import Path
 from typing import Union, List, Dict
@@ -12,7 +13,6 @@ from prettytable import PrettyTable
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import (
     DSGInvalidDataset,
-    DSGInvalidDimensionAssociation,
     DSGInvalidParameter,
     DSGValueNotRegistered,
     DSGDuplicateValueRegistered,
@@ -44,7 +44,7 @@ from dsgrid.registry.common import (
     DatasetRegistryStatus,
     ProjectRegistryStatus,
 )
-from dsgrid.utils.spark import create_dataframe_from_dimension_ids
+from dsgrid.utils.spark import get_unique_values
 from dsgrid.utils.timing import track_timing, timer_stats_collector
 from dsgrid.utils.files import load_data, run_in_other_dir
 from dsgrid.utils.filters import transform_and_validate_filters, matches_filters
@@ -247,6 +247,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         tmp_dirs = []
         try:
             if model.dimensions.base_dimensions:
+                logger.info("Register base dimensions")
                 self._register_dimensions_from_models(
                     src_dir,
                     model.dimensions.base_dimensions,
@@ -257,6 +258,7 @@ class ProjectRegistryManager(RegistryManagerBase):
                     force,
                 )
             if model.dimensions.supplemental_dimensions:
+                logger.info("Register supplemental dimensions")
                 self._register_dimensions_from_models(
                     src_dir,
                     model.dimensions.supplemental_dimensions,
@@ -267,6 +269,7 @@ class ProjectRegistryManager(RegistryManagerBase):
                     force,
                 )
             if model.dimensions.all_in_one_supplemental_dimensions:
+                logger.info("Register all-in-one supplemental dimensions")
                 supp_dir = src_dir / _SUPPLEMENTAL_TMP_DIR
                 assert not supp_dir.exists(), f"{supp_dir} exists"
                 supp_dir.mkdir()
@@ -358,6 +361,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         # Order of the next two is required for Pydantic validation.
         dimension_references += self._dimension_mgr.make_dimension_references(dimension_ids)
         dimensions.clear()
+        return dimension_references
 
     def _register_all_in_one_dimensions(
         self,
@@ -405,8 +409,8 @@ class ProjectRegistryManager(RegistryManagerBase):
                 name=dt_plural_dash,
                 display_name=dt_plural_formal,
                 dimension_type=dimension_type,
-                module=dim_config.model.module,
-                class_name=dim_config.model.class_name,
+                module="dsgrid.dimension.base_models",
+                class_name="DimensionRecordBaseModel",
                 description=dt_plural_formal,
             )
             new_dimensions.append(new_dim)
@@ -440,9 +444,12 @@ class ProjectRegistryManager(RegistryManagerBase):
 
     @track_timing(timer_stats_collector)
     def _register(self, config, submitter, log_message, force):
-        self._run_checks(config)
-
         registration = make_initial_config_registration(submitter, log_message)
+        if os.environ.get("__DSGRID_USE_CACHED_DIMENSION_ASSOCIATIONS_FOR_PROJECT_REGISTRATION__"):
+            try_load_cache = True
+        else:
+            try_load_cache = False
+        self._run_checks(config, check_dimension_associations=True, try_load_cache=try_load_cache)
 
         registry_model = ProjectRegistryModel(
             project_id=config.model.project_id,
@@ -458,8 +465,8 @@ class ProjectRegistryManager(RegistryManagerBase):
         self.fs_interface.mkdir(data_dir)
         registry_filename = registry_dir / REGISTRY_FILENAME
         registry_config.serialize(registry_filename, force=force)
-        config.serialize(self.get_config_directory(config.config_id, registry_config.version))
-
+        config_directory = self.get_config_directory(config.config_id, registry_config.version)
+        config.serialize(config_directory)
         self._update_registry_cache(config.model.project_id, registry_config)
 
         logger.info(
@@ -470,7 +477,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         )
 
     @track_timing(timer_stats_collector)
-    def _run_checks(self, config: ProjectConfig):
+    def _run_checks(self, config: ProjectConfig, check_dimension_associations=True, try_load_cache=True):
         dims = [x for x in config.iter_dimensions()]
         check_uniqueness((x.model.name for x in dims), "dimension name")
         check_uniqueness((x.model.display_name for x in dims), "dimension display name")
@@ -478,19 +485,12 @@ class ProjectRegistryManager(RegistryManagerBase):
             (getattr(x.model, "cls") for x in config.model.dimensions.base_dimensions),
             "dimension cls",
         )
-        self._check_dimension_associations(config)
-
-    @track_timing(timer_stats_collector)
-    def _check_dimension_associations(self, config: ProjectConfig):
-        for dimension_type in config.dimension_associations.dimension_types:
-            assoc_ids = config.dimension_associations.get_unique_ids(dimension_type)
-            dim = config.get_base_dimension(dimension_type)
-            dim_record_ids = dim.get_unique_ids()
-            diff = assoc_ids.difference(dim_record_ids)
-            if diff:
-                raise DSGInvalidDimensionAssociation(
-                    f"Dimension association for {dimension_type} has invalid records: {diff}"
-                )
+        if check_dimension_associations:
+            # This will raise an exception if the associations are invalid.
+            for data_source in sorted(config.get_base_dimension(
+                DimensionType.DATA_SOURCE
+            ).get_unique_ids()):
+                config.load_dimension_associations(data_source, try_load_cache=try_load_cache)
 
     @track_timing(timer_stats_collector)
     def register_and_submit_dataset(
@@ -684,7 +684,13 @@ class ProjectRegistryManager(RegistryManagerBase):
         else:
             new_status = ProjectRegistryStatus.IN_PROGRESS
         project_config.set_status(new_status)
-        version = self._update(project_config, submitter, VersionUpdateType.MINOR, log_message)
+        version = self._update(
+            project_config,
+            submitter,
+            VersionUpdateType.MINOR,
+            log_message,
+            check_dimension_associations=False,
+        )
 
         logger.info(
             "%s Registered dataset %s with version=%s in project %s",
@@ -726,9 +732,9 @@ class ProjectRegistryManager(RegistryManagerBase):
         )
 
         cols = [x.value for x in DimensionType if x not in exclude_dims]
-        assoc_table = project_config.make_dimension_association_table(data_source=data_source)
-        if pivoted_dimension.value in assoc_table.columns:
-            assoc_table = assoc_table.drop(pivoted_dimension.value)
+        # TODO DT: how to prevent the cache from being invalidated by a new dataset registration and bump?
+        # Should we create new references here?
+        assoc_table = project_config.load_dimension_associations(data_source)
         project_table = assoc_table.select(*cols).distinct()
         diff = project_table.exceptAll(dim_table.select(*cols).distinct())
         if not diff.rdd.isEmpty():
@@ -746,42 +752,23 @@ class ProjectRegistryManager(RegistryManagerBase):
             raise DSGInvalidDataset(
                 f"Dataset {dataset_config.config_id} is missing required dimension records"
             )
-        self._check_pivoted_dimension_columns(
-            project_config, handler, project_config.dimension_associations, data_source
-        )
+        project_pivoted_ids = get_unique_values(assoc_table, pivoted_dimension.value)
+        self._check_pivoted_dimension_columns(handler, project_pivoted_ids, data_source)
 
     @staticmethod
     @track_timing(timer_stats_collector)
-    def _get_project_dimensions_table(project_config, type1, type2, associations, data_source):
-        """for each dimension type x, record is the same as project's unless a relevant association is provided."""
-        pdim1_ids = associations.get_unique_ids(type1, data_source)
-        if pdim1_ids is None:
-            pdim1_ids = project_config.get_base_dimension(type1).get_unique_ids()
-
-        pdim2_ids = associations.get_unique_ids(type2, data_source)
-        if pdim2_ids is None:
-            pdim2_ids = project_config.get_base_dimension(type2).get_unique_ids()
-
-        records = itertools.product(pdim1_ids, pdim2_ids)
-        return create_dataframe_from_dimension_ids(records, type1, type2)
-
-    @staticmethod
-    @track_timing(timer_stats_collector)
-    def _check_pivoted_dimension_columns(project_config, handler, associations, data_source):
+    def _check_pivoted_dimension_columns(handler, project_pivoted_ids, data_source):
         """pivoted dimension record is the same as project's unless a relevant association is provided."""
         logger.info("Check pivoted dimension columns.")
         d_dim_ids = handler.get_pivoted_dimension_columns_mapped_to_project()
         pivoted_dim = handler.get_pivoted_dimension_type()
-        p_dim_ids = associations.get_unique_ids(pivoted_dim, data_source)
-        if p_dim_ids is None:
-            p_dim_ids = project_config.get_base_dimension(pivoted_dim).get_unique_ids()
 
-        if d_dim_ids.symmetric_difference(p_dim_ids):
+        if d_dim_ids.symmetric_difference(project_pivoted_ids):
             raise DSGInvalidDataset(
                 f"Mismatch between project and {data_source} dataset pivoted {pivoted_dim.value} dimension, "
                 "please double-check data, and any relevant association_table and dimension_mapping. "
-                f"\n - Invalid column(s) in {data_source} load data according to project: {d_dim_ids.difference(p_dim_ids)}"
-                f"\n - Missing column(s) in {data_source} load data according to project: {p_dim_ids.difference(d_dim_ids)}"
+                f"\n - Invalid column(s) in {data_source} load data according to project: {d_dim_ids.difference(project_pivoted_ids)}"
+                f"\n - Missing column(s) in {data_source} load data according to project: {project_pivoted_ids.difference(d_dim_ids)}"
             )
 
     def update_from_file(
@@ -801,13 +788,18 @@ class ProjectRegistryManager(RegistryManagerBase):
         with self.cloud_interface.make_lock_file_managed(lock_file_path):
             return self._update(config, submitter, update_type, log_message)
 
-    def _update(self, config, submitter, update_type, log_message):
+    def _update(
+        self, config, submitter, update_type, log_message, check_dimension_associations=False
+    ):
+        registry = self.get_registry_config(config.config_id)
         old_config = self.get_by_id(config.config_id)
         checker = ProjectUpdateChecker(old_config.model, config.model)
         checker.run()
-        self._run_checks(config)
+        self._run_checks(
+            config,
+            check_dimension_associations=check_dimension_associations,
+        )
 
-        registry = self.get_registry_config(config.config_id)
         old_key = ConfigKey(config.config_id, registry.version)
         version = self._update_config(config, submitter, update_type, log_message)
         new_key = ConfigKey(config.config_id, version)

--- a/dsgrid/registry/project_update_checker.py
+++ b/dsgrid/registry/project_update_checker.py
@@ -1,5 +1,6 @@
 import logging
 
+from dsgrid.config.dimension_association_manager import remove_project_dimension_associations
 from dsgrid.exceptions import DSGInvalidRegistryState
 from .config_update_checker_base import ConfigUpdateCheckerBase
 from .common import DatasetRegistryStatus, ProjectRegistryStatus
@@ -17,6 +18,11 @@ class ProjectUpdateChecker(ConfigUpdateCheckerBase):
         ProjectRegistryStatus.COMPLETE,
     )
     _REQUIRES_DATASET_UNREGISTRATION = (
+        "dimensions",
+        "dimension_mappings",
+        "dimension_associations",
+    )
+    _REQUIRES_DIMENSION_ASSOCIATION_CACHE_INVALIDATION = (
         "dimensions",
         "dimension_mappings",
         "dimension_associations",
@@ -47,3 +53,7 @@ class ProjectUpdateChecker(ConfigUpdateCheckerBase):
                     self._new_model.status,
                     changes,
                 )
+
+        changes = set(self._REQUIRES_DIMENSION_ASSOCIATION_CACHE_INVALIDATION).intersection(self._changed_fields)
+        if changes:
+            remove_project_dimension_associations(self._new_model.project_id)

--- a/dsgrid/registry/registry_manager_base.py
+++ b/dsgrid/registry/registry_manager_base.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
+from semver import VersionInfo
+
 from dsgrid import timer_stats_collector
 from dsgrid.common import REGISTRY_FILENAME, SYNC_EXCLUDE_LIST
 from dsgrid.exceptions import (
@@ -224,16 +226,20 @@ class RegistryManagerBase(abc.ABC):
         if version != cur_version:
             raise DSGInvalidParameter(f"version={version} is not current. Current={cur_version}")
 
+    @staticmethod
+    def get_next_version(version: VersionInfo, update_type: VersionUpdateType):
+        if update_type == VersionUpdateType.MAJOR:
+            return version.bump_major()
+        elif update_type == VersionUpdateType.MINOR:
+            return version.bump_minor()
+        elif update_type == VersionUpdateType.PATCH:
+            return version.bump_patch()
+        raise Exception(f"invalid version update type {update_type}")
+
     def _update_config(self, config, submitter, update_type, log_message):
         config_id = config.config_id
         registry_config = self.get_registry_config(config_id)
-
-        if update_type == VersionUpdateType.MAJOR:
-            registry_config.version = registry_config.version.bump_major()
-        elif update_type == VersionUpdateType.MINOR:
-            registry_config.version = registry_config.version.bump_minor()
-        elif update_type == VersionUpdateType.PATCH:
-            registry_config.version = registry_config.version.bump_patch()
+        registry_config.version = self.get_next_version(registry_config.version, update_type)
 
         registration = ConfigRegistrationModel(
             version=str(registry_config.version),

--- a/dsgrid/tests/common.py
+++ b/dsgrid/tests/common.py
@@ -18,6 +18,7 @@ TEST_PROJECT_REPO = TEST_PROJECT_PATH / "test_efs"
 TEST_STANDARD_SCENARIOS_PROJECT_REPO = TEST_PROJECT_PATH / "standard_scenarios_2021"
 TEST_DATASET_DIRECTORY = TEST_PROJECT_PATH / "datasets"
 TEST_REGISTRY = Path("tests/data/registry")
+TEST_EFS_REGISTRATION_FILE = Path("tests/data/test_efs_registration.json")
 AWS_PROFILE_NAME = "nrel-aws-dsgrid"
 TEST_REMOTE_REGISTRY = "s3://nrel-dsgrid-registry-test"
 

--- a/dsgrid/tests/register.py
+++ b/dsgrid/tests/register.py
@@ -1,0 +1,104 @@
+import getpass
+import logging
+import shutil
+from pathlib import Path
+
+import click
+
+from dsgrid.loggers import setup_logging, check_log_file_size
+from dsgrid.registry.registry_manager import RegistryManager
+from dsgrid.tests.common import (
+    create_local_test_registry,
+    replace_dimension_mapping_uuids_from_registry,
+    replace_dimension_uuids_from_registry,
+)
+from dsgrid.tests.registration_models import RegistrationModel, create_registration
+from dsgrid.utils.timing import timer_stats_collector
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.argument("input_file", type=click.Path(exists=True))
+@click.option(
+    "--verbose", is_flag=True, default=False, show_default=True, help="Enable verbose log output."
+)
+def run(input_file, verbose):
+    """Registers projects and datasets in a local registry for testing."""
+    level = logging.DEBUG if verbose else logging.INFO
+    log_file = Path("dsgrid_registration.log")
+    check_log_file_size(log_file, no_prompts=True)
+    logger = setup_logging("dsgrid", log_file, console_level=level, file_level=level, mode="a")
+    registration = create_registration(input_file)
+    if registration.create_registry:
+        if registration.registry_path.exists():
+            shutil.rmtree(registration.registry_path)
+        create_local_test_registry(registration.registry_path)
+
+    tmp_files = []
+    try:
+        _run_registration(registration, tmp_files)
+    finally:
+        for path in tmp_files:
+            path.unlink()
+        # Raise the console level so that timer stats only go to the log file.
+        for i, handler in enumerate(logger.handlers):
+            if handler.name == "console":
+                handler.setLevel(logging.WARNING)
+                break
+
+        timer_stats_collector.log_stats()
+
+
+def _run_registration(registration: RegistrationModel, tmp_files):
+    user = getpass.getuser()
+    log_message = "Initial registration"
+    reg_path = registration.registry_path
+    manager = RegistryManager.load(reg_path, offline_mode=True)
+    project_mgr = manager.project_manager
+    dataset_mgr = manager.dataset_manager
+
+    for project in registration.projects:
+        if project.register_project:
+            project_mgr.register(project.config_file, user, log_message)
+
+        for dataset in project.datasets:
+            if dataset.register_dataset:
+                if dataset.fix_dimension_uuids:
+                    suffix = dataset.config_file.suffix
+                    config_file = Path(str(dataset.config_file).replace(suffix, "__tmp" + suffix))
+                    config_file = shutil.copyfile(dataset.config_file, config_file)
+                    tmp_files.append(config_file)
+                    replace_dimension_uuids_from_registry(reg_path, [config_file])
+                else:
+                    config_file = dataset.config_file
+                dataset_mgr.register(
+                    config_file,
+                    dataset.dataset_path,
+                    user,
+                    log_message,
+                )
+
+            if dataset.submit_to_project:
+                if dataset.fix_dimension_mapping_uuids:
+                    suffix = dataset.dimension_mapping_file.suffix
+                    mapping_file = Path(
+                        str(dataset.dimension_mapping_file).replace(suffix, "__tmp" + suffix)
+                    )
+                    mapping_file = shutil.copyfile(dataset.dimension_mapping_file, mapping_file)
+                    tmp_files.append(mapping_file)
+                    replace_dimension_mapping_uuids_from_registry(reg_path, [mapping_file])
+                else:
+                    mapping_file = dataset.dimension_mapping_file
+                project_mgr.submit_dataset(
+                    project.project_id,
+                    dataset.dataset_id,
+                    user,
+                    log_message,
+                    dimension_mapping_file=mapping_file,
+                )
+
+
+if __name__ == "__main__":
+    run()

--- a/dsgrid/tests/registration_models.py
+++ b/dsgrid/tests/registration_models.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from pydantic import validator
+
+from dsgrid.data_models import DSGBaseModel
+from dsgrid.utils.files import load_data
+
+
+class DatasetRegistrationModel(DSGBaseModel):
+
+    dataset_id: str
+    dataset_path: str | Path
+    config_file: str | Path
+    dimension_mapping_file: str | Path | None
+    fix_dimension_uuids: bool = False
+    fix_dimension_mapping_uuids: bool = False
+    register_dataset: bool = True
+    submit_to_project: bool = True
+
+    @validator("dataset_path", "config_file", "dimension_mapping_file")
+    def fix_path(cls, val):
+        return Path(val) if isinstance(val, str) else val
+
+
+class ProjectRegistrationModel(DSGBaseModel):
+
+    project_id: str
+    config_file: str | Path
+    datasets: list[DatasetRegistrationModel]
+    register_project: bool = True
+
+    @validator("config_file")
+    def fix_path(cls, val):
+        return Path(val) if isinstance(val, str) else val
+
+
+class RegistrationModel(DSGBaseModel):
+
+    create_registry: bool
+    registry_path: str | Path
+    projects: list[ProjectRegistrationModel]
+
+    @validator("registry_path")
+    def fix_path(cls, val):
+        return Path(val) if isinstance(val, str) else val
+
+
+def create_registration(input_file: Path):
+    """Create registration inputs."""
+    return RegistrationModel(**load_data(input_file))

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -5,7 +5,6 @@ import math
 import os
 import shutil
 from pathlib import Path
-from this import d
 from typing import AnyStr, List, Union
 import enum
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py310']

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(here / "dsgrid" / "_version.py", encoding="utf-8") as f:
 with open(here / "README.md", encoding="utf-8") as f:
     readme = f.read()
 
-dev_requires = ["black", "pre-commit", "devtools", "jupyter", "flake8"]
+dev_requires = ["black>=22.3.0", "pre-commit", "devtools", "jupyter", "flake8"]
 
 test_requires = ["pytest", "pytest-cov"]
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "notebooks/*.ipynb",
         ]
     },
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "dsgrid=dsgrid.cli.dsgrid:cli",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from dsgrid.tests.common import (
     TEST_PROJECT_REPO,
     TEST_REGISTRY,
     TEST_STANDARD_SCENARIOS_PROJECT_REPO,
+    TEST_EFS_REGISTRATION_FILE,
 )
 
 
@@ -38,10 +39,7 @@ def pytest_sessionstart(session):
     else:
         if TEST_REGISTRY.exists():
             shutil.rmtree(TEST_REGISTRY)
-        ret = run_command(
-            f"python dsgrid/tests/make_us_data_registry.py {TEST_REGISTRY} -p {TEST_PROJECT_REPO} "
-            f"-d {TEST_DATASET_DIRECTORY}"
-        )
+        ret = run_command(f"python dsgrid/tests/register.py {TEST_EFS_REGISTRATION_FILE}")
         if ret == 0:
             print("make script returned 0")
             commit_file.write_text(latest_commit + "\n")

--- a/tests/data/standard_scenarios_registration.json
+++ b/tests/data/standard_scenarios_registration.json
@@ -1,0 +1,33 @@
+{
+  "create_registry": true,
+  "registry_path": "updated-standard-scenarios-registry",
+  "projects": [
+    {
+      "project_id": "dsgrid_conus_2022",
+      "config_file": "../dsgrid-project-StandardScenarios/dsgrid_project/project.toml",
+      "register_project": true,
+      "datasets": [
+        {
+          "dataset_id": "conus_2022_reference_comstock",
+          "dataset_path": "../dsgrid-data/conus_2022_reference_comstock",
+          "config_file": "../dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/comstock/dataset.toml",
+          "dimension_mapping_file": "../dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/comstock/dimension_mappings.toml",
+          "register_dataset": true,
+          "submit_to_project": true,
+          "fix_dimension_uuids": false,
+          "fix_dimension_mapping_uuids": false
+        },
+        {
+          "dataset_id": "conus_2022_reference_resstock",
+          "dataset_path": "../dsgrid-data/conus_2022_reference_resstock",
+          "config_file": "../dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/resstock/dataset.toml",
+          "dimension_mapping_file": "../dsgrid-project-StandardScenarios/dsgrid_project/datasets/modeled/resstock/dimension_mappings.toml",
+          "register_dataset": true,
+          "submit_to_project": true,
+          "fix_dimension_uuids": false,
+          "fix_dimension_mapping_uuids": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/test_efs_registration.json
+++ b/tests/data/test_efs_registration.json
@@ -1,0 +1,23 @@
+{
+  "create_registry": true,
+  "registry_path": "tests/data/registry",
+  "projects": [
+    {
+      "project_id": "test_efs",
+      "config_file": "dsgrid-test-data/test_efs/dsgrid_project/project.toml",
+      "register_project": true,
+      "datasets": [
+        {
+          "dataset_id": "test_efs_comstock",
+          "dataset_path": "dsgrid-test-data/datasets/test_efs_comstock",
+          "config_file": "dsgrid-test-data/test_efs/dsgrid_project/datasets/modeled/comstock/dataset.toml",
+          "dimension_mapping_file": "dsgrid-test-data/test_efs/dsgrid_project/datasets/modeled/comstock/dimension_mappings.toml",
+          "register_dataset": true,
+          "submit_to_project": true,
+          "fix_dimension_uuids": true,
+          "fix_dimension_mapping_uuids": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -34,8 +34,8 @@ def test_project_load():
     assert len(records) == 1
     assert records[0].id == "all_subsectors"
 
-    table = project.config.make_dimension_association_table()
-    assert table.select("data_source").distinct().collect()[0].data_source == "comstock"
+    table = project.config.load_dimension_associations("comstock")
+    assert table.count() > 0
 
     with pytest.raises(DSGValueNotRegistered):
         project = mgr.project_manager.load_project(PROJECT_ID, version="0.0.0")
@@ -64,8 +64,10 @@ def test_dataset_load():
     records = project.config.get_dimension_records("state")
     assert records.filter("id = 'CO'").count() > 0
 
+    table_name = DATASET_ID + "__" + "load_data"
+    assert spark.catalog.tableExists(table_name)
     project.unload_dataset(DATASET_ID)
-    assert spark.sql("show tables").rdd.isEmpty()
+    assert not spark.catalog.tableExists(table_name)
 
 
 def test_dimension_map_and_reduce_in_dataset():


### PR DESCRIPTION
 This PR refactor dimension association tables in preparation for registering AEO growth rates.

1. Store association tables by data source.
2. Cache the tables in the spark warehouse so that they don't have to be regenerated at every dataset submission.

I also added a more generic way to register projects and datasets.