### PR TITLE
Put restriction on numpy to fix pyspark

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ setup(
         "dash_bootstrap_components",
         "fastapi",
         "json5",
-        "numpy",
+        "numpy~=1.23.0",  # pyspark uses numpy.bool, which was removed in numpy 1.24
+                          # Remove this restriction when pyspark is fixed.
         "pandas",
         "prettytable",
         "pydantic",


### PR DESCRIPTION
All CI runs in PRs will fail until this is merged. Pyspark is using a numpy type that has been deleted.