### PR TITLE
Remove null-timestamp rows that are obsolete after aggregations

### DIFF
--- a/dsgrid/dataset/pivoted_table.py
+++ b/dsgrid/dataset/pivoted_table.py
@@ -6,7 +6,11 @@ import pyspark.sql.functions as F
 
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import DSGInvalidParameter
-from dsgrid.query.models import AggregationModel
+from dsgrid.query.models import (
+    AggregationModel,
+    DatasetDimensionsMetadataModel,
+    DimensionMetadataModel,
+)
 from dsgrid.query.query_context import QueryContext
 from dsgrid.utils.dataset import map_and_reduce_pivoted_dimension, remove_invalid_null_timestamps
 from dsgrid.utils.spark import get_unique_values
@@ -63,8 +67,10 @@ class PivotedTableHandler(TableFormatHandlerBase):
                     .drop("from_id")
                     .withColumnRenamed("to_id", query_name)
                 )
-                context.add_dimension_query_name(
-                    supp_dim.model.dimension_type, query_name, dataset_id=self.dataset_id
+                context.add_dimension_metadata(
+                    supp_dim.model.dimension_type,
+                    DimensionMetadataModel(dimension_query_name=query_name),
+                    dataset_id=self.dataset_id,
                 )
 
         return df
@@ -81,7 +87,7 @@ class PivotedTableHandler(TableFormatHandlerBase):
             # Those rows could be obsolete after aggregating stacked dimensions.
             # This is an expensive operation, so only do it if the dataframe changed.
             pivoted_columns = context.get_pivoted_columns()
-            time_columns = context.get_dimension_query_names(DimensionType.TIME)
+            time_columns = context.get_dimension_column_names(DimensionType.TIME)
             if time_columns:
                 stacked_columns = set(df.columns) - pivoted_columns.union(time_columns)
                 df = remove_invalid_null_timestamps(df, time_columns, stacked_columns)
@@ -119,7 +125,7 @@ class PivotedTableHandler(TableFormatHandlerBase):
                 # dimension or if this pivoted column has already been handled.
                 if (
                     query_name not in base_query_names
-                    and query_name not in context.get_dimension_query_names(pivoted_dim_type)
+                    and query_name not in context.get_dimension_column_names(pivoted_dim_type)
                 ):
                     if column.function is not None:
                         # TODO: Do we need to support this?
@@ -141,8 +147,10 @@ class PivotedTableHandler(TableFormatHandlerBase):
                 agg.aggregation_function.__name__,
                 rename=False,
             )
-            context.replace_dimension_query_names(
-                dim_config.model.dimension_type, {dimension_query_name}, dataset_id=self.dataset_id
+            context.replace_dimension_metadata(
+                dim_config.model.dimension_type,
+                [DimensionMetadataModel(dimension_query_name=dimension_query_name)],
+                dataset_id=self.dataset_id,
             )
             pivoted_columns -= dropped_columns
             logger.info("Replaced dimensions with supplemental records %s", new_pivoted_columns)
@@ -173,7 +181,7 @@ class PivotedTableHandler(TableFormatHandlerBase):
 
         pivoted_dimension_type = context.get_pivoted_dimension_type(dataset_id=self.dataset_id)
         pivoted_columns = set(context.get_pivoted_columns(dataset_id=self.dataset_id))
-        final_query_names = {x: set() for x in DimensionType if x != pivoted_dimension_type}
+        final_query_names = DatasetDimensionsMetadataModel()
         column_to_dim_type = {}
         dropped_dimensions = set()
         for agg in aggregations:
@@ -196,8 +204,13 @@ class PivotedTableHandler(TableFormatHandlerBase):
                 if not isinstance(expr, str) or expr != column.dimension_query_name:
                     # In this case we are replacing any existing query name with an expression
                     # or alias, and so the old name must be removed.
-                    final_query_names[dim_type].discard(column.dimension_query_name)
-                final_query_names[dim_type].add(name)
+                    final_query_names.remove_metadata(dim_type, column.dimension_query_name)
+                final_query_names.add_metadata(
+                    dim_type,
+                    DimensionMetadataModel(
+                        dimension_query_name=column.dimension_query_name, column_name=name
+                    ),
+                )
                 group_by_cols.append(expr)
 
             op = agg.aggregation_function
@@ -207,11 +220,11 @@ class PivotedTableHandler(TableFormatHandlerBase):
                 "Aggregated dimensions with groupBy %s and agg %s", group_by_cols, agg_expr
             )
 
-        for dim_type, columns in final_query_names.items():
-            if dim_type in dropped_dimensions and columns:
-                columns = set()
-            assert not columns.difference(df.columns), f"{columns=} {df.columns=}"
-            context.replace_dimension_query_names(dim_type, columns, dataset_id=self.dataset_id)
+        for dim_type in DimensionType:
+            metadata = final_query_names.get_metadata(dim_type)
+            if dim_type in dropped_dimensions and metadata:
+                metadata = []
+            context.replace_dimension_metadata(dim_type, metadata, dataset_id=self.dataset_id)
         return df
 
     @staticmethod

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -164,7 +164,7 @@ class Project:
         match context.model.result.column_type:
             case ColumnType.DIMENSION_QUERY_NAMES:
                 dim_columns = context.get_all_dimension_query_names()
-                time_columns = context.get_dimension_query_names(DimensionType.TIME)
+                time_columns = context.get_dimension_column_names(DimensionType.TIME)
             case ColumnType.DIMENSION_TYPES:
                 dim_columns = {x.value for x in DimensionType if x != DimensionType.TIME}
                 tcols = context.get_dimension_query_names(DimensionType.TIME)
@@ -328,7 +328,7 @@ class Project:
                         f"BUG: unhandled column type {context.model.result.column_type}"
                     )
             names = list(
-                context.get_dimension_query_names(DimensionType.MODEL_YEAR, dataset_id=dataset_id)
+                context.get_dimension_column_names(DimensionType.MODEL_YEAR, dataset_id=dataset_id)
             )
             assert len(names) == 1, f"{dataset_id=} {names=}"
             return names[0]
@@ -356,7 +356,7 @@ class Project:
             )
         match context.model.result.column_type:
             case ColumnType.DIMENSION_QUERY_NAMES:
-                time_columns = context.get_dimension_query_names(
+                time_columns = context.get_dimension_column_names(
                     DimensionType.TIME, dataset_id=dataset.initial_value_dataset_id
                 )
             case ColumnType.DIMENSION_TYPES:

--- a/dsgrid/query/derived_dataset.py
+++ b/dsgrid/query/derived_dataset.py
@@ -71,7 +71,7 @@ def create_derived_dataset_config_from_query(
     base_dim_query_names = project.config.get_base_dimension_query_names()
     num_new_supplemental_dimensions = 0
     for dim_type in DimensionType:
-        dimension_query_names = getattr(metadata.dimensions, dim_type.value)
+        dimension_query_names = metadata.dimensions.get_dimension_query_names(dim_type)
         assert len(dimension_query_names) == 1, dimension_query_names
         dim_query_name = next(iter(dimension_query_names))
         dim = project.config.get_dimension(dim_query_name)

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -190,7 +190,9 @@ class DatasetDimensionsMetadataModel(DSGBaseModel):
         """Return the dimension metadata."""
         return getattr(self, dimension_type.value)
 
-    def replace_metadata(self, dimension_type: DimensionType, metadata: DimensionMetadataModel):
+    def replace_metadata(
+        self, dimension_type: DimensionType, metadata: list[DimensionMetadataModel]
+    ):
         """Replace the dimension metadata."""
         setattr(self, dimension_type.value, metadata)
 

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -126,6 +126,14 @@ class AggregationModel(DSGBaseModel):
             for val in getattr(self.dimensions, field):
                 yield DimensionType(field), val
 
+    def list_dropped_dimensions(self):
+        """Return a list of dimension types that will be dropped by the aggregation."""
+        return [
+            DimensionType(x)
+            for x in DimensionQueryNamesModel.__fields__
+            if not getattr(self.dimensions, x)
+        ]
+
 
 class ReportType(enum.Enum):
     """Pre-defined reports"""

--- a/dsgrid/query/query_context.py
+++ b/dsgrid/query/query_context.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 
 from dsgrid.dimension.base_models import DimensionType
+from dsgrid.query.models import DimensionMetadataModel
 from dsgrid.utils.spark import get_spark_session
 from .models import ProjectQueryModel, DatasetMetadataModel, TableFormatType
 
@@ -32,12 +33,15 @@ class QueryContext:
 
     def consolidate_dataset_metadata(self):
         for dim_type in DimensionType:
-            field = dim_type.value
-            getattr(self._metadata.dimensions, field).clear()
+            main_metadata = self._metadata.dimensions.get_metadata(dim_type)
+            main_metadata.clear()
+            keys = set()
             for dataset_metadata in self._dataset_metadata.values():
-                getattr(self._metadata.dimensions, field).update(
-                    getattr(dataset_metadata.dimensions, field)
-                )
+                for metadata in dataset_metadata.dimensions.get_metadata(dim_type):
+                    key = metadata.make_key()
+                    if key not in keys:
+                        main_metadata.append(metadata)
+                        keys.add(key)
 
         self._metadata.pivoted.columns.clear()
         for dataset_metadata in self._dataset_metadata.values():
@@ -50,56 +54,42 @@ class QueryContext:
                     # TODO #202: Remove this check when we support transforming to long format.
                     raise Exception(
                         "Datasets have different pivoted dimension types: "
-                        f"{dataset_metadata.pivoted.dimension_type} {self.get_pivoted_dimension_type()}"
+                        f"{dataset_metadata.pivoted.dimension_type} "
+                        f"{self.get_pivoted_dimension_type()}"
                     )
 
     def get_pivoted_columns(self, dataset_id=None):
-        if dataset_id is None:
-            return self._metadata.pivoted.columns
-        return self._dataset_metadata[dataset_id].pivoted.columns
+        return self._get_metadata(dataset_id).pivoted.columns
 
     def set_pivoted_columns(self, columns, dataset_id=None):
-        if dataset_id is None:
-            self._metadata.pivoted.columns = columns
-        else:
-            self._dataset_metadata[dataset_id].pivoted.columns = columns
+        self._get_metadata(dataset_id).pivoted.columns = columns
         logger.info("Set pivoted columns dataset_id=%s: %s", dataset_id, columns)
 
     def add_pivoted_columns(self, columns, dataset_id=None):
-        if dataset_id is None:
-            self._metadata.pivoted.columns.update(columns)
-        else:
-            self._dataset_metadata[dataset_id].pivoted.columns.update(columns)
+        self._get_metadata(dataset_id).pivoted.columns.update(columns)
 
     def get_pivoted_dimension_type(self, dataset_id=None):
-        if dataset_id is None:
-            return self._metadata.pivoted.dimension_type
-        return self._dataset_metadata[dataset_id].pivoted.dimension_type
+        return self._get_metadata(dataset_id).pivoted.dimension_type
 
     def set_pivoted_dimension_type(self, val, dataset_id=None):
-        if dataset_id is None:
-            self._metadata.pivoted.dimension_type = val
-        else:
-            self._dataset_metadata[dataset_id].pivoted.dimension_type = val
+        self._get_metadata(dataset_id).pivoted.dimension_type = val
 
     def get_table_format_type(self, dataset_id=None):
-        if dataset_id is None:
-            return self._metadata.table_format_type
-        return self._dataset_metadata[dataset_id].table_format_type
+        return self._get_metadata(dataset_id).table_format_type
 
     def set_table_format_type(self, val, dataset_id=None):
-        if dataset_id is None:
-            self._metadata.table_format_type = val
-        else:
-            self._dataset_metadata[dataset_id].table_format_type = val
+        self._get_metadata(dataset_id).table_format_type = val
+
+    def get_dimension_column_names(self, dimension_type: DimensionType, dataset_id=None):
+        return self._get_metadata(dataset_id).dimensions.get_column_names(dimension_type)
 
     def get_dimension_query_names(self, dimension_type: DimensionType, dataset_id=None):
-        return self._get_dimension_query_name_container(dimension_type, dataset_id=dataset_id)
+        return self._get_metadata(dataset_id).dimensions.get_dimension_query_names(dimension_type)
 
     def get_all_dimension_query_names(self):
         names = set()
         for dimension_type in DimensionType:
-            names.update(getattr(self._metadata.dimensions, dimension_type.value))
+            names.update(self._metadata.dimensions.get_dimension_query_names(dimension_type))
         return names
 
     def set_dataset_metadata(
@@ -115,10 +105,9 @@ class QueryContext:
         self.set_pivoted_dimension_type(pivoted_dimension_type, dataset_id=dataset_id)
         self.set_table_format_type(table_format_type, dataset_id=dataset_id)
         for dim_type, name in project_config.get_base_dimension_to_query_name_mapping().items():
-            self.add_dimension_query_name(dim_type, name, dataset_id=dataset_id)
-
-    def get_dataset_metadata(self, dataset_id):
-        return self._dataset_metadata[dataset_id]
+            self.add_dimension_metadata(
+                dim_type, DimensionMetadataModel(dimension_query_name=name), dataset_id=dataset_id
+            )
 
     def init_dataset_metadata(self, dataset_id):
         self._dataset_metadata[dataset_id] = DatasetMetadataModel()
@@ -130,48 +119,35 @@ class QueryContext:
         assert dataset_id not in self._dataset_metadata, dataset_id
         self._dataset_metadata[dataset_id] = DatasetMetadataModel.from_file(filename)
 
-    def add_dimension_query_name(
-        self, dimension_type: DimensionType, dimension_query_name, dataset_id=None
+    def add_dimension_metadata(
+        self,
+        dimension_type: DimensionType,
+        dimension_metadata: DimensionMetadataModel,
+        dataset_id=None,
     ):
-        container = self._get_dimension_query_name_container(dimension_type, dataset_id=dataset_id)
-        if dimension_query_name not in container:
-            container.add(dimension_query_name)
-            logger.debug(
-                "Added dimension query name for %s: %s dataset_id=%s",
-                dimension_type,
-                dimension_query_name,
-                dataset_id,
-            )
-
-    def remove_dimension_query_name(
-        self, dimension_type: DimensionType, dimension_query_name, dataset_id=None
-    ):
-        container = self._get_dimension_query_name_container(dimension_type, dataset_id=dataset_id)
-        container.remove(dimension_query_name)
-        logger.info(
-            "Removed dimension query name for %s: %s", dimension_type, dimension_query_name
-        )
-
-    def replace_dimension_query_names(
-        self, dimension_type: DimensionType, dimension_query_names, dataset_id=None
-    ):
-        field = dimension_type.value
-        if dataset_id is None:
-            setattr(self._metadata.dimensions, field, dimension_query_names)
-        else:
-            setattr(self._dataset_metadata[dataset_id].dimensions, field, dimension_query_names)
-        logger.info(
-            "Replaced dimension for %s: %s dataset_id=%s",
+        self._get_metadata(dataset_id).dimensions.add_metadata(dimension_type, dimension_metadata)
+        logger.debug(
+            "Added dimension query name for %s: %s dataset_id=%s",
             dimension_type,
-            dimension_query_names,
+            dimension_metadata,
             dataset_id,
         )
 
-    def _get_dimension_query_name_container(self, dimension_type: DimensionType, dataset_id=None):
-        field = dimension_type.value
-        if dataset_id is None:
-            return getattr(self._metadata.dimensions, field)
-        return getattr(self._dataset_metadata[dataset_id].dimensions, field)
+    def replace_dimension_metadata(
+        self, dimension_type: DimensionType, dimension_metadata, dataset_id=None
+    ):
+        self._get_metadata(dataset_id).dimensions.replace_metadata(
+            dimension_type, dimension_metadata
+        )
+        logger.info(
+            "Replaced dimension for %s: %s dataset_id=%s",
+            dimension_type,
+            dimension_metadata,
+            dataset_id,
+        )
+
+    def _get_metadata(self, dataset_id):
+        return self._metadata if dataset_id is None else self._dataset_metadata[dataset_id]
 
     def get_record_ids(self):
         spark = get_spark_session()

--- a/dsgrid/query/report_peak_load.py
+++ b/dsgrid/query/report_peak_load.py
@@ -43,7 +43,7 @@ class PeakLoadReport(ReportsBase):
         expr = [F.max(x).alias(x) for x in value_columns]
         peak_load = df.groupBy(*inputs.group_by_columns).agg(*expr)
         join_cols = inputs.group_by_columns + value_columns
-        time_columns = context.get_dimension_query_names(DimensionType.TIME)
+        time_columns = context.get_dimension_column_names(DimensionType.TIME)
         diff = time_columns.difference(df.columns)
         if diff:
             raise Exception(f"BUG: expected time column(s) {diff} are not present in table")

--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -172,3 +172,21 @@ def is_noop_mapping(records: pyspark.sql.DataFrame) -> bool:
 def ordered_subset_columns(df, subset: set[str]) -> list[str]:
     """Return a list of columns in the dataframe that are present in subset."""
     return [x for x in df.columns if x in subset]
+
+
+def remove_invalid_null_timestamps(df, time_columns, stacked_columns):
+    """Remove rows from the dataframe where the time column is NULL and other rows with the
+    same dimensions contain valid data.
+    """
+    assert len(time_columns) == 1, time_columns
+    time_column = next(iter(time_columns))
+    orig_columns = df.columns
+    stacked = list(stacked_columns)
+    return (
+        df.join(
+            df.groupBy(*stacked).agg(F.count_distinct(time_column).alias("count_time")),
+            on=stacked,
+        )
+        .filter(f"{time_column} IS NOT NULL or count_time == 0")
+        .select(orig_columns)
+    )

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -215,13 +215,6 @@ def test_remove_invalid_null_timestamps():
     stacked = ["county", "subsector"]
     time_col = "timestamp"
     result = remove_invalid_null_timestamps(df, {time_col}, stacked)
-    result = (
-        df.join(
-            df.groupBy(*stacked).agg(F.count_distinct(time_col).alias("count_time")), on=stacked
-        )
-        .filter(f"{time_col} IS NOT NULL or count_time == 0")
-        .drop("count_time")
-    )
     assert result.count() == 6
     assert result.filter("county == 'Boulder'").count() == 2
     assert result.filter(f"county == 'Boulder' and {time_col} is NULL").rdd.isEmpty()

--- a/tests/test_derived_datasets.py
+++ b/tests/test_derived_datasets.py
@@ -104,17 +104,18 @@ def test_create_derived_dataset_config(tmp_path):
     assert sorted(new_df.columns) == sorted(orig_df.columns)
     assert new_df.sort(*orig_df.columns).collect() == orig_df.sort(*orig_df.columns).collect()
 
-    # Create the config in the CLI and Python API to get pytest coverage stats in both places.
+    # Create the config in the CLI and Python API to get test coverage in both places.
     dataset_dir = tmp_path / dataset_id
-    check_run_command(
-        f"dsgrid query project create-derived-dataset-config --offline "
-        f"--registry-path={REGISTRY_PATH} {query_output} {dataset_dir} --force"
-    )
     dataset_config_file = dataset_dir / DatasetRegistry.config_filename()
-    assert dataset_config_file.exists()
-    shutil.rmtree(dataset_dir)
 
     registry_manager = RegistryManager.load(REGISTRY_PATH, offline_mode=True)
     dataset_dir.mkdir()
     assert create_derived_dataset_config_from_query(query_output, dataset_dir, registry_manager)
     assert dataset_config_file.exists()
+
+    check_run_command(
+        f"dsgrid query project create-derived-dataset-config --offline "
+        f"--registry-path={REGISTRY_PATH} {query_output} {dataset_dir} --force"
+    )
+    assert dataset_config_file.exists()
+    shutil.rmtree(dataset_dir)


### PR DESCRIPTION
This PR fixes two problems:
- A derived dataset like comstock_projected has rows with `time_est == null` to designate data that is supposed to be there but is expectedly missing. These are obsolete after dropping the sector and subsector dimensions, but weren't being dropped. Now they are.
- The first fix uncovered an existing problem where weren't properly tracking the column names in the table resulting from a query. This is more of a bandaid than a true fix. We are still treating the column names as "dimension_query_names" even though they are really just labels. One example of why this is still a problem is here: https://github.com/dsgrid/dsgrid/blob/466017cb7dc3bfba667e75019bea65ab3699f658/dsgrid/dataset/table_format_handler_base.py#L80 This function runs after all aggregations and allows users to say they want record names instead of IDs. Using actual dimension_query_names here is convenient. If they added `state` as a column, we can very easily look up the `state` supplemental dimension records. If the user says that they want to use an alias, this will break. We could track this with an additional layer of mappings. Let me know what you think. I'm not sure how much of a problem it is just yet. I could fix it now or defer to later. We could also remove the alias functionality and/or the replace-ids-with-names functionality.