### PR TITLE
Remove data_source as a project dimension

### DIFF
--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -12,7 +12,12 @@ from dsgrid.config.dimension_association_manager import (
     save_dimension_associations,
 )
 from dsgrid.data_models import DSGBaseModel, serialize_model_data
-from dsgrid.dimension.base_models import check_required_dimensions, check_timezone_in_geography
+from dsgrid.dimension.base_models import (
+    check_required_dimensions,
+    check_timezone_in_geography,
+    get_project_dimension_types,
+    DimensionType,
+)
 from dsgrid.exceptions import (
     DSGInvalidField,
     DSGInvalidDimension,
@@ -41,7 +46,6 @@ from .dimension_mapping_base import DimensionMappingReferenceModel
 from .mapping_tables import MappingTableByNameModel
 from .dimensions import (
     DimensionReferenceModel,
-    DimensionType,
     handle_dimension_union,
     DimensionModel,
 )
@@ -411,7 +415,6 @@ class _DimensionQueryNamesModel(DSGBaseModel):
 class ProjectDimensionQueryNamesModel(DSGBaseModel):
     """Defines the query names for all base and supplemental dimensions in the project."""
 
-    data_source: _DimensionQueryNamesModel
     geography: _DimensionQueryNamesModel
     metric: _DimensionQueryNamesModel
     model_year: _DimensionQueryNamesModel
@@ -633,7 +636,7 @@ class ProjectConfig(ConfigBase):
 
         """
         query_names = {}
-        for dimension_type in DimensionType:
+        for dimension_type in get_project_dimension_types():
             dim = self.get_base_dimension(dimension_type)
             query_names[dimension_type] = dim.model.dimension_query_name
         return query_names
@@ -661,7 +664,7 @@ class ProjectConfig(ConfigBase):
         base_query_names_by_type = self.get_base_dimension_to_query_name_mapping()
         supp_query_names_by_type = self.get_supplemental_dimension_to_query_name_mapping()
         model = {}
-        for dimension_type in DimensionType:
+        for dimension_type in get_project_dimension_types():
             model[dimension_type.value] = {
                 "base": base_query_names_by_type[dimension_type],
                 "supplemental": supp_query_names_by_type[dimension_type],

--- a/dsgrid/dataset/growth_rates.py
+++ b/dsgrid/dataset/growth_rates.py
@@ -3,7 +3,6 @@ import logging
 import pyspark.sql.functions as F
 from pyspark.sql.types import IntegerType
 
-from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import DSGInvalidQuery
 from dsgrid.query.models import ExponentialGrowthDatasetModel
 from dsgrid.utils.spark import get_unique_values
@@ -52,14 +51,6 @@ def apply_growth_rate_123(
         ).drop(column)
 
     dim_columns = set(initial_value_df.columns) - pivoted_columns - time_columns
-    # TODO #185: data_source needs some thought. They are different in these two dfs.
-    # And this should be dimension_query_name instead of dimension type
-    # What is the data_source of the resulting df?
-    if DimensionType.DATA_SOURCE.value in dim_columns:
-        dim_columns.remove(DimensionType.DATA_SOURCE.value)
-    if DimensionType.DATA_SOURCE.value in gr_df.columns:
-        gr_df = gr_df.drop(DimensionType.DATA_SOURCE.value)
-
     df = initial_value_df.join(gr_df, on=list(dim_columns))
     for column in df.columns:
         if column in pivoted_columns:

--- a/dsgrid/dataset/pivoted_table.py
+++ b/dsgrid/dataset/pivoted_table.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pyspark.sql.functions as F
 
-from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.base_models import get_project_dimension_types
 from dsgrid.exceptions import DSGInvalidParameter
 from dsgrid.query.models import AggregationModel
 from dsgrid.query.query_context import QueryContext
@@ -186,7 +186,9 @@ class PivotedTableHandler(TableFormatHandlerBase):
                 "Aggregated dimensions with groupBy %s and agg %s", group_by_cols, agg_expr
             )
 
-        final_query_names = {x: set() for x in DimensionType if x != pivoted_dimension_type}
+        final_query_names = {
+            x: set() for x in get_project_dimension_types() if x != pivoted_dimension_type
+        }
         for column in group_by_query_names:
             dim = self.project_config.get_dimension(column)
             final_query_names[dim.model.dimension_type].add(column)

--- a/dsgrid/dimension/base_models.py
+++ b/dsgrid/dimension/base_models.py
@@ -34,6 +34,11 @@ class DimensionType(DSGEnum):
             )
 
 
+def get_project_dimension_types() -> set[DimensionType]:
+    """Return the types that must be present in a dataset for operation with a project."""
+    return {x for x in DimensionType if x != DimensionType.DATA_SOURCE}
+
+
 class DimensionRecordBaseModel(DSGBaseModel):
     """Base class for all dsgrid dimension models"""
 

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -8,7 +8,7 @@ from semver import VersionInfo
 
 from dsgrid.data_models import DSGBaseModel
 
-from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.base_models import DimensionType, get_project_dimension_types
 from dsgrid.dimension.dimension_filters import make_dimension_filter, DimensionFilterBaseModel
 from dsgrid.utils.files import compute_hash
 
@@ -73,7 +73,6 @@ class DimensionQueryNamesModel(DSGBaseModel):
     If a value is empty, that dimension will be aggregated and dropped from the table.
     """
 
-    data_source: List[Union[str, ColumnModel]]
     geography: List[Union[str, ColumnModel]]
     metric: List[Union[str, ColumnModel]]
     model_year: List[Union[str, ColumnModel]]
@@ -85,7 +84,7 @@ class DimensionQueryNamesModel(DSGBaseModel):
 
     @root_validator
     def fix_columns(cls, values):
-        for dim_type in DimensionType:
+        for dim_type in get_project_dimension_types():
             field = dim_type.value
             container = values[field]
             for i, item in enumerate(container):
@@ -146,7 +145,6 @@ class TableFormatType(enum.Enum):
 class DatasetDimensionsMetadataModel(DSGBaseModel):
     """Defines the dimensions of a dataset serialized to file."""
 
-    data_source: Set[str] = set()
     geography: Set[str] = set()
     metric: Set[str] = set()
     model_year: Set[str] = set()

--- a/dsgrid/query/query_context.py
+++ b/dsgrid/query/query_context.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.base_models import DimensionType, get_project_dimension_types
 from dsgrid.utils.spark import get_spark_session
 from .models import QueryBaseModel, DatasetMetadataModel, TableFormatType
 
@@ -31,7 +31,7 @@ class QueryContext:
         return self._model
 
     def consolidate_dataset_metadata(self):
-        for dim_type in DimensionType:
+        for dim_type in get_project_dimension_types():
             field = dim_type.value
             getattr(self._metadata.dimensions, field).clear()
             for dataset_metadata in self._dataset_metadata.values():
@@ -98,7 +98,7 @@ class QueryContext:
 
     def get_all_dimension_query_names(self):
         names = set()
-        for dimension_type in DimensionType:
+        for dimension_type in get_project_dimension_types():
             names.update(getattr(self._metadata.dimensions, dimension_type.value))
         return names
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -113,7 +113,7 @@ def test_dimension_map_and_reduce_in_dataset():
     assert "fraction" in mapped_load_data_lookup.columns
 
     # * this check is specific to the actual from_fraction values specified in the mapping *
-    data_filters = "data_source=='comstock' and subsector=='Warehouse' and model_year=='2050'"
+    data_filters = "sector=='com' and subsector=='Warehouse' and model_year=='2050'"
     fraction = [
         row.fraction
         for row in mapped_load_data_lookup.filter(data_filters)

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.base_models import get_project_dimension_types
 from dsgrid.exceptions import DSGValueNotRegistered
 from dsgrid.utils.files import load_data
 from dsgrid.config.project_config import ProjectConfigModel, ProjectDimensionQueryNamesModel
@@ -64,6 +64,6 @@ def test_project_duplicate_type(config_as_dict, dimension_manager):
 
 
 def test_project_dimension_query_names_model():
-    assert not {x.value for x in DimensionType}.difference(
+    assert not {x.value for x in get_project_dimension_types()}.difference(
         ProjectDimensionQueryNamesModel.__fields__
     )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -11,7 +11,7 @@ from pyspark.sql.types import DoubleType, IntegerType, StringType, StructField, 
 import pytest
 from pyspark.sql import SparkSession
 
-from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.base_models import DimensionType, get_project_dimension_types
 from dsgrid.dimension.dimension_filters import (
     DimensionFilterExpressionModel,
     DimensionFilterColumnOperatorModel,
@@ -128,7 +128,6 @@ def test_peak_load():
 def test_invalid_drop_pivoted_dimension(tmp_path):
     invalid_agg = AggregationModel(
         dimensions=DimensionQueryNamesModel(
-            data_source=["data_source"],
             geography=["county"],
             metric=[],
             model_year=["model_year"],
@@ -224,7 +223,7 @@ def test_query_cli_run(tmp_path):
 
 def test_dimension_query_names_model():
     # Test that this model is defined with all dimension types.
-    diff = {x.value for x in DimensionType}.symmetric_difference(
+    diff = {x.value for x in get_project_dimension_types()}.symmetric_difference(
         set(DimensionQueryNamesModel.__fields__)
     )
     assert not diff
@@ -508,7 +507,6 @@ class QueryTestElectricityUse(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=[],
                             geography=[self._geography],
                             metric=["electricity"],
                             model_year=[],
@@ -582,7 +580,6 @@ class QueryTestElectricityUseFilterResults(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=[],
                             geography=[self._geography],
                             metric=["electricity"],
                             model_year=[],
@@ -669,7 +666,6 @@ class QueryTestTotalElectricityUseWithFilter(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=[],
                             geography=["county"],
                             metric=["electricity"],
                             model_year=[],
@@ -728,7 +724,6 @@ class QueryTestDiurnalElectricityUseByCountyChained(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=["data_source"],
                             geography=["county"],
                             metric=["electricity"],
                             model_year=["model_year"],
@@ -742,7 +737,6 @@ class QueryTestDiurnalElectricityUseByCountyChained(QueryTestBase):
                     ),
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=[],
                             geography=["county"],
                             metric=["electricity"],
                             model_year=[],
@@ -811,7 +805,6 @@ class QueryTestElectricityUseByStateAndPCA(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=["data_source"],
                             geography=["state", "reeds_pca", "census_region"],
                             metric=["electricity"],
                             model_year=["model_year"],
@@ -868,7 +861,6 @@ class QueryTestPeakLoadByStateSubsector(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=["data_source"],
                             geography=["state"],
                             metric=["electricity"],
                             model_year=["model_year"],
@@ -998,7 +990,6 @@ class QueryTestElectricityValuesCompositeDatasetAgg(QueryTestBase):
                 aggregations=[
                     AggregationModel(
                         dimensions=DimensionQueryNamesModel(
-                            data_source=[],
                             geography=[self._geography],
                             metric=["electricity"],
                             model_year=[],


### PR DESCRIPTION
This PR is the outcome of today's conversation. I don't like it very much. I think a better approach would be to remove `DATA_SOURCE` as a member of `DimensionType`. `data_source` is already a field in `DatasetConfigModel`, which may meet all requirements.