### PR TITLE
Cache mapped datasets during the query process

### DIFF
--- a/dsgrid/cli/query.py
+++ b/dsgrid/cli/query.py
@@ -218,14 +218,14 @@ def create_project(
             )
         else:
             assert False
-        query.project.dimension_filters.append(flt)
+        query.project.dataset_params.dimension_filters.append(flt)
 
     if default_per_dataset_aggregation or default_result_aggregation:
         default_aggs = {}
         for dim_type, name in project.config.get_base_dimension_to_query_name_mapping().items():
             default_aggs[dim_type.value] = [name]
         if default_per_dataset_aggregation:
-            query.project.per_dataset_aggregations = [
+            query.project.dataset_params.per_dataset_aggregations = [
                 AggregationModel(
                     dimensions=DimensionQueryNamesModel(**default_aggs),
                     aggregation_function=aggregation_function,

--- a/dsgrid/data_models.py
+++ b/dsgrid/data_models.py
@@ -70,6 +70,13 @@ class DSGBaseModel(BaseModel):
                 fields.add(f)
         return fields
 
+    @classmethod
+    def from_file(cls, filename: Path):
+        """Deserialize the model from a file. Unlike the load method,
+        this does not change directories.
+        """
+        return cls(**load_data(filename))
+
 
 class EnumValue:
     """Class to define a DSGEnum value"""

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -105,7 +105,7 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
         # It should be cheaper to do this before the join with lookup.
         table_handler = PivotedTableHandler(project_config, dataset_id=self.dataset_id)
         ld_df = table_handler.process_pivoted_aggregations(
-            ld_df, context.model.project.per_dataset_aggregations, context
+            ld_df, context.model.project.dataset_params.per_dataset_aggregations, context
         )
 
         # TODO: handle fraction application
@@ -114,7 +114,7 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
 
         ld_df = table_handler.convert_columns_to_query_names(ld_df)
         ld_df = table_handler.process_stacked_aggregations(
-            ld_df, context.model.project.per_dataset_aggregations, context
+            ld_df, context.model.project.dataset_params.per_dataset_aggregations, context
         )
 
         return ld_df
@@ -122,7 +122,8 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
     def _check_aggregations(self, context):
         pivoted_type = self.get_pivoted_dimension_type()
         for agg in itertools.chain(
-            context.model.project.per_dataset_aggregations, context.model.result.aggregations
+            context.model.project.dataset_params.per_dataset_aggregations,
+            context.model.result.aggregations,
         ):
             if not getattr(agg.dimensions, pivoted_type.value):
                 raise DSGInvalidQuery(

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -1,6 +1,7 @@
 """Interface to a dsgrid project."""
 
 import logging
+from pathlib import Path
 
 import pyspark.sql.functions as F
 from pyspark.sql import SparkSession
@@ -11,6 +12,11 @@ from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import DSGValueNotRegistered
 from dsgrid.query.query_context import QueryContext
 
+from dsgrid.utils.spark import (
+    read_dataframe,
+    custom_spark_conf,
+    write_dataframe_and_auto_partition,
+)
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 
 
@@ -119,18 +125,33 @@ class Project:
         return [x.dataset_id for x in self._iter_datasets()]
 
     @track_timing(timer_stats_collector)
-    def process_query(self, context: QueryContext):
+    def process_query(self, context: QueryContext, cached_project_mapped_datasets_dir: Path):
         self._build_filtered_record_ids_by_dimension_type(context)
 
         dfs = []
         for dataset_id in context.model.project.dataset_ids:
             logger.info("Start processing query for dataset_id=%s", dataset_id)
-            dataset = self.get_dataset(dataset_id)
-            dfs.append(dataset.get_dataframe(context, self._config))
+            model_hash, text = context.model.project.dataset_params.serialize()
+            hash_dir = cached_project_mapped_datasets_dir / model_hash
+            if not hash_dir.exists():
+                hash_dir.mkdir()
+                model_file = hash_dir / "model.json"
+                model_file.write_text(text)
+            cached_dataset = hash_dir / (dataset_id + ".parquet")
+            if cached_dataset.exists():
+                logger.info("Use cached project-mapped dataset %s", dataset_id)
+                df = read_dataframe(cached_dataset)
+            else:
+                logger.info("Build project-mapped dataset %s", dataset_id)
+                dataset = self.get_dataset(dataset_id)
+                df = dataset.get_dataframe(context, self._config)
+                with custom_spark_conf(context.model.project.get_spark_conf(dataset_id)):
+                    df = write_dataframe_and_auto_partition(df, cached_dataset)
+            dfs.append(df)
             logger.info("Finished processing query for dataset_id=%s", dataset_id)
 
         if not dfs:
-            logger.warning("No data matched %s", context.name)
+            logger.warning("No data matched %s", context.model.name)
             return None
 
         # All dataset columns need to be in the same order.
@@ -149,13 +170,14 @@ class Project:
         dim_columns = sorted(dim_columns)
         time_columns = sorted(time_columns)
         expected_columns = time_columns + pivoted_columns_sorted + dim_columns
-        for i, dataset_id in enumerate(context.model.project.dataset_ids):
-            remaining = sorted(set(dfs[i].columns).difference(expected_columns))
+        for i, df in enumerate(dfs):
+            remaining = sorted(set(df.columns).difference(expected_columns))
             final_columns = expected_columns + remaining
-            missing = pivoted_columns.difference(dfs[i].columns)
+            missing = pivoted_columns.difference(df.columns)
             for column in missing:
-                dfs[i] = dfs[i].withColumn(column, F.lit(None).cast(DoubleType()))
-            dfs[i] = dfs[i].select(*final_columns)
+                df = df.withColumn(column, F.lit(None).cast(DoubleType()))
+            df = df.select(*final_columns)
+            dfs[i] = df
 
         main_df = dfs[0]
         if len(dfs) > 1:
@@ -173,7 +195,7 @@ class Project:
         record_ids = {}
         base_query_names = self._config.get_base_dimension_query_names()
 
-        for dim_filter in context.model.project.dimension_filters:
+        for dim_filter in context.model.project.dataset_params.dimension_filters:
             dim_type = dim_filter.dimension_type
             query_name = dim_filter.dimension_query_name
             df = self._config.get_dimension_records(query_name)

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -129,12 +129,13 @@ class Project:
         self._build_filtered_record_ids_by_dimension_type(context)
 
         dfs = []
+        project_version = f"{context.model.project.project_id}__{context.model.project.version}"
         for dataset_id in context.model.project.dataset_ids:
             logger.info("Start processing query for dataset_id=%s", dataset_id)
             model_hash, text = context.model.project.dataset_params.serialize()
-            hash_dir = cached_project_mapped_datasets_dir / model_hash
+            hash_dir = cached_project_mapped_datasets_dir / project_version / model_hash
             if not hash_dir.exists():
-                hash_dir.mkdir()
+                hash_dir.mkdir(parents=True)
                 model_file = hash_dir / "model.json"
                 model_file.write_text(text)
             cached_dataset = hash_dir / (dataset_id + ".parquet")

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -1,6 +1,5 @@
 import abc
 import enum
-from pathlib import Path
 from typing import Any, List, Optional, Set, Union
 
 import pyspark.sql.functions as F
@@ -11,7 +10,7 @@ from dsgrid.data_models import DSGBaseModel
 
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.dimension.dimension_filters import make_dimension_filter, DimensionFilterBaseModel
-from dsgrid.utils.files import compute_hash, load_data
+from dsgrid.utils.files import compute_hash
 
 
 class FilteredDatasetModel(DSGBaseModel):
@@ -172,16 +171,22 @@ class DatasetMetadataModel(DSGBaseModel):
     table_format_type: Optional[TableFormatType]
 
 
-class ProjectQueryParamsModel(DSGBaseModel):
-    """Defines how to transform a project into a CompositeDataset"""
+class CacheableQueryBaseModel(DSGBaseModel):
+    def serialize(self):
+        """Return a JSON representation of the model along with a hash that uniquely identifies it."""
+        text = self.json(indent=2)
+        return compute_hash(text.encode()), text
 
-    project_id: str = Field(description="Project ID for query")
-    dataset_ids: List[str] = Field(description="Dataset IDs from which to read")
-    excluded_dataset_ids: List[str] = Field(
-        description="Datasets to exclude from query", default=[]
-    )
-    # TODO: default needs to change
-    include_dsgrid_dataset_components: bool = Field(description="", default=False)
+
+class SparkConfByDataset(DSGBaseModel):
+
+    dataset_id: str
+    conf: dict[str, Any]
+
+
+class ProjectQueryDatasetParamsModel(CacheableQueryBaseModel):
+    """Parameters in a project query that only apply to datasets"""
+
     dimension_filters: List[Any] = Field(
         # Use Any here because we don't want Pydantic to try to discern the types.
         description="Filters to apply to all datasets",
@@ -200,34 +205,6 @@ class ProjectQueryParamsModel(DSGBaseModel):
         description="Controls table format",
         default=TableFormatType.PIVOTED,
     )
-    version: Optional[str] = Field(
-        description="Version of project or dataset on which the query is based. "
-        "Should not be set by the user",
-    )
-
-    @root_validator(pre=True)
-    def check_unsupported_fields(cls, values):
-        if values.get("include_dsgrid_dataset_components", False):
-            raise ValueError("Setting include_dsgrid_dataset_components=true is not supported yet")
-        if values.get("drop_dimensions", []):
-            raise ValueError("drop_dimensions is not supported yet")
-        if values.get("excluded_dataset_ids", []):
-            raise ValueError("excluded_dataset_ids is not supported yet")
-        fmt = TableFormatType.PIVOTED.value
-        if values.get("table_format", fmt) not in (fmt, TableFormatType.PIVOTED):
-            raise ValueError(f"only table_format={fmt} is currently supported")
-        return values
-
-    @validator("excluded_dataset_ids")
-    def check_dataset_ids(cls, excluded_dataset_ids, values):
-        dataset_ids = values.get("dataset_ids")
-        if dataset_ids is None:
-            return excluded_dataset_ids
-
-        if excluded_dataset_ids and dataset_ids:
-            raise ValueError("excluded_dataset_ids and dataset_ids cannot both be set")
-
-        return excluded_dataset_ids
 
     @validator("dimension_filters")
     def handle_dimension_filters(cls, dimension_filters):
@@ -256,10 +233,65 @@ class ProjectQueryParamsModel(DSGBaseModel):
         return aggregations
 
 
+class ProjectQueryParamsModel(CacheableQueryBaseModel):
+    """Defines how to transform a project into a CompositeDataset"""
+
+    project_id: str = Field(description="Project ID for query")
+    dataset_ids: List[str] = Field(description="Dataset IDs from which to read")
+    excluded_dataset_ids: List[str] = Field(
+        description="Datasets to exclude from query", default=[]
+    )
+    # TODO: default needs to change
+    include_dsgrid_dataset_components: bool = Field(description="", default=False)
+    dataset_params: ProjectQueryDatasetParamsModel = Field(
+        description="Parameters affecting datasets. Will be used for caching intermediate tables.",
+        default=ProjectQueryDatasetParamsModel(),
+    )
+    version: Optional[str] = Field(
+        description="Version of project or dataset on which the query is based. "
+        "Should not be set by the user",
+    )
+    spark_conf_per_dataset: list[SparkConfByDataset] = Field(
+        description="Apply these Spark configuration settings while a dataset is being processed.",
+        default=[],
+    )
+
+    @root_validator(pre=True)
+    def check_unsupported_fields(cls, values):
+        if values.get("include_dsgrid_dataset_components", False):
+            raise ValueError("Setting include_dsgrid_dataset_components=true is not supported yet")
+        if values.get("drop_dimensions", []):
+            raise ValueError("drop_dimensions is not supported yet")
+        if values.get("excluded_dataset_ids", []):
+            raise ValueError("excluded_dataset_ids is not supported yet")
+        fmt = TableFormatType.PIVOTED.value
+        if values.get("table_format", fmt) not in (fmt, TableFormatType.PIVOTED):
+            raise ValueError(f"only table_format={fmt} is currently supported")
+        return values
+
+    @validator("excluded_dataset_ids")
+    def check_dataset_ids(cls, excluded_dataset_ids, values):
+        dataset_ids = values.get("dataset_ids")
+        if dataset_ids is None:
+            return excluded_dataset_ids
+
+        if excluded_dataset_ids and dataset_ids:
+            raise ValueError("excluded_dataset_ids and dataset_ids cannot both be set")
+
+        return excluded_dataset_ids
+
+    def get_spark_conf(self, dataset_id) -> dict[str, Any]:
+        """Return the Spark settings to apply while processing dataset_id."""
+        for dataset in self.spark_conf_per_dataset:
+            if dataset.dataset_id == dataset_id:
+                return dataset.conf
+        return {}
+
+
 QUERY_FORMAT_VERSION = VersionInfo.parse("0.1.0")
 
 
-class QueryBaseModel(DSGBaseModel, abc.ABC):
+class QueryBaseModel(CacheableQueryBaseModel, abc.ABC):
     """Base class for all queries"""
 
     name: str = Field(description="Name of query")
@@ -269,15 +301,11 @@ class QueryBaseModel(DSGBaseModel, abc.ABC):
         default=str(QUERY_FORMAT_VERSION),  # TODO: str shouldn't be required
     )
 
-    @classmethod
-    def from_file(cls, filename: Path):
-        """Deserialize the query model from a file."""
-        return cls(**load_data(filename))
-
-    def serialize(self):
-        """Return a JSON representation of the model along with a hash that uniquely identifies it."""
-        text = self.json(indent=2)
-        return compute_hash(text.encode()), text
+    def dict(self, *args, **kwargs):
+        data = super().dict(*args, **kwargs)
+        if data["version"] is not None:
+            data["version"] = str(data["version"])
+        return data
 
     def serialize_cached_content(self):
         """Return a JSON representation of the model that can be used for caching purposes along
@@ -286,14 +314,8 @@ class QueryBaseModel(DSGBaseModel, abc.ABC):
         text = self.json(exclude={"name"}, indent=2)
         return compute_hash(text.encode()), text
 
-    def dict(self, *args, **kwargs):
-        data = super().dict(*args, **kwargs)
-        if data["version"] is not None:
-            data["version"] = str(data["version"])
-        return data
 
-
-class QueryResultParamsModel(DSGBaseModel):
+class QueryResultParamsModel(CacheableQueryBaseModel):
     """Controls post-processing and storage of CompositeDatasets"""
 
     supplemental_columns: List[Union[str, ColumnModel]] = Field(

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -222,13 +222,13 @@ class ProjectQueryDatasetParamsModel(CacheableQueryBaseModel):
                     # TODO: we could add support for this, but it does add some ambiguity.
                     if item.function is not None:
                         raise ValueError(
-                            f"function={item.function} cannot be set in ProjectQueryParamsModel"
+                            f"function={item.function} cannot be set in ProjectQueryDatasetParamsModel"
                         )
                     if item.alias is not None:
                         # TODO: need to support aliases here. The code that handles columns during
                         # dataset concatenation doesn't support it.
                         raise ValueError(
-                            f"alias={item.alias} cannot be set in ProjectQueryParamsModel"
+                            f"alias={item.alias} cannot be set in ProjectQueryDatasetParamsModel"
                         )
         return aggregations
 

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -332,7 +332,7 @@ def write_dataframe_and_auto_partition(
     columns : None, list
         If not None and repartitioning is needed, partition on these columns.
     rtol_pct : int
-        Don't repartition or coalesce if the relative difference between target and desired
+        Don't repartition or coalesce if the relative difference between desired and actual
         partitions is within this tolerance as a percentage.
 
     Returns
@@ -357,7 +357,7 @@ def write_dataframe_and_auto_partition(
     total_size = sum((x.stat().st_size for x in filename.glob("*.parquet")))
     desired = math.ceil(total_size / partition_size_bytes)
     actual = df.rdd.getNumPartitions()
-    if abs(actual - desired) / min(actual, desired) * 100 < rtol_pct:
+    if abs(actual - desired) / desired * 100 < rtol_pct:
         logger.info("No change in number of partitions is needed for %s.", filename)
     elif actual > desired:
         df = df.coalesce(desired)

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -1,12 +1,13 @@
 """Spark helper functions"""
 
+import enum
 import logging
 import math
 import os
 import shutil
+from contextlib import contextmanager
 from pathlib import Path
 from typing import AnyStr, List, Union
-import enum
 
 import pandas as pd
 from pyspark.sql import Row, SparkSession
@@ -314,7 +315,9 @@ def overwrite_dataframe_file(filename, df):
     return read_method(str(filename), **kwargs)
 
 
-def write_dataframe_and_auto_partition(df, filename, partition_size_mb=128, columns=None):
+def write_dataframe_and_auto_partition(
+    df, filename, partition_size_mb=128, columns=None, rtol_pct=50
+):
     """Write a dataframe to a file and then automatically coalesce or repartition it if needed.
     If the file already exists, it will be overwritten.
 
@@ -328,6 +331,9 @@ def write_dataframe_and_auto_partition(df, filename, partition_size_mb=128, colu
         Target size in MB for each partition
     columns : None, list
         If not None and repartitioning is needed, partition on these columns.
+    rtol_pct : int
+        Don't repartition or coalesce if the relative difference between target and desired
+        partitions is within this tolerance as a percentage.
 
     Returns
     -------
@@ -351,19 +357,19 @@ def write_dataframe_and_auto_partition(df, filename, partition_size_mb=128, colu
     total_size = sum((x.stat().st_size for x in filename.glob("*.parquet")))
     desired = math.ceil(total_size / partition_size_bytes)
     actual = df.rdd.getNumPartitions()
-    if actual > desired:
+    if abs(actual - desired) / min(actual, desired) * 100 < rtol_pct:
+        logger.info("No change in number of partitions is needed for %s.", filename)
+    elif actual > desired:
         df = df.coalesce(desired)
         df = overwrite_dataframe_file(filename, df)
         logger.info("Coalesced %s to partition count %s", filename, desired)
-    elif actual < desired:
+    else:
         if columns is None:
             df = df.repartition(desired)
         else:
             df = df.repartition(desired, *columns)
         df = overwrite_dataframe_file(filename, df)
         logger.info("Repartitioned %s to partition count", filename, desired)
-    else:
-        logger.info("No change in number of partitions is needed for %s.", filename)
 
     return df
 
@@ -398,6 +404,30 @@ def sql_from_sqlalchemy(query):
     """
     logger.debug("sqlchemy query = %s", query)
     return sql(str(query).replace('"', ""))
+
+
+@contextmanager
+def custom_spark_conf(conf):
+    """Apply a custom Spark configuration for the duration of a code block.
+
+    Parameters
+    ----------
+    conf : dict
+        Key-value pairs to set on the spark configuration.
+
+    """
+    spark = _get_spark_session()
+    orig_settings = {}
+
+    try:
+        for key, val in conf.items():
+            orig_settings[key] = spark.conf.get(key)
+            spark.conf.set(key, val)
+            logger.info("Set %s=%s while running", key, val)
+        yield
+    finally:
+        for key, val in orig_settings.items():
+            spark.conf.set(key, val)
 
 
 def _get_spark_session():

--- a/tests/data/project_query.json
+++ b/tests/data/project_query.json
@@ -8,41 +8,43 @@
     ],
     "excluded_dataset_ids": [],
     "include_dsgrid_dataset_components": false,
-    "dimension_filters": [
-      {
-        "dimension_type": "geography",
-        "dimension_query_name": "county",
-        "column": "id",
-        "operator": "isin",
-        "value": [
-          "06037"
-        ],
-        "negate": false,
-        "filter_type": "DimensionFilterColumnOperatorModel"
-      },
-      {
-        "dimension_type": "subsector",
-        "dimension_query_name": "subsector",
-        "column": "id",
-        "operator": "isin",
-        "value": [
-          "single_family_detached"
-        ],
-        "negate": false,
-        "filter_type": "DimensionFilterColumnOperatorModel"
-      },
-      {
-        "dimension_type": "metric",
-        "dimension_query_name": "electricity",
-        "column": "id",
-        "value": "%",
-        "operator": "like",
-        "negate": false,
-        "filter_type": "SupplementalDimensionFilterColumnOperatorModel"
-      }
-    ],
-    "per_dataset_aggregations": [],
-    "table_format": "pivoted",
+    "dataset_params": {
+      "dimension_filters": [
+        {
+          "dimension_type": "geography",
+          "dimension_query_name": "county",
+          "column": "id",
+          "operator": "isin",
+          "value": [
+            "06037"
+          ],
+          "negate": false,
+          "filter_type": "DimensionFilterColumnOperatorModel"
+        },
+        {
+          "dimension_type": "subsector",
+          "dimension_query_name": "subsector",
+          "column": "id",
+          "operator": "isin",
+          "value": [
+            "single_family_detached"
+          ],
+          "negate": false,
+          "filter_type": "DimensionFilterColumnOperatorModel"
+        },
+        {
+          "dimension_type": "metric",
+          "dimension_query_name": "electricity",
+          "column": "id",
+          "value": "%",
+          "operator": "like",
+          "negate": false,
+          "filter_type": "SupplementalDimensionFilterColumnOperatorModel"
+        }
+      ],
+      "per_dataset_aggregations": [],
+      "table_format": "pivoted"
+    },
     "version": "1.3.0"
   },
   "result": {


### PR DESCRIPTION
I'm opening this PR because I struggled with queries on Eagle with full ComStock and ResStock datasets. This introduces one main behavioral change: persist each project-mapped dataset to a file during a query. Save the location based on a hash of the dataset portion of the query. This will help us make incremental process. Suppose you're using Eagle and trying to get something done on the debug queue (1 hour limit). Each dataset takes 45 minutes. The query would never finish. With this change we'll finish in two attempts.

The change will be helpful beyond Eagle. We'll be able to avoid rebuilding mapped datasets. The overall queries will also be easier to monitor and debug.

I also added some supporting code, like adding the ability to customize the Spark config for each dataset.