### PR TITLE
Check for case where datasets have invalid columns

### DIFF
--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -514,6 +514,15 @@ def submit_dataset(
     callback=_path_callback,
 )
 @click.option(
+    "-r",
+    "--dimension-mapping-references-file",
+    type=click.Path(exists=True),
+    show_default=True,
+    help="dimension mapping references file. Mutually exclusive with dimension_mapping_file. "
+    "Use it when the mappings are already registered.",
+    callback=_path_callback,
+)
+@click.option(
     "-a",
     "--autogen-reverse-supplemental-mappings",
     type=click.Choice([x.value for x in DimensionType]),
@@ -543,6 +552,7 @@ def register_and_submit_dataset(
     dataset_config_file,
     dataset_path,
     dimension_mapping_file,
+    dimension_mapping_references_file,
     autogen_reverse_supplemental_mappings,
     project_id,
     log_message,
@@ -557,6 +567,7 @@ def register_and_submit_dataset(
         submitter,
         log_message,
         dimension_mapping_file=dimension_mapping_file,
+        dimension_mapping_references_file=dimension_mapping_references_file,
         autogen_reverse_supplemental_mappings=autogen_reverse_supplemental_mappings,
     )
 

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -112,15 +112,15 @@ class DatasetSchemaHandlerBase(abc.ABC):
         return sorted(list(self._config.get_dimension(dim_type).get_unique_ids()))
 
     @track_timing(timer_stats_collector)
-    def get_pivoted_dimension_columns_mapped_to_project(self):
+    def get_pivoted_dimension_columns_mapped_to_project(self) -> set[str]:
         """Get columns for the dimension that is pivoted in load_data and remap them to the
-        project's record names. The returned dict will not include columns that the project does
+        project's record names. The returned set will not include columns that the project does
         not care about.
 
         Returns
         -------
-        dict
-            Mapping of pivoted dimension column names to project record names.
+        set
+            Pivoted dimension column names as defined by the project
 
         """
         columns = set(self.get_pivoted_dimension_columns())

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -130,17 +130,16 @@ class DatasetSchemaHandlerBase(abc.ABC):
                 mapping_config = self._dimension_mapping_mgr.get_by_id(
                     ref.mapping_id, version=ref.version
                 )
-                from_ids = set()
-                to_ids = set()
-                for record in mapping_config.model.records:
-                    if record.to_id is not None:
-                        from_ids.add(record.from_id)
-                        to_ids.add(record.to_id)
-
-                diff = from_ids.difference(columns)
+                records = mapping_config.get_records_dataframe()
+                from_ids = get_unique_values(records, "from_id")
+                to_ids = get_unique_values(
+                    records.select("to_id").filter("to_id IS NOT NULL"), "to_id"
+                )
+                diff = from_ids.symmetric_difference(columns)
                 if diff:
                     raise DSGInvalidDataset(
-                        f"Dimension_mapping={mapping_config.config_id} has more from_id records than the dataset pivoted {dim_type.value} dimension: {diff}"
+                        f"Dimension_mapping={mapping_config.config_id} does not have the same "
+                        f"record IDs as the dataset={self._config.config_id} columns: {diff}"
                     )
                 return to_ids
 

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -498,6 +498,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         submitter,
         log_message,
         dimension_mapping_file=None,
+        dimension_mapping_references_file=None,
         autogen_reverse_supplemental_mappings=None,
     ):
         context = RegistrationContext()
@@ -516,6 +517,7 @@ class ProjectRegistryManager(RegistryManagerBase):
                 submitter,
                 log_message,
                 dimension_mapping_file=dimension_mapping_file,
+                dimension_mapping_references_file=dimension_mapping_references_file,
                 autogen_reverse_supplemental_mappings=autogen_reverse_supplemental_mappings,
                 context=context,
             )

--- a/dsgrid/tests/register.py
+++ b/dsgrid/tests/register.py
@@ -64,6 +64,8 @@ def _run_registration(registration: RegistrationModel, tmp_files):
             project_mgr.register(project.config_file, user, log_message)
 
         for dataset in project.datasets:
+            refs_file = None
+            config_file = None
             if dataset.register_dataset:
                 if dataset.fix_dimension_uuids:
                     suffix = dataset.config_file.suffix
@@ -73,12 +75,6 @@ def _run_registration(registration: RegistrationModel, tmp_files):
                     replace_dimension_uuids_from_registry(reg_path, [config_file])
                 else:
                     config_file = dataset.config_file
-                dataset_mgr.register(
-                    config_file,
-                    dataset.dataset_path,
-                    user,
-                    log_message,
-                )
 
             if dataset.submit_to_project:
                 if (
@@ -98,6 +94,27 @@ def _run_registration(registration: RegistrationModel, tmp_files):
                     replace_dimension_mapping_uuids_from_registry(reg_path, [refs_file])
                 else:
                     refs_file = dataset.dimension_mapping_references_file
+
+            if dataset.register_dataset and dataset.submit_to_project:
+                # If something fails in the submit stage, dsgrid will delete the dataset.
+                project_mgr.register_and_submit_dataset(
+                    config_file,
+                    dataset.dataset_path,
+                    project.project_id,
+                    user,
+                    log_message,
+                    dimension_mapping_file=dataset.dimension_mapping_file,
+                    dimension_mapping_references_file=refs_file,
+                    autogen_reverse_supplemental_mappings=dataset.autogen_reverse_supplemental_mappings,
+                )
+            elif dataset.register_dataset:
+                dataset_mgr.register(
+                    config_file,
+                    dataset.dataset_path,
+                    user,
+                    log_message,
+                )
+            elif dataset.submit_to_project:
                 project_mgr.submit_dataset(
                     project.project_id,
                     dataset.dataset_id,


### PR DESCRIPTION
## Description

This fixes a bug where the code was not checking for the case where a dataset has pivoted
columns that are not defined in the project's dimension and not present
in the dataset dimension mapping record file. The bug resulted mapped dataframes with
invalid columns.
