### PR TITLE
Skip no-op mappings

### DIFF
--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -12,6 +12,7 @@ from dsgrid.exceptions import DSGInvalidDataset, DSGInvalidQuery
 from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.query.query_context import QueryContext
 from dsgrid.utils.dataset import (
+    is_noop_mapping,
     map_and_reduce_stacked_dimension,
     map_and_reduce_pivoted_dimension,
     add_time_zone,
@@ -322,6 +323,9 @@ class DatasetSchemaHandlerBase(abc.ABC):
                     filtered_records[dim_type], on=records.to_id == filtered_records[dim_type].id
                 ).drop("id")
 
+            if is_noop_mapping(records):
+                logger.info("Skip no-op mapping %s.", ref.mapping_id)
+                continue
             if column in df.columns:
                 df = map_and_reduce_stacked_dimension(df, records, column)
             elif (

--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 # from typing import List
 
+import pyspark
 import pyspark.sql.functions as F
 
 from dsgrid.exceptions import DSGInvalidField, DSGInvalidDimensionMapping
@@ -159,6 +160,13 @@ def check_null_value_in_unique_dimension_rows(dim_table, exclude_columns=None):
             "Combination of remapped dataset dimensions contain NULL value(s) for "
             f"dimension(s): \n{str(exc)}"
         )
+
+
+def is_noop_mapping(records: pyspark.sql.DataFrame) -> bool:
+    """Return True if the mapping is a no-op."""
+    return records.filter(
+        (records.from_id != records.to_id) | (records.from_fraction != 1.0)
+    ).rdd.isEmpty()
 
 
 def ordered_subset_columns(df, subset: set[str]) -> list[str]:


### PR DESCRIPTION
This significantly reduces the amount of work Spark has to perform when mapping our derived datasets to the project.