### PR TITLE
Fix Spark issues when verifying dimension association tables

### DIFF
--- a/dsgrid/cli/dsgrid.py
+++ b/dsgrid/cli/dsgrid.py
@@ -10,7 +10,7 @@ from dsgrid.cli.download import download
 from dsgrid.cli.install_notebooks import install_notebooks
 from dsgrid.cli.query import query
 from dsgrid.cli.registry import registry
-from dsgrid.loggers import setup_logging, check_log_file_size
+from dsgrid.loggers import setup_logging, check_log_file_size, disable_console_logging
 
 
 logger = logging.getLogger(__name__)
@@ -35,16 +35,8 @@ def cli(ctx, log_file, no_prompts, verbose):
 
 @cli.result_callback()
 def callback(*args, **kwargs):
-    # Raise the console level so that timer stats only go to the log file.
-    dsgrid_logger = logging.getLogger("dsgrid")
-    for i, handler in enumerate(dsgrid_logger.handlers):
-        if handler.name == "console":
-            handler.setLevel(logging.WARNING)
-            break
-
-    timer_stats_collector.log_stats()
-
-    # Leave the console logger changed because the process will now exit.
+    with disable_console_logging(name="dsgrid"):
+        timer_stats_collector.log_stats()
 
 
 cli.add_command(download)

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -39,7 +39,7 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
     @classmethod
     def load(cls, config: DatasetConfig, *args, **kwargs):
         load_data_df = read_dataframe(config.load_data_path)
-        load_data_lookup = read_dataframe(config.load_data_lookup_path, cache=True)
+        load_data_lookup = read_dataframe(config.load_data_lookup_path)
         load_data_lookup = config.add_trivial_dimensions(load_data_lookup)
         return cls(load_data_df, load_data_lookup, config, *args, **kwargs)
 

--- a/dsgrid/loggers.py
+++ b/dsgrid/loggers.py
@@ -3,6 +3,7 @@
 import logging
 import logging.config
 import os
+from contextlib import contextmanager
 
 
 # ETH@20210325 - What if you want to set up logging for all loggers, or for all
@@ -98,3 +99,23 @@ def check_log_file_size(filename, limit_mb=10, no_prompts=False):
         val = input(msg)
         if val == "" or val.lower() == "y":
             os.remove(filename)
+
+
+@contextmanager
+def disable_console_logging(name="dsgrid"):
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        console_level = None
+        try:
+            for handler in logger.handlers:
+                if handler.name == "console":
+                    console_level = handler.level
+                    handler.setLevel(logging.FATAL)
+                    break
+            yield
+        finally:
+            for handler in logger.handlers:
+                if handler.name == "console":
+                    assert console_level is not None
+                    handler.setLevel(console_level)
+                    break

--- a/dsgrid/loggers.py
+++ b/dsgrid/loggers.py
@@ -104,18 +104,17 @@ def check_log_file_size(filename, limit_mb=10, no_prompts=False):
 @contextmanager
 def disable_console_logging(name="dsgrid"):
     logger = logging.getLogger(name)
-    if logger.handlers:
-        console_level = None
-        try:
-            for handler in logger.handlers:
-                if handler.name == "console":
-                    console_level = handler.level
-                    handler.setLevel(logging.FATAL)
-                    break
-            yield
-        finally:
-            for handler in logger.handlers:
-                if handler.name == "console":
-                    assert console_level is not None
-                    handler.setLevel(console_level)
-                    break
+    console_level = None
+    try:
+        for handler in logger.handlers:
+            if handler.name == "console":
+                console_level = handler.level
+                handler.setLevel(logging.FATAL)
+                break
+        yield
+    finally:
+        for handler in logger.handlers:
+            if handler.name == "console":
+                assert console_level is not None
+                handler.setLevel(console_level)
+                break

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ with open(here / "README.md", encoding="utf-8") as f:
 
 dev_requires = ["black>=22.3.0", "pre-commit", "devtools", "jupyter", "flake8", "pyarrow"]
 
-test_requires = ["pytest", "pytest-cov"]
+test_requires = [
+    "httpx",  # starlette, used by fastapi, requires this as an optional dependency for testing.
+    "pytest",
+    "pytest-cov",
+]
 
 doc_requires = [
     "ghp-import",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,13 @@ def pytest_sessionstart(session):
         )
         print("git submodule init")
         print("git submodule update")
+        sys.exit(1)
+
+    # Saving these tables during tests doesn't add any value and adds complications whenever
+    # multiple processes try to access the Hive metastore, particularly when we inject errors.
+    # We only need this when we submit datasets to projects and users want to inspect the
+    # outcomes. This feature may become opt-in if we encounter similar problems.
+    os.environ["__DSGRID_SKIP_SAVING_DIMENSION_ASSOCIATIONS__"] = "1"
 
     commit_file = TEST_REGISTRY / "commit.txt"
     latest_commit = _get_latest_commit()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -234,6 +234,11 @@ def shutdown_project():
     if spark is not None:
         spark.stop()
 
+    # There could be collisions with the Hive metastore.
+    for path in ("metastore_db", "spark-warehouse"):
+        if Path(path).exists():
+            shutil.rmtree(path)
+
 
 def run_query_test(test_query_cls, *args):
     output_dir = Path(tempfile.gettempdir()) / "queries"

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -8,8 +8,6 @@ import pyspark
 import pytest
 from semver import VersionInfo
 
-from dsgrid.config.dimension_association_manager import _make_dimension_associations_table_name
-from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import (
     DSGDuplicateValueRegistered,
     DSGInvalidDataset,
@@ -27,7 +25,6 @@ from dsgrid.tests.common import (
     TEST_DATASET_DIRECTORY,
 )
 from dsgrid.utils.files import dump_data, load_data
-from dsgrid.utils.spark import is_table_stored
 from dsgrid.tests.make_us_data_registry import make_test_data_registry
 
 
@@ -84,12 +81,7 @@ def test_register_project_and_dataset(make_test_project_dir):
         dimension_mapping_mgr.register(dimension_mapping_config, user, log_message)
         assert len(dimension_mapping_mgr.list_ids()) == len(mapping_ids)
 
-        table_name = _make_dimension_associations_table_name(
-            project_id, dataset_id, DimensionType.METRIC
-        )
-        assert is_table_stored(table_name)
         check_configs_update(base_dir, manager)
-        assert not is_table_stored(table_name)
         check_update_project_dimension(base_dir, manager, dataset_id)
         # Note that the dataset is now unregistered.
 


### PR DESCRIPTION
We sometimes encounter issues when submitting a dataset to a project. Too many executors get involved in validating dimension associations and the process either takes too long or encounters memory errors. This PR attempts to fix the issue by restarting the spark session with configuration parameters that limit the executors to 1 - but only if Spark dynamic allocation is enabled.

I also had to change the way we cache dimension and mapping record dataframes so that we don't lose that benefit.