### PR TITLE
Use pytest tmp_path fixture

### DIFF
--- a/tests/test_filter_registry.py
+++ b/tests/test_filter_registry.py
@@ -1,7 +1,3 @@
-import shutil
-import tempfile
-from pathlib import Path
-
 from dsgrid.config.simple_models import RegistrySimpleModel
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.registry.registry_manager import RegistryManager
@@ -40,45 +36,42 @@ FILTER_CONFIG = {
 }
 
 
-def test_filter_registry():
+def test_filter_registry(tmp_path):
     simple_model = RegistrySimpleModel(**FILTER_CONFIG)
-    dst = Path(tempfile.gettempdir()) / "test-dsgrid-registry"
+    dst = tmp_path / "test-dsgrid-registry"
     RegistryManager.copy(TEST_REGISTRY, dst, force=True)
-    try:
-        FilterRegistryManager.load(dst, offline_mode=True).filter(simple_model)
-        mgr = RegistryManager.load(dst, offline_mode=True)
-        project = mgr.project_manager.load_project(PROJECT_ID)
+    FilterRegistryManager.load(dst, offline_mode=True).filter(simple_model)
+    mgr = RegistryManager.load(dst, offline_mode=True)
+    project = mgr.project_manager.load_project(PROJECT_ID)
 
-        # Verify that the dataset, dimensions, and dimension mappings are all filtered.
-        project.load_dataset(DATASET_ID)
-        dataset = project.get_dataset(DATASET_ID)
-        load_data_df = dataset._handler._load_data
-        load_data_lookup_df = dataset._handler._load_data_lookup
-        df = load_data_df.join(load_data_lookup_df, on="id").drop("id")
-        dataset_geos = df.select("geography").distinct().collect()
-        assert len(dataset_geos) == 1
-        assert dataset_geos[0].geography == COUNTY_ID
+    # Verify that the dataset, dimensions, and dimension mappings are all filtered.
+    project.load_dataset(DATASET_ID)
+    dataset = project.get_dataset(DATASET_ID)
+    load_data_df = dataset._handler._load_data
+    load_data_lookup_df = dataset._handler._load_data_lookup
+    df = load_data_df.join(load_data_lookup_df, on="id").drop("id")
+    dataset_geos = df.select("geography").distinct().collect()
+    assert len(dataset_geos) == 1
+    assert dataset_geos[0].geography == COUNTY_ID
 
-        base_dim = project.config.get_base_dimension(DimensionType.GEOGRAPHY)
-        records = base_dim.get_records_dataframe().collect()
-        assert len(records) == 1
-        assert records[0].id == COUNTY_ID
+    base_dim = project.config.get_base_dimension(DimensionType.GEOGRAPHY)
+    records = base_dim.get_records_dataframe().collect()
+    assert len(records) == 1
+    assert records[0].id == COUNTY_ID
 
-        supp_dim = project.config.get_dimension_records(QUERY_NAME).collect()
-        assert len(supp_dim) == 1
-        assert supp_dim[0].id == STATE_ID
+    supp_dim = project.config.get_dimension_records(QUERY_NAME).collect()
+    assert len(supp_dim) == 1
+    assert supp_dim[0].id == STATE_ID
 
-        found_mapping_records = False
-        for dim in project.config.list_supplemental_dimensions(DimensionType.GEOGRAPHY):
-            if dim.model.dimension_query_name == QUERY_NAME:
-                for mapping in project.config.get_base_to_supplemental_dimension_mappings_by_types(
-                    DimensionType.GEOGRAPHY
-                ):
-                    if mapping.model.to_dimension.dimension_id == dim.model.dimension_id:
-                        records = mapping.get_records_dataframe().collect()
-                        assert len(records) == 1
-                        assert records[0].from_id == COUNTY_ID and records[0].to_id == STATE_ID
-                        found_mapping_records = True
-        assert found_mapping_records
-    finally:
-        shutil.rmtree(dst)
+    found_mapping_records = False
+    for dim in project.config.list_supplemental_dimensions(DimensionType.GEOGRAPHY):
+        if dim.model.dimension_query_name == QUERY_NAME:
+            for mapping in project.config.get_base_to_supplemental_dimension_mappings_by_types(
+                DimensionType.GEOGRAPHY
+            ):
+                if mapping.model.to_dimension.dimension_id == dim.model.dimension_id:
+                    records = mapping.get_records_dataframe().collect()
+                    assert len(records) == 1
+                    assert records[0].from_id == COUNTY_ID and records[0].to_id == STATE_ID
+                    found_mapping_records = True
+    assert found_mapping_records

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -86,7 +86,7 @@ def test_peak_load():
     run_query_test(QueryTestPeakLoadByStateSubsector)
 
 
-def test_invalid_drop_pivoted_dimension():
+def test_invalid_drop_pivoted_dimension(tmp_path):
     invalid_agg = AggregationModel(
         dimensions=DimensionQueryNamesModel(
             data_source=["data_source"],
@@ -116,7 +116,7 @@ def test_invalid_drop_pivoted_dimension():
         ),
     )
     project = get_project()
-    output_dir = Path(tempfile.gettempdir()) / "queries"
+    output_dir = tmp_path / "queries"
 
     query.project.dataset_params.per_dataset_aggregations = [invalid_agg]
     with pytest.raises(DSGInvalidQuery):
@@ -128,75 +128,57 @@ def test_invalid_drop_pivoted_dimension():
         ProjectQuerySubmitter(project, output_dir).submit(query)
 
 
-def test_create_composite_dataset_query():
-    output_dir = Path(tempfile.gettempdir()) / "queries"
-    if output_dir.exists():
-        shutil.rmtree(output_dir)
-
+def test_create_composite_dataset_query(tmp_path):
+    output_dir = tmp_path / "queries"
     project = get_project()
-    try:
-        query = QueryTestElectricityValuesCompositeDataset(
-            REGISTRY_PATH, project, output_dir=output_dir
-        )
-        CompositeDatasetQuerySubmitter(project, output_dir).create_dataset(query.make_query())
+    query = QueryTestElectricityValuesCompositeDataset(
+        REGISTRY_PATH, project, output_dir=output_dir
+    )
+    CompositeDatasetQuerySubmitter(project, output_dir).create_dataset(query.make_query())
 
-        query2 = QueryTestElectricityValuesCompositeDatasetAgg(
-            REGISTRY_PATH, project, output_dir=output_dir, geography="county"
-        )
-        CompositeDatasetQuerySubmitter(project, output_dir).submit(query2.make_query())
+    query2 = QueryTestElectricityValuesCompositeDatasetAgg(
+        REGISTRY_PATH, project, output_dir=output_dir, geography="county"
+    )
+    CompositeDatasetQuerySubmitter(project, output_dir).submit(query2.make_query())
 
-        query3 = QueryTestElectricityValuesCompositeDatasetAgg(
-            REGISTRY_PATH,
-            project,
-            output_dir=output_dir,
-            geography="state",
-        )
-        CompositeDatasetQuerySubmitter(project, output_dir).submit(query3.make_query())
-    finally:
-        if output_dir.exists():
-            shutil.rmtree(output_dir)
+    query3 = QueryTestElectricityValuesCompositeDatasetAgg(
+        REGISTRY_PATH,
+        project,
+        output_dir=output_dir,
+        geography="state",
+    )
+    CompositeDatasetQuerySubmitter(project, output_dir).submit(query3.make_query())
 
 
-def test_query_cli_create_validate():
-    filename = Path(tempfile.gettempdir()) / "query.json"
-    try:
-        cmd = (
-            f"dsgrid query project create --offline --registry-path={REGISTRY_PATH} "
-            f"-d -r -f {filename} -F expression -F column_operator "
-            "-F supplemental_column_operator -F raw --force my_query dsgrid_conus_2022"
-        )
-        shutdown_project()
-        check_run_command(cmd)
-        query = ProjectQueryModel.from_file(filename)
-        assert query.name == "my_query"
-        assert query.project.dataset_params.per_dataset_aggregations
-        assert query.result.aggregations
-        check_run_command(f"dsgrid query project validate {filename}")
-    finally:
-        if filename.exists():
-            filename.unlink()
+def test_query_cli_create_validate(tmp_path):
+    filename = tmp_path / "query.json"
+    cmd = (
+        f"dsgrid query project create --offline --registry-path={REGISTRY_PATH} "
+        f"-d -r -f {filename} -F expression -F column_operator "
+        "-F supplemental_column_operator -F raw --force my_query dsgrid_conus_2022"
+    )
+    shutdown_project()
+    check_run_command(cmd)
+    query = ProjectQueryModel.from_file(filename)
+    assert query.name == "my_query"
+    assert query.project.dataset_params.per_dataset_aggregations
+    assert query.result.aggregations
+    check_run_command(f"dsgrid query project validate {filename}")
 
 
-def test_query_cli_run():
-    output_dir = Path(tempfile.gettempdir()) / "queries"
-    if output_dir.exists():
-        shutil.rmtree(output_dir)
-
+def test_query_cli_run(tmp_path):
+    output_dir = tmp_path / "queries"
     project = get_project()
-    try:
-        query = QueryTestElectricityValues(True, REGISTRY_PATH, project, output_dir=output_dir)
-        filename = Path(tempfile.gettempdir()) / "query.json"
-        filename.write_text(query.make_query().json())
-        cmd = (
-            f"dsgrid query project run --offline --registry-path={REGISTRY_PATH} "
-            f"--output={output_dir} {filename}"
-        )
-        shutdown_project()
-        check_run_command(cmd)
-        query.validate()
-    finally:
-        if output_dir.exists():
-            shutil.rmtree(output_dir)
+    query = QueryTestElectricityValues(True, REGISTRY_PATH, project, output_dir=output_dir)
+    filename = tmp_path / "query.json"
+    filename.write_text(query.make_query().json())
+    cmd = (
+        f"dsgrid query project run --offline --registry-path={REGISTRY_PATH} "
+        f"--output={output_dir} {filename}"
+    )
+    shutdown_project()
+    check_run_command(cmd)
+    query.validate()
 
 
 def test_dimension_query_names_model():

--- a/tests/test_register_project.py
+++ b/tests/test_register_project.py
@@ -1,38 +1,30 @@
 import getpass
 import shutil
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import pytest
 
 from dsgrid.tests.make_us_data_registry import make_test_data_registry
 
 
-def test_invalid_projects(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        manager = make_test_data_registry(
-            base_dir,
-            make_test_project_dir,
-            include_projects=False,
-            include_datasets=False,
-        )
+def test_invalid_projects(make_test_project_dir, tmp_path):
+    manager = make_test_data_registry(
+        tmp_path,
+        make_test_project_dir,
+        include_projects=False,
+        include_datasets=False,
+    )
 
-        user = getpass.getuser()
-        log_message = "test log message"
-        register_tests = []
+    user = getpass.getuser()
+    log_message = "test log message"
+    register_tests = []
 
-        # This is arranged in this way to avoid having to re-create the registry every time,
-        # which is quite slow. There is one downside: if one test is able to register the
-        # project (which would be a bug), later tests will fail even if they should pass.
-        for i, setup_test in enumerate(register_tests):
-            test_dir = base_dir / f"test_data_dir_{i}"
-            try:
-                shutil.copytree(make_test_project_dir, test_dir)
-                project_config_file = test_dir / "project.toml"
-                exc, match_msg = setup_test(test_dir)
-                with pytest.raises(exc, match=match_msg):
-                    manager.project_manager.register(project_config_file, user, log_message)
-            finally:
-                if test_dir.exists():
-                    shutil.rmtree(test_dir)
+    # This is arranged in this way to avoid having to re-create the registry every time,
+    # which is quite slow. There is one downside: if one test is able to register the
+    # project (which would be a bug), later tests will fail even if they should pass.
+    for i, setup_test in enumerate(register_tests):
+        test_dir = tmp_path / f"test_data_dir_{i}"
+        shutil.copytree(make_test_project_dir, test_dir)
+        project_config_file = test_dir / "project.toml"
+        exc, match_msg = setup_test(test_dir)
+        with pytest.raises(exc, match=match_msg):
+            manager.project_manager.register(project_config_file, user, log_message)

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -2,7 +2,6 @@ import getpass
 import os
 import shutil
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import pyspark
 import pytest
@@ -28,382 +27,365 @@ from dsgrid.utils.files import dump_data, load_data
 from dsgrid.tests.make_us_data_registry import make_test_data_registry
 
 
-def test_register_project_and_dataset(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        manager = make_test_data_registry(base_dir, make_test_project_dir, TEST_DATASET_DIRECTORY)
-        project_mgr = manager.project_manager
-        dataset_mgr = manager.dataset_manager
-        dimension_mgr = manager.dimension_manager
-        dimension_mapping_mgr = manager.dimension_mapping_manager
-        project_ids = project_mgr.list_ids()
-        assert len(project_ids) == 1
-        project_id = project_ids[0]
-        dataset_ids = dataset_mgr.list_ids()
-        dataset_id = dataset_ids[0]
-        assert len(dataset_ids) == 1
-        dimension_ids = dimension_mgr.list_ids()
-        assert dimension_ids
-        dimension_id = dimension_ids[0]
-        dimension_mapping_ids = dimension_mapping_mgr.list_ids()
-        assert dimension_mapping_ids
-        dimension_mapping_id = dimension_mapping_ids[0]
-        user = getpass.getuser()
-        log_message = "initial registration"
-        dataset_path = TEST_DATASET_DIRECTORY / dataset_id
+def test_register_project_and_dataset(make_test_project_dir, tmp_path):
+    manager = make_test_data_registry(tmp_path, make_test_project_dir, TEST_DATASET_DIRECTORY)
+    project_mgr = manager.project_manager
+    dataset_mgr = manager.dataset_manager
+    dimension_mgr = manager.dimension_manager
+    dimension_mapping_mgr = manager.dimension_mapping_manager
+    project_ids = project_mgr.list_ids()
+    assert len(project_ids) == 1
+    project_id = project_ids[0]
+    dataset_ids = dataset_mgr.list_ids()
+    dataset_id = dataset_ids[0]
+    assert len(dataset_ids) == 1
+    dimension_ids = dimension_mgr.list_ids()
+    assert dimension_ids
+    dimension_id = dimension_ids[0]
+    dimension_mapping_ids = dimension_mapping_mgr.list_ids()
+    assert dimension_mapping_ids
+    dimension_mapping_id = dimension_mapping_ids[0]
+    user = getpass.getuser()
+    log_message = "initial registration"
+    dataset_path = TEST_DATASET_DIRECTORY / dataset_id
 
-        project_config = project_mgr.get_by_id(project_id, VersionInfo.parse("1.1.0"))
-        assert project_config.model.status == ProjectRegistryStatus.COMPLETE
-        dataset = project_config.get_dataset(dataset_id)
-        assert dataset.status == DatasetRegistryStatus.REGISTERED
+    project_config = project_mgr.get_by_id(project_id, VersionInfo.parse("1.1.0"))
+    assert project_config.model.status == ProjectRegistryStatus.COMPLETE
+    dataset = project_config.get_dataset(dataset_id)
+    assert dataset.status == DatasetRegistryStatus.REGISTERED
 
-        # The project version from before dataset submission should still be there.
-        project_config = project_mgr.get_by_id(project_id, VersionInfo.parse("1.0.0"))
-        dataset = project_config.get_dataset(dataset_id)
-        assert dataset.status == DatasetRegistryStatus.UNREGISTERED
+    # The project version from before dataset submission should still be there.
+    project_config = project_mgr.get_by_id(project_id, VersionInfo.parse("1.0.0"))
+    dataset = project_config.get_dataset(dataset_id)
+    assert dataset.status == DatasetRegistryStatus.UNREGISTERED
 
-        with pytest.raises(DSGDuplicateValueRegistered):
-            project_config_file = make_test_project_dir / "project.toml"
-            project_mgr.register(project_config_file, user, log_message)
+    with pytest.raises(DSGDuplicateValueRegistered):
+        project_config_file = make_test_project_dir / "project.toml"
+        project_mgr.register(project_config_file, user, log_message)
 
-        with pytest.raises(DSGDuplicateValueRegistered):
-            dataset_config_file = (
-                make_test_project_dir / "datasets" / "modeled" / "comstock" / "dataset.toml"
-            )
-            dataset_mgr.register(dataset_config_file, dataset_path, user, log_message)
+    with pytest.raises(DSGDuplicateValueRegistered):
+        dataset_config_file = (
+            make_test_project_dir / "datasets" / "modeled" / "comstock" / "dataset.toml"
+        )
+        dataset_mgr.register(dataset_config_file, dataset_path, user, log_message)
 
-        # Duplicate mappings get re-used.
-        mapping_ids = dimension_mapping_mgr.list_ids()
-        dimension_mapping_mgr.dump(dimension_mapping_id, base_dir)
-        dimension_mapping_config = base_dir / "dimension_mapping.toml"
-        data = load_data(dimension_mapping_config)
-        dump_data({"mappings": [data]}, dimension_mapping_config)
-        dimension_mapping_mgr.register(dimension_mapping_config, user, log_message)
-        assert len(dimension_mapping_mgr.list_ids()) == len(mapping_ids)
+    # Duplicate mappings get re-used.
+    mapping_ids = dimension_mapping_mgr.list_ids()
+    dimension_mapping_mgr.dump(dimension_mapping_id, tmp_path)
+    dimension_mapping_config = tmp_path / "dimension_mapping.toml"
+    data = load_data(dimension_mapping_config)
+    dump_data({"mappings": [data]}, dimension_mapping_config)
+    dimension_mapping_mgr.register(dimension_mapping_config, user, log_message)
+    assert len(dimension_mapping_mgr.list_ids()) == len(mapping_ids)
 
-        check_configs_update(base_dir, manager)
-        check_update_project_dimension(base_dir, manager, dataset_id)
-        # Note that the dataset is now unregistered.
+    check_configs_update(tmp_path, manager)
+    check_update_project_dimension(tmp_path, manager)
+    # Note that the dataset is now unregistered.
 
-        # Test removals.
-        check_config_remove(project_mgr, project_id)
-        check_config_remove(dataset_mgr, dataset_id)
-        check_config_remove(dimension_mgr, dimension_id)
-        check_config_remove(dimension_mapping_mgr, dimension_mapping_id)
+    # Test removals.
+    check_config_remove(project_mgr, project_id)
+    check_config_remove(dataset_mgr, dataset_id)
+    check_config_remove(dimension_mgr, dimension_id)
+    check_config_remove(dimension_mapping_mgr, dimension_mapping_id)
 
 
-def test_duplicate_dimensions(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        path = create_local_test_registry(Path(tmpdir))
-        user = getpass.getuser()
-        log_message = "Initial registration"
-        manager = RegistryManager.load(path, offline_mode=True)
+def test_duplicate_dimensions(make_test_project_dir, tmp_path):
+    path = create_local_test_registry(Path(tmp_path))
+    user = getpass.getuser()
+    log_message = "Initial registration"
+    manager = RegistryManager.load(path, offline_mode=True)
 
-        dimension_mgr = manager.dimension_manager
-        dimension_mgr.register(make_test_project_dir / "dimensions.toml", user, log_message)
+    dimension_mgr = manager.dimension_manager
+    dimension_mgr.register(make_test_project_dir / "dimensions.toml", user, log_message)
 
-        # Registering duplicate dimensions and mappings are allowed.
-        # If names are the same, they are replaced. Otherwise, new ones get registered.
-        # Time dimension has more fields checked.
-        dimension_ids = dimension_mgr.list_ids()
-        dim_config_file = make_test_project_dir / "dimensions.toml"
+    # Registering duplicate dimensions and mappings are allowed.
+    # If names are the same, they are replaced. Otherwise, new ones get registered.
+    # Time dimension has more fields checked.
+    dimension_ids = dimension_mgr.list_ids()
+    dim_config_file = make_test_project_dir / "dimensions.toml"
 
-        dimension_mgr.register(dim_config_file, user, log_message)
-        assert len(dimension_mgr.list_ids()) == len(dimension_ids)
+    dimension_mgr.register(dim_config_file, user, log_message)
+    assert len(dimension_mgr.list_ids()) == len(dimension_ids)
 
-        data = load_data(dim_config_file)
-        data["dimensions"][0]["name"] += " new"
-        dump_data(data, dim_config_file)
+    data = load_data(dim_config_file)
+    data["dimensions"][0]["name"] += " new"
+    dump_data(data, dim_config_file)
 
-        dimension_mgr.register(dim_config_file, user, log_message)
-        assert len(dimension_mgr.list_ids()) == len(dimension_ids) + 1
+    dimension_mgr.register(dim_config_file, user, log_message)
+    assert len(dimension_mgr.list_ids()) == len(dimension_ids) + 1
 
-        data = load_data(dim_config_file)
-        for dim in data["dimensions"]:
-            if dim["type"] == "time":
-                assert dim["time_interval_type"] == "period_beginning"
-                dim["time_interval_type"] = "period_ending"
-        dump_data(data, dim_config_file)
+    data = load_data(dim_config_file)
+    for dim in data["dimensions"]:
+        if dim["type"] == "time":
+            assert dim["time_interval_type"] == "period_beginning"
+            dim["time_interval_type"] = "period_ending"
+    dump_data(data, dim_config_file)
 
-        dimension_mgr.register(dim_config_file, user, log_message)
-        assert len(dimension_mgr.list_ids()) == len(dimension_ids) + 2
-
-
-def test_duplicate_project_dimension_display_names(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        path = create_local_test_registry(Path(tmpdir))
-        user = getpass.getuser()
-        log_message = "Initial registration"
-        manager = RegistryManager.load(path, offline_mode=True)
-
-        project_file = make_test_project_dir / "project.toml"
-        data = load_data(project_file)
-        for dim in data["dimensions"]["supplemental_dimensions"]:
-            if dim["display_name"] == "State":
-                dim["display_name"] = "County"
-        dump_data(data, project_file)
-        with pytest.raises(DSGInvalidDimension):
-            manager.project_manager.register(project_file, user, log_message)
+    dimension_mgr.register(dim_config_file, user, log_message)
+    assert len(dimension_mgr.list_ids()) == len(dimension_ids) + 2
 
 
-def test_register_duplicate_project_rollback_dimensions(make_test_project_dir):
+def test_duplicate_project_dimension_display_names(make_test_project_dir, tmp_path):
+    path = create_local_test_registry(tmp_path)
+    user = getpass.getuser()
+    log_message = "Initial registration"
+    manager = RegistryManager.load(path, offline_mode=True)
+
+    project_file = make_test_project_dir / "project.toml"
+    data = load_data(project_file)
+    for dim in data["dimensions"]["supplemental_dimensions"]:
+        if dim["display_name"] == "State":
+            dim["display_name"] = "County"
+    dump_data(data, project_file)
+    with pytest.raises(DSGInvalidDimension):
+        manager.project_manager.register(project_file, user, log_message)
+
+
+def test_register_duplicate_project_rollback_dimensions(make_test_project_dir, tmp_path):
     src_dir = make_test_project_dir
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        manager = make_test_data_registry(
-            base_dir, src_dir, include_projects=False, include_datasets=False
-        )
-        project_file = src_dir / "project.toml"
-        orig_dimension_ids = manager.dimension_manager.list_ids()
+    manager = make_test_data_registry(
+        tmp_path, src_dir, include_projects=False, include_datasets=False
+    )
+    project_file = src_dir / "project.toml"
+    orig_dimension_ids = manager.dimension_manager.list_ids()
 
-        data = load_data(project_file)
-        # Inject an invalid project ID so that we can test rollback of dimensions.
-        data["project_id"] = "project-with-dashes"
-        dump_data(data, project_file)
+    data = load_data(project_file)
+    # Inject an invalid project ID so that we can test rollback of dimensions.
+    data["project_id"] = "project-with-dashes"
+    dump_data(data, project_file)
 
-        with pytest.raises(ValueError):
-            manager.project_manager.register(
-                project_file,
-                getpass.getuser(),
-                "register duplicate project",
-            )
-
-        # Dimensions and mappings should have been registered and then cleared.
-        assert manager.dimension_manager.list_ids() == orig_dimension_ids
-        assert not manager.dimension_mapping_manager.list_ids()
-
-
-def test_register_and_submit_rollback_on_failure(make_test_project_dir):
-    src_dir = make_test_project_dir
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        path = create_local_test_registry(base_dir)
-        manager = RegistryManager.load(path, offline_mode=True)
-        project_file = src_dir / "project.toml"
-        project_id = load_data(project_file)["project_id"]
-        dataset_dir = src_dir / "datasets" / "modeled" / "comstock"
-        dataset_config_file = dataset_dir / "dataset.toml"
-        dataset_id = load_data(dataset_config_file)["dataset_id"]
-        dataset_mapping_file = dataset_dir / "dimension_mappings.toml"
-        dataset_path = (
-            Path(os.environ.get("DSGRID_LOCAL_DATA_DIRECTORY", TEST_DATASET_DIRECTORY))
-            / "test_efs_comstock"
-        )
-        subsectors_file = (
-            dataset_dir
-            / "dimension_mappings"
-            / "lookup_comstock_subsectors_to_project_subsectors.csv"
-        )
-        # Remove some records.
-        data = subsectors_file.read_text().splitlines()[:-2]
-        subsectors_file.write_text("\n".join(data))
-
+    with pytest.raises(ValueError):
         manager.project_manager.register(
             project_file,
             getpass.getuser(),
-            "register project",
+            "register duplicate project",
         )
 
-        replace_dimension_uuids_from_registry(path, (dataset_config_file,))
-        orig_dimension_ids = manager.dimension_manager.list_ids()
-        orig_mapping_ids = manager.dimension_mapping_manager.list_ids()
+    # Dimensions and mappings should have been registered and then cleared.
+    assert manager.dimension_manager.list_ids() == orig_dimension_ids
+    assert not manager.dimension_mapping_manager.list_ids()
 
-        try:
-            with pytest.raises(DSGInvalidDataset):
-                manager.project_manager.register_and_submit_dataset(
-                    dataset_config_file,
-                    dataset_path,
-                    project_id,
-                    getpass.getuser(),
-                    "register dataset and submit",
-                    dimension_mapping_file=dataset_mapping_file,
-                )
-        finally:
-            missing_record_file = Path(
-                f"{dataset_id}__{project_id}__missing_dimension_record_combinations.csv"
+
+def test_register_and_submit_rollback_on_failure(make_test_project_dir, tmp_path):
+    src_dir = make_test_project_dir
+    path = create_local_test_registry(tmp_path)
+    manager = RegistryManager.load(path, offline_mode=True)
+    project_file = src_dir / "project.toml"
+    project_id = load_data(project_file)["project_id"]
+    dataset_dir = src_dir / "datasets" / "modeled" / "comstock"
+    dataset_config_file = dataset_dir / "dataset.toml"
+    dataset_id = load_data(dataset_config_file)["dataset_id"]
+    dataset_mapping_file = dataset_dir / "dimension_mappings.toml"
+    dataset_path = (
+        Path(os.environ.get("DSGRID_LOCAL_DATA_DIRECTORY", TEST_DATASET_DIRECTORY))
+        / "test_efs_comstock"
+    )
+    subsectors_file = (
+        dataset_dir / "dimension_mappings" / "lookup_comstock_subsectors_to_project_subsectors.csv"
+    )
+    # Remove some records.
+    data = subsectors_file.read_text().splitlines()[:-2]
+    subsectors_file.write_text("\n".join(data))
+
+    manager.project_manager.register(
+        project_file,
+        getpass.getuser(),
+        "register project",
+    )
+
+    replace_dimension_uuids_from_registry(path, (dataset_config_file,))
+    orig_dimension_ids = manager.dimension_manager.list_ids()
+    orig_mapping_ids = manager.dimension_mapping_manager.list_ids()
+
+    try:
+        with pytest.raises(DSGInvalidDataset):
+            manager.project_manager.register_and_submit_dataset(
+                dataset_config_file,
+                dataset_path,
+                project_id,
+                getpass.getuser(),
+                "register dataset and submit",
+                dimension_mapping_file=dataset_mapping_file,
             )
-            if missing_record_file.exists():
-                shutil.rmtree(missing_record_file)
-
-        assert manager.dimension_manager.list_ids() == orig_dimension_ids
-        assert manager.dimension_mapping_manager.list_ids() == orig_mapping_ids
-        assert not manager.dataset_manager.list_ids()
-        assert manager.project_manager.list_ids() == [project_id]
-
-
-def test_auto_updates(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        mgr = make_test_data_registry(base_dir, make_test_project_dir, TEST_DATASET_DIRECTORY)
-        project_mgr = mgr.project_manager
-        dataset_mgr = mgr.dataset_manager
-        dimension_mgr = mgr.dimension_manager
-        dimension_mapping_mgr = mgr.dimension_mapping_manager
-        project_id = project_mgr.list_ids()[0]
-        dataset_id = dataset_mgr.list_ids()[0]
-        dimension_id = [x for x in dimension_mgr.iter_ids() if x.startswith("us_counties")][0]
-        dimension = dimension_mgr.get_by_id(dimension_id)
-
-        # Test that we can convert records to a Spark DataFrame. Unrelated to the rest.
-        assert isinstance(dimension.get_records_dataframe(), pyspark.sql.DataFrame)
-
-        dimension.model.description += "; test update"
-        update_type = VersionUpdateType.MINOR
-        log_message = "test update"
-        dimension_mgr.update(dimension, update_type, log_message)
-
-        # Find a mapping that uses this dimension and verify that it gets updated.
-        mapping = None
-        for _mapping in dimension_mapping_mgr.iter_configs():
-            fields = _mapping.config_id.split("__")
-            if fields[0].startswith("us_counties") and fields[1].startswith("us_census_regions"):
-                mapping = _mapping
-                break
-        assert mapping is not None
-        orig_version = dimension_mapping_mgr.get_current_version(mapping.config_id)
-        assert orig_version == VersionInfo.parse("1.0.0")
-
-        mgr.update_dependent_configs(dimension, update_type, log_message)
-
-        new_version = dimension_mapping_mgr.get_current_version(mapping.config_id)
-        assert new_version == VersionInfo.parse("1.1.0")
-
-        project = project_mgr.get_by_id(project_id)
-        found = False
-        for mapping_ref in project.model.dimension_mappings.base_to_supplemental_references:
-            if mapping_ref.mapping_id == mapping.config_id:
-                assert mapping_ref.version == new_version
-                found = True
-        assert found
-
-        dataset = dataset_mgr.get_by_id(dataset_id)
-        found = False
-        for dimension_ref in dataset.model.dimension_references:
-            if dimension_ref.dimension_id == dimension.config_id:
-                assert dimension_ref.version == VersionInfo.parse("1.1.0")
-                found = True
-        assert found
-
-        assert project.model.datasets[0].version == VersionInfo.parse("1.1.0")
-        assert project_mgr.get_current_version(project_id) == VersionInfo.parse("1.2.0")
-        assert dataset_mgr.get_current_version(dataset_id) == VersionInfo.parse("1.1.0")
-
-        # The project should get updated again if we update the dimension mapping.
-        mapping.model.description += "test update"
-        dimension_mapping_mgr.update(mapping, VersionUpdateType.PATCH, "test update")
-        assert dimension_mapping_mgr.get_current_version(mapping.config_id) == VersionInfo.parse(
-            "1.1.1"
+    finally:
+        missing_record_file = Path(
+            f"{dataset_id}__{project_id}__missing_dimension_record_combinations.csv"
         )
-        mgr.update_dependent_configs(mapping, VersionUpdateType.PATCH, "test update")
-        assert project_mgr.get_current_version(project_id) == VersionInfo.parse("1.2.1")
+        if missing_record_file.exists():
+            shutil.rmtree(missing_record_file)
 
-        # And again if we update the dataset.
-        dataset.model.description += "test update"
-        dataset_mgr.update(dataset, VersionUpdateType.PATCH, "test update")
-        mgr.update_dependent_configs(dataset, VersionUpdateType.PATCH, "test update")
-        assert project_mgr.get_current_version(project_id) == VersionInfo.parse("1.2.2")
+    assert manager.dimension_manager.list_ids() == orig_dimension_ids
+    assert manager.dimension_mapping_manager.list_ids() == orig_mapping_ids
+    assert not manager.dataset_manager.list_ids()
+    assert manager.project_manager.list_ids() == [project_id]
 
 
-def test_invalid_dimension_mapping(make_test_project_dir):
-    with TemporaryDirectory() as tmpdir:
-        path = create_local_test_registry(Path(tmpdir))
-        user = getpass.getuser()
-        log_message = "Initial registration"
-        manager = RegistryManager.load(path, offline_mode=True)
+def test_auto_updates(make_test_project_dir, tmp_path):
+    mgr = make_test_data_registry(tmp_path, make_test_project_dir, TEST_DATASET_DIRECTORY)
+    project_mgr = mgr.project_manager
+    dataset_mgr = mgr.dataset_manager
+    dimension_mgr = mgr.dimension_manager
+    dimension_mapping_mgr = mgr.dimension_mapping_manager
+    project_id = project_mgr.list_ids()[0]
+    dataset_id = dataset_mgr.list_ids()[0]
+    dimension_id = [x for x in dimension_mgr.iter_ids() if x.startswith("us_counties")][0]
+    dimension = dimension_mgr.get_by_id(dimension_id)
 
-        dim_mgr = manager.dimension_manager
-        dim_mgr.register(make_test_project_dir / "dimensions.toml", user, log_message)
-        dim_mapping_mgr = manager.dimension_mapping_manager
-        dimension_mapping_file = make_test_project_dir / "dimension_mappings_with_ids.toml"
-        replace_dimension_uuids_from_registry(path, [dimension_mapping_file])
+    # Test that we can convert records to a Spark DataFrame. Unrelated to the rest.
+    assert isinstance(dimension.get_records_dataframe(), pyspark.sql.DataFrame)
 
-        record_file = (
-            make_test_project_dir
-            / "dimension_mappings"
-            / "base_to_supplemental"
-            / "lookup_county_to_state.csv"
-        )
-        orig_text = record_file.read_text()
+    dimension.model.description += "; test update"
+    update_type = VersionUpdateType.MINOR
+    log_message = "test update"
+    dimension_mgr.update(dimension, update_type, log_message)
 
-        # Invalid 'from' record
-        record_file.write_text(orig_text + "invalid county,1,CO\n")
-        with pytest.raises(DSGInvalidDimensionMapping):
-            dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+    # Find a mapping that uses this dimension and verify that it gets updated.
+    mapping = None
+    for _mapping in dimension_mapping_mgr.iter_configs():
+        fields = _mapping.config_id.split("__")
+        if fields[0].startswith("us_counties") and fields[1].startswith("us_census_regions"):
+            mapping = _mapping
+            break
+    assert mapping is not None
+    orig_version = dimension_mapping_mgr.get_current_version(mapping.config_id)
+    assert orig_version == VersionInfo.parse("1.0.0")
 
-        # Invalid 'from' record - nulls aren't allowd
-        record_file.write_text(orig_text + ",1.2,CO\n")
-        with pytest.raises(DSGInvalidDimensionMapping):
-            dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+    mgr.update_dependent_configs(dimension, update_type, log_message)
 
-        # Invalid 'to' record
-        record_file.write_text(orig_text.replace("CO", "Colorado"))
-        with pytest.raises(DSGInvalidDimensionMapping):
-            dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+    new_version = dimension_mapping_mgr.get_current_version(mapping.config_id)
+    assert new_version == VersionInfo.parse("1.1.0")
 
-        # Duplicate "from" record, invalid as mapping_type = one_to_one_multiplication
-        orig_text2 = orig_text.split(",")
-        orig_text2 = ",".join(orig_text2[::2])
-        record_file.write_text(orig_text2 + "\n08031,CO\n")
-        msg = r"dimension_mapping.*has mapping_type.*, which does not allow duplicated.*records"
-        with pytest.raises(DSGInvalidDimensionMapping, match=msg):
-            dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+    project = project_mgr.get_by_id(project_id)
+    found = False
+    for mapping_ref in project.model.dimension_mappings.base_to_supplemental_references:
+        if mapping_ref.mapping_id == mapping.config_id:
+            assert mapping_ref.version == new_version
+            found = True
+    assert found
 
-        # Valid - null value in "to" record (Only one valid test allowed in this test func)
-        record_file.write_text(orig_text.replace("CO", ""))
+    dataset = dataset_mgr.get_by_id(dataset_id)
+    found = False
+    for dimension_ref in dataset.model.dimension_references:
+        if dimension_ref.dimension_id == dimension.config_id:
+            assert dimension_ref.version == VersionInfo.parse("1.1.0")
+            found = True
+    assert found
+
+    assert project.model.datasets[0].version == VersionInfo.parse("1.1.0")
+    assert project_mgr.get_current_version(project_id) == VersionInfo.parse("1.2.0")
+    assert dataset_mgr.get_current_version(dataset_id) == VersionInfo.parse("1.1.0")
+
+    # The project should get updated again if we update the dimension mapping.
+    mapping.model.description += "test update"
+    dimension_mapping_mgr.update(mapping, VersionUpdateType.PATCH, "test update")
+    assert dimension_mapping_mgr.get_current_version(mapping.config_id) == VersionInfo.parse(
+        "1.1.1"
+    )
+    mgr.update_dependent_configs(mapping, VersionUpdateType.PATCH, "test update")
+    assert project_mgr.get_current_version(project_id) == VersionInfo.parse("1.2.1")
+
+    # And again if we update the dataset.
+    dataset.model.description += "test update"
+    dataset_mgr.update(dataset, VersionUpdateType.PATCH, "test update")
+    mgr.update_dependent_configs(dataset, VersionUpdateType.PATCH, "test update")
+    assert project_mgr.get_current_version(project_id) == VersionInfo.parse("1.2.2")
+
+
+def test_invalid_dimension_mapping(make_test_project_dir, tmp_path):
+    path = create_local_test_registry(tmp_path)
+    user = getpass.getuser()
+    log_message = "Initial registration"
+    manager = RegistryManager.load(path, offline_mode=True)
+
+    dim_mgr = manager.dimension_manager
+    dim_mgr.register(make_test_project_dir / "dimensions.toml", user, log_message)
+    dim_mapping_mgr = manager.dimension_mapping_manager
+    dimension_mapping_file = make_test_project_dir / "dimension_mappings_with_ids.toml"
+    replace_dimension_uuids_from_registry(path, [dimension_mapping_file])
+
+    record_file = (
+        make_test_project_dir
+        / "dimension_mappings"
+        / "base_to_supplemental"
+        / "lookup_county_to_state.csv"
+    )
+    orig_text = record_file.read_text()
+
+    # Invalid 'from' record
+    record_file.write_text(orig_text + "invalid county,1,CO\n")
+    with pytest.raises(DSGInvalidDimensionMapping):
         dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
 
+    # Invalid 'from' record - nulls aren't allowd
+    record_file.write_text(orig_text + ",1.2,CO\n")
+    with pytest.raises(DSGInvalidDimensionMapping):
+        dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
 
-def test_register_submit_dataset_long_workflow(make_test_project_dir):
+    # Invalid 'to' record
+    record_file.write_text(orig_text.replace("CO", "Colorado"))
+    with pytest.raises(DSGInvalidDimensionMapping):
+        dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+
+    # Duplicate "from" record, invalid as mapping_type = one_to_one_multiplication
+    orig_text2 = orig_text.split(",")
+    orig_text2 = ",".join(orig_text2[::2])
+    record_file.write_text(orig_text2 + "\n08031,CO\n")
+    msg = r"dimension_mapping.*has mapping_type.*, which does not allow duplicated.*records"
+    with pytest.raises(DSGInvalidDimensionMapping, match=msg):
+        dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+
+    # Valid - null value in "to" record (Only one valid test allowed in this test func)
+    record_file.write_text(orig_text.replace("CO", ""))
+    dim_mapping_mgr.register(dimension_mapping_file, user, log_message)
+
+
+def test_register_submit_dataset_long_workflow(make_test_project_dir, tmp_path):
     src_dir = make_test_project_dir
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        manager = make_test_data_registry(
-            base_dir, src_dir, include_projects=False, include_datasets=False
-        )
-        dim_mapping_mgr = manager.dimension_mapping_manager
-        project_config_file = src_dir / "project_with_dimension_ids.toml"
-        project_id = load_data(project_config_file)["project_id"]
-        project_dimension_mapping_config = src_dir / "dimension_mappings_with_ids.toml"
-        project_dimension_file = src_dir / "dimensions.toml"
-        dataset_dir = src_dir / "datasets" / "modeled" / "comstock"
-        dataset_config_file = dataset_dir / "dataset_with_dimension_ids.toml"
-        dataset_id = load_data(dataset_config_file)["dataset_id"]
-        dataset_dimension_file = dataset_dir / "dimensions.toml"
-        dimension_mapping_config = dataset_dir / "dimension_mapping_config_with_ids.toml"
-        dimension_mapping_refs = dataset_dir / "dimension_mapping_references.toml"
-        user = getpass.getuser()
-        log_message = "register"
+    manager = make_test_data_registry(
+        tmp_path, src_dir, include_projects=False, include_datasets=False
+    )
+    dim_mapping_mgr = manager.dimension_mapping_manager
+    project_config_file = src_dir / "project_with_dimension_ids.toml"
+    project_id = load_data(project_config_file)["project_id"]
+    project_dimension_mapping_config = src_dir / "dimension_mappings_with_ids.toml"
+    project_dimension_file = src_dir / "dimensions.toml"
+    dataset_dir = src_dir / "datasets" / "modeled" / "comstock"
+    dataset_config_file = dataset_dir / "dataset_with_dimension_ids.toml"
+    dataset_id = load_data(dataset_config_file)["dataset_id"]
+    dataset_dimension_file = dataset_dir / "dimensions.toml"
+    dimension_mapping_config = dataset_dir / "dimension_mapping_config_with_ids.toml"
+    dimension_mapping_refs = dataset_dir / "dimension_mapping_references.toml"
+    user = getpass.getuser()
+    log_message = "register"
 
-        manager.dimension_manager.register(project_dimension_file, user, log_message)
-        manager.dimension_manager.register(dataset_dimension_file, user, log_message)
+    manager.dimension_manager.register(project_dimension_file, user, log_message)
+    manager.dimension_manager.register(dataset_dimension_file, user, log_message)
 
-        needs_replacements = [project_dimension_mapping_config, dimension_mapping_config]
-        replace_dimension_uuids_from_registry(base_dir, needs_replacements)
+    needs_replacements = [project_dimension_mapping_config, dimension_mapping_config]
+    replace_dimension_uuids_from_registry(tmp_path, needs_replacements)
 
-        dim_mapping_mgr.register(project_dimension_mapping_config, user, log_message)
-        dim_mapping_mgr.register(dimension_mapping_config, user, log_message)
+    dim_mapping_mgr.register(project_dimension_mapping_config, user, log_message)
+    dim_mapping_mgr.register(dimension_mapping_config, user, log_message)
 
-        needs_replacements = [project_config_file, dimension_mapping_refs]
-        replace_dimension_mapping_uuids_from_registry(base_dir, needs_replacements)
-        replace_dimension_uuids_from_registry(base_dir, (project_config_file, dataset_config_file))
+    needs_replacements = [project_config_file, dimension_mapping_refs]
+    replace_dimension_mapping_uuids_from_registry(tmp_path, needs_replacements)
+    replace_dimension_uuids_from_registry(tmp_path, (project_config_file, dataset_config_file))
 
-        manager.project_manager.register(project_config_file, user, "register project")
-        dataset_path = TEST_DATASET_DIRECTORY / dataset_id
-        manager.dataset_manager.register(
-            dataset_config_file, dataset_path, user, "register dataset"
-        )
-        manager.project_manager.submit_dataset(
-            project_id,
-            dataset_id,
-            user,
-            log_message,
-            dimension_mapping_references_file=dimension_mapping_refs,
-        )
+    manager.project_manager.register(project_config_file, user, "register project")
+    dataset_path = TEST_DATASET_DIRECTORY / dataset_id
+    manager.dataset_manager.register(dataset_config_file, dataset_path, user, "register dataset")
+    manager.project_manager.submit_dataset(
+        project_id,
+        dataset_id,
+        user,
+        log_message,
+        dimension_mapping_references_file=dimension_mapping_refs,
+    )
 
-        assert manager.dimension_manager.list_ids()
-        assert manager.dimension_mapping_manager.list_ids()
-        assert manager.project_manager.list_ids() == [project_id]
-        assert manager.dataset_manager.list_ids() == [dataset_id]
+    assert manager.dimension_manager.list_ids()
+    assert manager.dimension_mapping_manager.list_ids()
+    assert manager.project_manager.list_ids() == [project_id]
+    assert manager.dataset_manager.list_ids() == [dataset_id]
 
 
 def register_project(project_mgr, config_file, project_id, user, log_message):
@@ -416,7 +398,7 @@ def register_dataset(dataset_mgr, config_file, dataset_id, user, log_message):
     assert dataset_mgr.list_ids() == [dataset_id]
 
 
-def check_update_project_dimension(tmpdir, manager, dataset_id):
+def check_update_project_dimension(tmpdir, manager):
     """Verify that updating a project's dimension causes all datasets to go unregistered."""
     project_mgr = manager.project_manager
     project_id = project_mgr.list_ids()[0]
@@ -424,7 +406,7 @@ def check_update_project_dimension(tmpdir, manager, dataset_id):
     dimension_id = dimension_mgr.list_ids()[0]
     user = getpass.getuser()
 
-    dim_dir = Path(tmpdir) / "new_dimension"
+    dim_dir = tmpdir / "new_dimension"
     dim_config_file = dim_dir / dimension_mgr.registry_class().config_filename()
     dimension_mgr.dump(dimension_id, dim_dir, force=True)
     dim_data = load_data(dim_config_file)
@@ -438,7 +420,7 @@ def check_update_project_dimension(tmpdir, manager, dataset_id):
         "update to description",
         dimension_mgr.get_current_version(dimension_id),
     )
-    project_dir = Path(tmpdir) / "new_project"
+    project_dir = tmpdir / "new_project"
     project_config_file = project_dir / project_mgr.registry_class().config_filename()
     project_mgr.dump(project_id, project_dir, force=True)
     project_data = load_data(project_config_file)

--- a/tests/test_tempo_registration.py
+++ b/tests/test_tempo_registration.py
@@ -2,7 +2,6 @@ import getpass
 import logging
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -22,18 +21,17 @@ logger = logging.getLogger()
 
 # This is disabled because the test data is not finalized.
 @pytest.mark.skip
-def test_register_project_and_dataset(make_standard_scenarios_project_dir):
-    with TemporaryDirectory() as _:
-        pass
-        # base_dir = Path(tmpdir)
-        # manager = make_registry_for_tempo(
-        #     base_dir, make_standard_scenarios_project_dir, TEST_DATASET_DIRECTORY
-        # )
-        # TODO: not working yet
-        # dataset_mgr = manager.dataset_manager
-        # config_ids = dataset_mgr.list_ids()
-        # assert len(config_ids) == 1
-        # assert config_ids[0] == "tempo_standard_scenarios_2021"
+def test_register_project_and_dataset(make_standard_scenarios_project_dir, tmp_path):
+    pass
+    # base_dir = Path(tmpdir)
+    # manager = make_registry_for_tempo(
+    #     base_dir, make_standard_scenarios_project_dir, TEST_DATASET_DIRECTORY
+    # )
+    # TODO: not working yet
+    # dataset_mgr = manager.dataset_manager
+    # config_ids = dataset_mgr.list_ids()
+    # assert len(config_ids) == 1
+    # assert config_ids[0] == "tempo_standard_scenarios_2021"
 
 
 def make_registry_for_tempo(registry_path, src_dir, dataset_path=None) -> RegistryManager:

--- a/tests/test_trivial_dimensions.py
+++ b/tests/test_trivial_dimensions.py
@@ -7,37 +7,32 @@ from dsgrid.tests.common import (
 )
 from dsgrid.tests.make_us_data_registry import make_test_data_registry
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
-
-def test_trivial_dimension_bad(make_test_project_dir, make_test_data_dir):
+def test_trivial_dimension_bad(make_test_project_dir, make_test_data_dir, tmp_path):
     """Test bad trivial dimensions where county geography is set to trivial"""
-    with TemporaryDirectory() as tmpdir:
-        base_dir = Path(tmpdir)
-        manager = make_test_data_registry(
-            base_dir,
-            make_test_project_dir,
-            include_projects=False,
-            include_datasets=False,
+    manager = make_test_data_registry(
+        tmp_path,
+        make_test_project_dir,
+        include_projects=False,
+        include_datasets=False,
+    )
+    project_config_file = make_test_project_dir / "project.toml"
+    manager.project_manager.register(project_config_file, "user", "log")
+
+    dataset_dir = make_test_project_dir / "datasets" / "modeled" / "comstock"
+    assert dataset_dir.exists()
+    dataset_config_file = dataset_dir / "dataset.toml"
+    replace_dimension_uuids_from_registry(tmp_path, (dataset_config_file,))
+
+    config = load_data(dataset_config_file)
+    config["trivial_dimensions"] = config["trivial_dimensions"] + ["geography"]
+    dump_data(config, dataset_config_file)
+    dataset_path = make_test_data_dir / config["dataset_id"]
+
+    with pytest.raises(DSGInvalidDimension):
+        manager.dataset_manager.register(
+            config_file=dataset_config_file,
+            dataset_path=dataset_path,
+            submitter="test",
+            log_message="test",
         )
-        project_config_file = make_test_project_dir / "project.toml"
-        manager.project_manager.register(project_config_file, "user", "log")
-
-        dataset_dir = make_test_project_dir / "datasets" / "modeled" / "comstock"
-        assert dataset_dir.exists()
-        dataset_config_file = dataset_dir / "dataset.toml"
-        replace_dimension_uuids_from_registry(base_dir, (dataset_config_file,))
-
-        config = load_data(dataset_config_file)
-        config["trivial_dimensions"] = config["trivial_dimensions"] + ["geography"]
-        dump_data(config, dataset_config_file)
-        dataset_path = make_test_data_dir / config["dataset_id"]
-
-        with pytest.raises(DSGInvalidDimension):
-            manager.dataset_manager.register(
-                config_file=dataset_config_file,
-                dataset_path=dataset_path,
-                submitter="test",
-                log_message="test",
-            )


### PR DESCRIPTION
## Description
I noticed that pytest provides a fixture to manage temporary directories. This PR removes the temporary directories that we were creating in our tests. No functional changes.
