### PR TITLE
Disable AWS tests

### DIFF
--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -8,6 +8,7 @@ from typing import Union, List, Dict
 
 from prettytable import PrettyTable
 
+from dsgrid.common import SYNC_EXCLUDE_LIST
 from dsgrid.config.dataset_config import DatasetConfig, ALLOWED_DATA_FILES
 from dsgrid.config.dataset_schema_handler_factory import make_dataset_schema_handler
 from dsgrid.config.dimensions_config import DimensionsConfig, DimensionsConfigModel
@@ -381,3 +382,36 @@ class DatasetRegistryManager(RegistryManagerBase):
         if return_table:
             return table
         display_table(table)
+
+    def sync_pull(self, path):
+        """Synchronizes files from the remote registry to local.
+        Deletes any files locally that do not exist on remote.
+
+        path : Path
+            Local path
+
+        """
+        remote_path = self.relative_remote_path(path)
+        self.cloud_interface.sync_pull(
+            remote_path, path, exclude=SYNC_EXCLUDE_LIST, delete_local=True
+        )
+
+    def sync_push(self, path):
+        """Synchronizes files from the local path to the remote registry.
+
+        path : Path
+            Local path
+
+        """
+        remote_path = self.relative_remote_path(path)
+        lock_file_path = self.get_registry_lock_file(path.name)
+        self.cloud_interface.check_lock_file(lock_file_path)
+        try:
+            self.cloud_interface.sync_push(
+                remote_path=remote_path, local_path=path, exclude=SYNC_EXCLUDE_LIST
+            )
+        except Exception:
+            logger.exception(
+                "Please report this error to the dsgrid team. The registry may need recovery."
+            )
+            raise

--- a/dsgrid/registry/dimension_mapping_registry_manager.py
+++ b/dsgrid/registry/dimension_mapping_registry_manager.py
@@ -390,10 +390,6 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
         new_key = ConfigKey(config.model.mapping_id, model.version)
         self._mappings.pop(old_key, None)
         self._mappings[new_key] = MappingTableConfig(model)
-
-        if not self.offline_mode:
-            self.sync_push(self._path)
-
         return model
 
     def remove(self, mapping_id):

--- a/dsgrid/registry/registry_manager_base.py
+++ b/dsgrid/registry/registry_manager_base.py
@@ -9,7 +9,6 @@ from typing import List
 
 from semver import VersionInfo
 
-from dsgrid.common import SYNC_EXCLUDE_LIST
 from dsgrid.exceptions import (
     DSGInvalidParameter,
     DSGValueNotRegistered,
@@ -423,36 +422,3 @@ class RegistryManagerBase(abc.ABC):
 
         """
         # TODO: Do we want to handle specific versions? This removes all configs.
-
-    def sync_pull(self, path):
-        """Synchronizes files from the remote registry to local.
-        Deletes any files locally that do not exist on remote.
-
-        path : Path
-            Local path
-
-        """
-        remote_path = self.relative_remote_path(path)
-        self.cloud_interface.sync_pull(
-            remote_path, path, exclude=SYNC_EXCLUDE_LIST, delete_local=True
-        )
-
-    def sync_push(self, path):
-        """Synchronizes files from the local path to the remote registry.
-
-        path : Path
-            Local path
-
-        """
-        remote_path = self.relative_remote_path(path)
-        lock_file_path = self.get_registry_lock_file(path.name)
-        self.cloud_interface.check_lock_file(lock_file_path)
-        try:
-            self.cloud_interface.sync_push(
-                remote_path=remote_path, local_path=path, exclude=SYNC_EXCLUDE_LIST
-            )
-        except Exception:
-            logger.exception(
-                "Please report this error to the dsgrid team. The registry may need recovery."
-            )
-            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [tool.black]
 line-length = 99
 target-version = ['py310']
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra"
+testpaths = [
+    "tests",
+]


### PR DESCRIPTION
Changes:
- File syncing only applies to datasets now. Fix this in the code. (There is no solution for db syncing yet.)
- Set the default tests directory for pytest. Exclude `tests_aws` since they are non-functional.