### PR TITLE
Update docs on installation and browsing the registry.

### DIFF
--- a/docs/source/how_tos/browse_registry.rst
+++ b/docs/source/how_tos/browse_registry.rst
@@ -7,7 +7,10 @@ CLI
 
 List Registry Components
 -------------------------
-You can list components by type: projects, datasets, dimensions, dimension mappings.
+
+Assuming you have already :ref:`configured dsgrid <configure_dsgrid>` to point to the right 
+database (URL and name), you can list components by type: projects, datasets, dimensions, dimension 
+mappings:
 
 .. code-block:: console
 
@@ -27,6 +30,13 @@ You can also list all components at once:
 .. code-block:: console
 
     $ dsgrid registry list
+
+You can also browse different registries by specifying the database URL and name directly on the 
+command line:
+
+.. code-block:: console
+
+    $ dsgrid -u http://dsgrid-registry.hpc.nrel.gov:8529 -N standard-scenarios registry list
 
 
 .. _project-viewer:

--- a/docs/source/how_tos/index.rst
+++ b/docs/source/how_tos/index.rst
@@ -17,5 +17,6 @@ This guide lists the steps to perform common dsgrid operations.
    create_derived_dataset
    query_project
    filter_a_query
+   set_up_standalone_registry
    run_dsgrid_on_eagle
    spark_cluster_on_eagle

--- a/docs/source/how_tos/installation.rst
+++ b/docs/source/how_tos/installation.rst
@@ -115,6 +115,8 @@ with this command:
 You can test your installation similarly if you are using a different registry, just change the
 ArangoDB URL (-u) and database name (-N) arguments to match your set-up.
 
+.. _configure_dsgrid:
+
 Save your configuration
 =======================
 

--- a/docs/source/how_tos/installation.rst
+++ b/docs/source/how_tos/installation.rst
@@ -110,10 +110,10 @@ with this command:
 
 .. code-block:: console
 
-    $ dsgrid -u http://dsgrid-registry.hpc.nrel.gov:8529 -n standard-scenarios registry projects list
+    $ dsgrid -u http://dsgrid-registry.hpc.nrel.gov:8529 -N standard-scenarios registry projects list
 
 You can test your installation similarly if you are using a different registry, just change the
-ArangoDB URL (-u) and database name (-n) arguments to match your set-up.
+ArangoDB URL (-u) and database name (-N) arguments to match your set-up.
 
 Save your configuration
 =======================
@@ -127,10 +127,10 @@ The appropriate configuration for using the shared registry at NREL is:
 
 .. code-block:: console
 
-    $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -n standard-scenarios --offline
+    $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -N standard-scenarios --offline
 
 Similar to testing your installation, you can save the correct configurations for other set-ups
-by changing the ArangoDB URL (-u) and database name (-n) arguments of the above command.
+by changing the ArangoDB URL (-u) and database name (-N) arguments of the above command.
 
 .. todo:: Access from AWS
 

--- a/docs/source/how_tos/installation.rst
+++ b/docs/source/how_tos/installation.rst
@@ -17,16 +17,44 @@ Steps to make a dsgrid Conda environment:
    installation size.
 2. Create a suitable environment.
 
-.. code-block:: bash
+.. code-block:: console
 
-    conda create -n dsgrid python=3.10
+    $ conda create -n dsgrid python=3.10
 
 3. Activate the environment:
 
-.. code-block:: bash
+.. code-block:: console
 
-    conda activate dsgrid
+    $ conda activate dsgrid
 
+dsgrid's key dependencies are an `ArangoDB registry <#registry>`_, which can be 
+`shared <#nrel-shared-registry>`_ or `standalone <#standalone-registry>`_, and 
+`Apache Spark`_. Apache Spark requires Java, so check if you have it. Both of these 
+commands must work:
+
+.. tabs::
+
+    .. code-tab:: console Mac/Linux
+
+        $ java --version
+        openjdk 11.0.12 2021-07-20
+        $ echo $JAVA_HOME
+        /Users/dthom/brew/Cellar/openjdk@11/11.0.12
+
+        $ # If you don't have java installed:
+        $ conda install openjdk
+
+    .. code-tab:: pwsh-session Windows
+
+        > java --version
+        openjdk 11.0.13 2021-10-19
+        OpenJDK Runtime Environment JBR-11.0.13.7-1751.21-jcef (build 11.0.13+7-b1751.21)
+        OpenJDK 64-Bit Server VM JBR-11.0.13.7-1751.21-jcef (build 11.0.13+7-b1751.21, mixed mode)
+        > echo %JAVA_HOME%
+        C:\Users\ehale\Anaconda3\envs\dsgrid\Library
+
+        > # If you don't have java installed:
+        > conda install openjdk 
 
 Package Installation
 =====================
@@ -62,18 +90,17 @@ NREL. To query the data you must be on the NREL HPC.
 
 Standalone Registry
 -------------------
-To use dsgrid in your own computational environment, you will need to run ArangoDB, and either set
-up a new dsgrid registry or load a dsgrid registry that has been written to disk.
+To use dsgrid in your own computational environment, you will need to run ArangoDB and either set
+up a new dsgrid registry or load a dsgrid registry that has been written to disk. Please see the 
+:ref:`how-to guide on setting up a standalone dsgrid registry <set_up_standalone_registry>`.
 
-.. todo:: Link to how-to for setting up a standalone ArangoDB on laptops, etc.
-
-.. todo:: Link to how-to for setting up a standalone dsgrid registry on Eagle
 
 Apache Spark
 ============
 
 - NREL High Performance Computing: :ref:`how-to-start-spark-cluster-eagle`
 - Standalone resources: [TODO: Provide link]
+
 
 Test your installation
 ======================

--- a/docs/source/how_tos/run_dsgrid_on_eagle.rst
+++ b/docs/source/how_tos/run_dsgrid_on_eagle.rst
@@ -16,7 +16,7 @@ How to run dsgrid on Eagle
 
 .. code-block:: console
 
-    $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -n standard-scenarios --offline
+    $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -N standard-scenarios --offline
 
 4. Start a Spark cluster with your desired number of compute nodes by following the instructions at
    :ref:`how-to-start-spark-cluster-eagle`.

--- a/docs/source/how_tos/set_up_standalone_registry.rst
+++ b/docs/source/how_tos/set_up_standalone_registry.rst
@@ -1,0 +1,154 @@
+.. _set_up_standalone_registry:
+
+***********************************
+How to Set Up a Standalone Registry
+***********************************
+
+dsgrid stores registry information in an ArangoDB database. If you want to work with a completely 
+local version of dsgrid, you must set up and connect to a local ArangoDB instance. There are two 
+ways to install ArangoDB on your computer: `Native Installation`_ or `Docker Container`_. You might 
+also want to set up a standalone registry on `NREL HPC`_ for development or testing purposes.
+
+Once installed, the easiest way to mange the database manually is through Arango's web UI,
+available at http://localhost:8529.
+
+Native Installation
+===================
+
+1. Install **ArangoDB Community Edition** locally by following the instructions at
+   https://www.arangodb.com/download-major/. If asked and you plan to run dsgrid tests, set the root 
+   password to openSesame to match the defaults.
+
+   Add the ``bin`` directory to your system path and customize the configuration files, 
+   particularly regarding authentication, as desired. 
+
+    .. tabs::
+
+        .. tab:: Mac
+
+            The ``bin`` directory will be in a location like:
+
+            .. code-block:: bash
+
+                $HOME/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/bin
+
+            though you may have chosen to install to ``/Applications``. 
+
+            The configuration files will be in a directory like:
+
+            .. code-block:: bash
+
+                $HOME/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/etc/arangodb3
+
+        .. tab:: Windows
+
+            The ``bin`` directory will be in a location like:
+
+            .. code-block:: pwsh
+                
+                C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5\usr\bin
+
+            and the executable installer will have already added it to your path (User variables, 
+            Path).
+
+            The configuration files will be in a directory like:
+
+            .. code-block:: pwsh
+
+                C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5\etc\arangodb3
+
+2. Start the database.
+
+    .. tabs::
+
+        .. tab:: Mac
+
+            Start the database by running ``arangodb``. 
+
+            If you get the error ``cannot find configuration file`` then make this directory and copy 
+            the configuration files:
+
+            .. code-block:: console
+
+                $ mkdir ~/.arangodb
+                $ cp ~/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/etc/arangodb3/*conf ~/.arangodb
+
+            If you don't copy the files, you can specify the config file with 
+            ``arangodb --conf <your-path>/arangod.conf``
+
+        .. tab:: Windows
+
+            Start the database by running ``arangod``. It is preferable to run ``arangod`` from the 
+            path like ``C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5``. Alternatively, you can 
+            directly use the ArangoDB Server shortcut on your Windows desktop.
+
+
+Docker Container
+================
+
+Run the ArangoDB Docker container by following instructions at
+https://www.arangodb.com/download-major/docker/. Note the details about data persistence.
+
+For example:
+
+.. code-block:: console
+    
+    $ docker create --name arangodb-persist arangodb true
+
+    $ docker run --name=arango-container --volumes-from arangodb-persist -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.10.4
+
+Once the docker container is running, Arango commands will need to be preceded with `docker exec`. 
+For example, using the container name from above:
+
+.. code-block:: console
+    
+    $ docker exec arango-container arangorestore ...
+
+
+NREL HPC
+========
+
+The dsgrid repository includes ``scripts/start_arangodb_on_eagle.sh``. It will start an ArangoDB
+on a compute node using the debug partition. It stores Arango files in ``/scratch/${USER}/arangodb3``
+and ``/scratch/${USER}/arangodb3-apps``. If you would like to use a completely new database,
+delete those directories before running the script.
+
+Note that Slurm will log stdout/stderr from ``arangod`` into ``./arango_<job-id>.o/e``.
+
+The repository also includes ``scripts/start_spark_and_arango_on_eagle.sh``. It starts Spark as well
+as ArangoDB, but you must have cloned ``https://github.com/NREL/HPC.git``. It looks for the repo at
+``~/repos/HPC``, but you can set a custom value on the command line, such as the example below.
+
+You may want to adjust the number and type of nodes in the script based on your Spark requirements.
+
+.. code-block:: console
+
+    $ sbatch scripts/start_spark_and_arango_on_eagle.sh ~/HPC
+
+Note that Slurm will log stdout/stderr from into ``./dsgrid_infra<job-id>.o/e``. Look at the .o
+file to see the URL for the Spark cluster and the Spark configuration directory.
+
+It is advised to gracefully shut down the database if you want to ensure that all updates have
+been persisted to files. To do that:
+
+1. ssh to the compute node running the database.
+   
+2. Identify the process ID of ``arangod``. In this example the PID is ``195412``.
+   
+    .. code-block:: console
+
+        $ ps -ef | grep arango
+        dthom    195412 195392  0 09:31 ?        00:00:06 arangod --server.authentication=true --config /tmp/arangod.conf
+
+3. Send ``SIGTERM`` to the process.
+
+    .. code-block:: console
+
+        $ kill -s TERM 195412
+
+4. ``arangod`` will detect the signal and gracefully shutdown.
+
+Modify the HPC parameters as needed. Or run the commands manually. **Note that you should never run
+ArangoDB on a login node.**
+
+If you need to start a Spark cluster, you can do that on the same compute node running the database.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ Documentation Overview
 ======================
 
 If you are new to dsgrid, you'll likely want to start by reading the rest of this page, reading
-the how-to guide on installation, and then choosing a tutorial that corresponds to how you expect
+the :ref:`how-to guide on installation <installation>`, and then choosing a tutorial that corresponds to how you expect
 to be using dsgrid in the near future.
 
 For general use, the documentation is organized into:

--- a/docs/source/reference/cli_fundamentals.rst
+++ b/docs/source/reference/cli_fundamentals.rst
@@ -86,7 +86,7 @@ name as needed.
 
 .. code-block:: console
 
-   $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -n standard-scenarios --offline
+   $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -N standard-scenarios --offline
    Wrote dsgrid config to /Users/dthom/.dsgrid.json5
 
 Environment variables

--- a/dsgrid/cli/config.py
+++ b/dsgrid/cli/config.py
@@ -24,7 +24,7 @@ def config():
     help="Enable tracking of function timings.",
 )
 @click.option(
-    "-n",
+    "-N",
     "--database-name",
     type=str,
     default=None,

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import logging
 from pathlib import Path
 from setuptools import setup, find_packages
 
+from pygments.lexers.shell import BashSessionLexer, PowerShellSessionLexer
+
 logger = logging.getLogger(__name__)
 
 here = Path(__file__).parent.resolve()


### PR DESCRIPTION
## Description

Adds installation information about Java dependency and how to set up a standalone dsgrid registry.

Clarifies how to be sure you are pointing at the right dsgrid registry in the "browse the registry" how-to.

## Checklist

- [ ] Tests exercising the new feature or bug fix
- [ ] All tests pass
- [ ] At least one code review approval
- [ ] Consider transferring TODOs to JIRA or GitHub
