### PR TITLE
Make skip-check environment variables more explicit

### DIFF
--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -168,7 +168,7 @@ class DatasetSchemaHandlerBase(abc.ABC):
         2. all dimension combinations return the same set of time range(s).
 
         """
-        if os.environ.get("__DSGRID_SKIP_DATASET_TIME_CONSISTENCY_CHECKS__"):
+        if os.environ.get("__DSGRID_SKIP_CHECK_DATASET_TIME_CONSISTENCY__"):
             logger.warning("Skip dataset time consistency checks.")
             return
 

--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -58,7 +58,7 @@ class DatasetRegistryManager(RegistryManagerBase):
         logger.info("Run dataset registration checks.")
         check_required_dimensions(config.model.dimension_references, "dataset dimensions")
         check_uniqueness((x.model.name for x in config.model.dimensions), "dimension name")
-        if not os.environ.get("__DSGRID_SKIP_DATASET_CONSISTENCY_CHECKS__"):
+        if not os.environ.get("__DSGRID_SKIP_CHECK_DATASET_CONSISTENCY__"):
             self._check_dataset_consistency(config)
 
     def _check_dataset_consistency(self, config: DatasetConfig):

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -824,7 +824,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         mapping_references: List[DimensionMappingReferenceModel],
     ):
         project_config.add_dataset_dimension_mappings(dataset_config, mapping_references)
-        if os.environ.get("__DSGRID_SKIP_DATASET_TO_PROJECT_MAPPING_CHECKS__") is not None:
+        if os.environ.get("__DSGRID_SKIP_CHECK_DATASET_TO_PROJECT_MAPPING__") is not None:
             logger.warning("Skip dataset-to-project mapping checks")
         else:
             # This operation can be very problematic if there are many executors and runs much

--- a/dsgrid/registry/registry_manager.py
+++ b/dsgrid/registry/registry_manager.py
@@ -548,10 +548,11 @@ class RegistryManager:
     @staticmethod
     def _check_environment_variables(params):
         if not params.offline:
-            illegal_vars = [x for x in os.environ if x.startswith("__DSGRID")]
+            illegal_vars = [x for x in os.environ if x.startswith("__DSGRID_SKIP_CHECK")]
             if illegal_vars:
                 raise Exception(
-                    f"Internal environment variables are not allowed to be set in online mode: {illegal_vars}"
+                    f"Internal environment variables to skip checks are not allowed to be set "
+                    f"in online mode: {illegal_vars}"
                 )
 
 

--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -119,7 +119,7 @@ def add_column_from_records(df, dimension_records, dimension_name, column_to_add
 
 @track_timing(timer_stats_collector)
 def check_null_value_in_unique_dimension_rows(dim_table):
-    if os.environ.get("__DSGRID_SKIP_NULL_UNIQUE_DIMENSION_CHECK__"):
+    if os.environ.get("__DSGRID_SKIP_CHECK_NULL_UNIQUE_DIMENSION__"):
         # This has intermittently caused GC-related timeouts for TEMPO.
         # Leave a backdoor to skip these checks, which may eventually be removed.
         logger.warning("Skip check_null_value_in_unique_dimension_rows")

--- a/tests_aws/test_registry/test_aws_registry_workflow_online_mode.py
+++ b/tests_aws/test_registry/test_aws_registry_workflow_online_mode.py
@@ -103,8 +103,8 @@ def check_configs_projects_and_datasets(s3):
             for file in files:
                 if "projects" in path:
                     assert file in ("1.0.0", "1.1.0", "registry.toml")
-                    # project.toml, data_source__sector.csv, data_source__subsector.csv, sector__subsector.csv
-                    expected_file_count = 4
+                    # project.toml
+                    expected_file_count = 1
                 else:
                     assert file in ("1.0.0", "registry.toml")
                     expected_file_count = 1  # dataset.toml


### PR DESCRIPTION
Closes GitHub Issue #170 

## Description
The code was checking for any internal environment variable being set while in online mode. That was too restrictive. We should only throw errors when those internal environments cause checks to be skipped.
