### PR TITLE
Update HPC instructions for Kestrel

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -20,7 +20,7 @@ pip install -e .[admin] # dev plus what is needed for creating documentation and
 
 **Java**
 Spark requires Java. Most people already have Java installed on their personal computers, so this
-is typically only a problem on Eagle or the cloud. Check if you have it. Both of these commands
+is typically only a problem on an HPC or the cloud. Check if you have it. Both of these commands
 must work.
 ```
 $ java --version
@@ -114,21 +114,21 @@ Once the docker container is running, Arango commands will need to be preceded w
 docker exec arango-container arangorestore ...
 ```
 
-#### Eagle
-The dsgrid repository includes `scripts/start_arangodb_on_eagle.sh`. It will start an ArangoDB
+#### Kestrel
+The dsgrid repository includes `scripts/start_arangodb_on_kestrel.sh`. It will start an ArangoDB
 on a compute node using the debug partition. It stores Arango files in `/scratch/${USER}/arangodb3`
 and `/scratch/${USER}/arangodb3-apps`. If you would like to use a completely new database,
 delete those directories before running the script.
 
 Note that Slurm will log stdout/stderr from `arangod` into `./arango_<job-id>.o/e`.
 
-The repository also includes `scripts/start_spark_and_arango_on_eagle.sh`. It starts Spark as well
+The repository also includes `scripts/start_spark_and_arango_on_kestrel.sh`. It starts Spark as well
 as ArangoDB, but you must have cloned `https://github.com/NREL/HPC.git`. It looks for the repo at
 `~/repos/HPC`, but you can set a custom value on the command line, such as the example below.
 
 You may want to adjust the number and type of nodes in the script based on your Spark requirements.
 ```
-$ sbatch scripts/start_spark_and_arango_on_eagle.sh ~/HPC
+$ sbatch scripts/start_spark_and_arango_on_kestrel.sh ~/HPC
 ```
 
 Note that Slurm will log stdout/stderr from into `./dsgrid_infra<job-id>.o/e`. Look at the .o
@@ -202,7 +202,7 @@ $ docker exec arango-container arangorestore \
     --include-system-collections true
 ```
 
-If you are running on Eagle, run this script from the dsgrid repository. Note that you can run this
+If you are running on an HPC, run this script from the dsgrid repository. Note that you can run this
 command on a login node. `DB_HOSTNAME` is the node name of the compute node running Arango.
 ```
 $ bash scripts/restore_simple_standard_scenarios.sh <path-to-your-local-dsgrid-test-data> <DB_HOSTNAME>
@@ -216,8 +216,8 @@ If you update the configs or data for the StandardScenarios registry then you'll
 the test data repository per these instructions.
 
 1. Register and submit all datasets to a clean registry. The initial registry can be created with
-this command after modifiying the paths specified in the JSON5 file. Four `bigmem` compute nodes
-on Eagle are recommended in order to complete the job in one hour. Two may be sufficient if you
+this command after modifiying the paths specified in the JSON5 file. Three compute nodes
+on Kestrel are recommended in order to complete the job in one hour. Two may be sufficient if you
 run multiple iterations.
 
 Run this from your scratch directory.
@@ -265,10 +265,10 @@ If you only want to run AWS tests:
 pytest tests_aws
 ```
 
-If you're running tests on Eagle and used the `scripts/start_spark_and_arango_on_eagle.sh` or set up a custom configuration you will want to:
+If you're running tests on an HPC and used the `scripts/start_spark_and_arango_on_kestrel.sh` or set up a custom configuration you will want to:
 
 - ssh to the node where Arango is running
-- change to the directory from which you ran the `start_spark_and_arango_on_eagle.sh` script or otherwise identify the full path to the Spark config directory
+- change to the directory from which you ran the `start_spark_and_arango_on_kestrel.sh` script or otherwise identify the full path to the Spark config directory
 - `export SPARK_CONF_DIR=$(pwd)/conf` (You can also get the correct command from `grep SPARK dsgrid_infra*.o`.)
 - `cd ~/dsgrid`
 - `module load conda`
@@ -356,7 +356,7 @@ Clone the repository to your system.
 git clone https://github.com/dsgrid/dsgrid-project-EFS $HOME/dsgrid-project-EFS
 ```
 
-Download the EFS datasets from AWS or Eagle (`/projects/dsgrid/efs_datasets/converted_output/commercial`)
+Download the EFS datasets from AWS or HPC (`/projects/dsgrid/efs_datasets/converted_output/commercial`)
 to a local path and set an environment variable for it.
 
 This is what that directory should contain:
@@ -504,7 +504,7 @@ debug(geography_dim.model)
 
 When developing code to support queries you will need to use a miniature registry. Running against
 full datasets in a project will take forever. Here is an example of how to create a simplified version
-of the StandardScenarios project. Run this on an Eagle compute node after configuring a cluster.
+of the StandardScenarios project. Run this on an HPC compute node after configuring a cluster.
 
 This uses a configuration file from the dsgrid-test-data repository that selects a few dimension records
 from each dataset.

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -5,18 +5,18 @@
 # Do not run this while connected to the VPN. You may get a certificate error while downloading spark.
 # docker build --tag spark_py311 --build-arg VERSION=x.y.z .
 
-# This container can be converted to a Singularity container on Eagle with these commands:
-# Save and upload the docker image to Eagle.
+# This container can be converted to an Apptainer container on Kestrel with these commands:
+# Save and upload the docker image to Kestrel.
 # $ docker save -o spark_py311_vx.y.z.tar spark_py311
-# $ scp spark_py311_vx.y.z.tar <username>@eagle.hpc.nrel.gov:/projects/dsgrid/containers
-# Acquire a compute node.
-# $ export SINGULARITY_TMPDIR=/tmp/scratch
-# $ module load singularity-container
+# $ scp spark_py311_vx.y.z.tar <username>@kestrel.hpc.nrel.gov:/projects/dsgrid/containers
+# Acquire a compute node with local storage (salloc --tmp=1600G).
+# $ export APPTAINER_CACHEDIR=/tmp/scratch
+# $ module load apptainer
 # Create writable image for testing and development or read-only image for production.
 # Writable
-# $ singularity build --sandbox spark_py311 docker-archive://spark_py311_v0.1.0.tar
+# $ apptainer build --sandbox spark_py311 docker-archive://spark_py311_v0.1.0.tar
 # Read-only
-# $ singularity build spark_py311_v0.1.0.sif docker-archive://spark_py311_v0.1.0.tar
+# $ apptainer build spark_py311_v0.1.0.sif docker-archive://spark_py311_v0.1.0.tar
 
 # Note: Apache provides a container with Spark and Python installed, but as of now it is Python 3.9
 # and dsgrid requires 3.10+. Whenever they have a newer Python, we can simplify this.
@@ -41,7 +41,7 @@ RUN apt-get update \
     tini tmux tree vim wget openssh-client dropbear locales \
     && rm -rf /var/lib/apt/lists/*
 
-# This prevents bash warnings on Eagle.
+# This prevents bash warnings on Kestrel.
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
     locale-gen
 ENV LANG en_US.UTF-8

--- a/docs/source/how_tos/index.rst
+++ b/docs/source/how_tos/index.rst
@@ -18,5 +18,5 @@ This guide lists the steps to perform common dsgrid operations.
    query_project
    filter_a_query
    set_up_standalone_registry
-   run_dsgrid_on_eagle
-   spark_cluster_on_eagle
+   run_dsgrid_on_kestrel
+   spark_cluster_on_kestrel

--- a/docs/source/how_tos/installation.rst
+++ b/docs/source/how_tos/installation.rst
@@ -94,11 +94,10 @@ To use dsgrid in your own computational environment, you will need to run Arango
 up a new dsgrid registry or load a dsgrid registry that has been written to disk. Please see the 
 :ref:`how-to guide on setting up a standalone dsgrid registry <set_up_standalone_registry>`.
 
-
 Apache Spark
 ============
 
-- NREL High Performance Computing: :ref:`how-to-start-spark-cluster-eagle`
+- NREL High Performance Computing: :ref:`how-to-start-spark-cluster-kestrel`
 - Standalone resources: [TODO: Provide link]
 
 

--- a/docs/source/how_tos/run_dsgrid_on_kestrel.rst
+++ b/docs/source/how_tos/run_dsgrid_on_kestrel.rst
@@ -1,8 +1,8 @@
-.. _how-to-run-dsgrid-eagle:
+.. _how-to-run-dsgrid-kestrel:
 
-**************************
-How to run dsgrid on Eagle
-**************************
+****************************
+How to run dsgrid on Kestrel
+****************************
 
 1. ssh to a login node and start a screen session (or similar, e.g., tmux):
 
@@ -19,7 +19,7 @@ How to run dsgrid on Eagle
     $ dsgrid config create -u http://dsgrid-registry.hpc.nrel.gov:8529 -N standard-scenarios --offline
 
 4. Start a Spark cluster with your desired number of compute nodes by following the instructions at
-   :ref:`how-to-start-spark-cluster-eagle`.
+   :ref:`how-to-start-spark-cluster-kestrel`.
 
 5. Run all CPU-intensive dsgrid commands from the first node in your HPC allocation like this:
 

--- a/docs/source/how_tos/set_up_standalone_registry.rst
+++ b/docs/source/how_tos/set_up_standalone_registry.rst
@@ -4,9 +4,9 @@
 How to Set Up a Standalone Registry
 ***********************************
 
-dsgrid stores registry information in an ArangoDB database. If you want to work with a completely 
-local version of dsgrid, you must set up and connect to a local ArangoDB instance. There are two 
-ways to install ArangoDB on your computer: `Native Installation`_ or `Docker Container`_. You might 
+dsgrid stores registry information in an ArangoDB database. If you want to work with a completely
+local version of dsgrid, you must set up and connect to a local ArangoDB instance. There are two
+ways to install ArangoDB on your computer: `Native Installation`_ or `Docker Container`_. You might
 also want to set up a standalone registry on `NREL HPC`_ for development or testing purposes.
 
 Once installed, the easiest way to mange the database manually is through Arango's web UI,
@@ -16,11 +16,11 @@ Native Installation
 ===================
 
 1. Install **ArangoDB Community Edition** locally by following the instructions at
-   https://www.arangodb.com/download-major/. If asked and you plan to run dsgrid tests, set the root 
+   https://www.arangodb.com/download-major/. If asked and you plan to run dsgrid tests, set the root
    password to openSesame to match the defaults.
 
-   Add the ``bin`` directory to your system path and customize the configuration files, 
-   particularly regarding authentication, as desired. 
+   Add the ``bin`` directory to your system path and customize the configuration files,
+   particularly regarding authentication, as desired.
 
     .. tabs::
 
@@ -32,7 +32,7 @@ Native Installation
 
                 $HOME/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/bin
 
-            though you may have chosen to install to ``/Applications``. 
+            though you may have chosen to install to ``/Applications``.
 
             The configuration files will be in a directory like:
 
@@ -45,10 +45,10 @@ Native Installation
             The ``bin`` directory will be in a location like:
 
             .. code-block:: pwsh
-                
+
                 C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5\usr\bin
 
-            and the executable installer will have already added it to your path (User variables, 
+            and the executable installer will have already added it to your path (User variables,
             Path).
 
             The configuration files will be in a directory like:
@@ -63,9 +63,9 @@ Native Installation
 
         .. tab:: Mac
 
-            Start the database by running ``arangodb``. 
+            Start the database by running ``arangodb``.
 
-            If you get the error ``cannot find configuration file`` then make this directory and copy 
+            If you get the error ``cannot find configuration file`` then make this directory and copy
             the configuration files:
 
             .. code-block:: console
@@ -73,13 +73,13 @@ Native Installation
                 $ mkdir ~/.arangodb
                 $ cp ~/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/etc/arangodb3/*conf ~/.arangodb
 
-            If you don't copy the files, you can specify the config file with 
+            If you don't copy the files, you can specify the config file with
             ``arangodb --conf <your-path>/arangod.conf``
 
         .. tab:: Windows
 
-            Start the database by running ``arangod``. It is preferable to run ``arangod`` from the 
-            path like ``C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5``. Alternatively, you can 
+            Start the database by running ``arangod``. It is preferable to run ``arangod`` from the
+            path like ``C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5``. Alternatively, you can
             directly use the ArangoDB Server shortcut on your Windows desktop.
 
 
@@ -92,30 +92,30 @@ https://www.arangodb.com/download-major/docker/. Note the details about data per
 For example:
 
 .. code-block:: console
-    
+
     $ docker create --name arangodb-persist arangodb true
 
     $ docker run --name=arango-container --volumes-from arangodb-persist -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.10.4
 
-Once the docker container is running, Arango commands will need to be preceded with `docker exec`. 
+Once the docker container is running, Arango commands will need to be preceded with `docker exec`.
 For example, using the container name from above:
 
 .. code-block:: console
-    
+
     $ docker exec arango-container arangorestore ...
 
 
 NREL HPC
 ========
 
-The dsgrid repository includes ``scripts/start_arangodb_on_eagle.sh``. It will start an ArangoDB
+The dsgrid repository includes ``scripts/start_arangodb_on_kestrel.sh``. It will start an ArangoDB
 on a compute node using the debug partition. It stores Arango files in ``/scratch/${USER}/arangodb3``
 and ``/scratch/${USER}/arangodb3-apps``. If you would like to use a completely new database,
 delete those directories before running the script.
 
 Note that Slurm will log stdout/stderr from ``arangod`` into ``./arango_<job-id>.o/e``.
 
-The repository also includes ``scripts/start_spark_and_arango_on_eagle.sh``. It starts Spark as well
+The repository also includes ``scripts/start_spark_and_arango_on_kestrel.sh``. It starts Spark as well
 as ArangoDB, but you must have cloned ``https://github.com/NREL/HPC.git``. It looks for the repo at
 ``~/repos/HPC``, but you can set a custom value on the command line, such as the example below.
 
@@ -123,7 +123,7 @@ You may want to adjust the number and type of nodes in the script based on your 
 
 .. code-block:: console
 
-    $ sbatch scripts/start_spark_and_arango_on_eagle.sh ~/HPC
+    $ sbatch scripts/start_spark_and_arango_on_kestrel.sh ~/HPC
 
 Note that Slurm will log stdout/stderr from into ``./dsgrid_infra<job-id>.o/e``. Look at the .o
 file to see the URL for the Spark cluster and the Spark configuration directory.
@@ -132,9 +132,9 @@ It is advised to gracefully shut down the database if you want to ensure that al
 been persisted to files. To do that:
 
 1. ssh to the compute node running the database.
-   
+
 2. Identify the process ID of ``arangod``. In this example the PID is ``195412``.
-   
+
     .. code-block:: console
 
         $ ps -ef | grep arango

--- a/docs/source/how_tos/set_up_standalone_registry.rst
+++ b/docs/source/how_tos/set_up_standalone_registry.rst
@@ -5,83 +5,15 @@ How to Set Up a Standalone Registry
 ***********************************
 
 dsgrid stores registry information in an ArangoDB database. If you want to work with a completely
-local version of dsgrid, you must set up and connect to a local ArangoDB instance. There are two
-ways to install ArangoDB on your computer: `Native Installation`_ or `Docker Container`_. You might
-also want to set up a standalone registry on `NREL HPC`_ for development or testing purposes.
+local version of dsgrid, you must set up and connect to a local ArangoDB instance. ArangoDB
+recommends running their database in Docker containers when using Windows and Mac computers. They
+provide a native installation package for Windows and Linux, but not Mac.
+
+Native installation instructions are provided here for Windows, but Docker is the recommended
+solution.
 
 Once installed, the easiest way to mange the database manually is through Arango's web UI,
 available at http://localhost:8529.
-
-Native Installation
-===================
-
-1. Install **ArangoDB Community Edition** locally by following the instructions at
-   https://www.arangodb.com/download-major/. If asked and you plan to run dsgrid tests, set the root
-   password to openSesame to match the defaults.
-
-   Add the ``bin`` directory to your system path and customize the configuration files,
-   particularly regarding authentication, as desired.
-
-    .. tabs::
-
-        .. tab:: Mac
-
-            The ``bin`` directory will be in a location like:
-
-            .. code-block:: bash
-
-                $HOME/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/bin
-
-            though you may have chosen to install to ``/Applications``.
-
-            The configuration files will be in a directory like:
-
-            .. code-block:: bash
-
-                $HOME/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/etc/arangodb3
-
-        .. tab:: Windows
-
-            The ``bin`` directory will be in a location like:
-
-            .. code-block:: pwsh
-
-                C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5\usr\bin
-
-            and the executable installer will have already added it to your path (User variables,
-            Path).
-
-            The configuration files will be in a directory like:
-
-            .. code-block:: pwsh
-
-                C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5\etc\arangodb3
-
-2. Start the database.
-
-    .. tabs::
-
-        .. tab:: Mac
-
-            Start the database by running ``arangodb``.
-
-            If you get the error ``cannot find configuration file`` then make this directory and copy
-            the configuration files:
-
-            .. code-block:: console
-
-                $ mkdir ~/.arangodb
-                $ cp ~/Applications/ArangoDB3-CLI.app/Contents/Resources/opt/arangodb/etc/arangodb3/*conf ~/.arangodb
-
-            If you don't copy the files, you can specify the config file with
-            ``arangodb --conf <your-path>/arangod.conf``
-
-        .. tab:: Windows
-
-            Start the database by running ``arangod``. It is preferable to run ``arangod`` from the
-            path like ``C:\Users\$USER\AppData\Local\ArangoDB3 3.10.5``. Alternatively, you can
-            directly use the ArangoDB Server shortcut on your Windows desktop.
-
 
 Docker Container
 ================
@@ -95,29 +27,80 @@ For example:
 
     $ docker create --name arangodb-persist arangodb true
 
-    $ docker run --name=arango-container --volumes-from arangodb-persist -p 8529:8529 -e ARANGO_ROOT_PASSWORD=openSesame arangodb/arangodb:3.10.4
+.. code-block:: console
 
-Once the docker container is running, Arango commands will need to be preceded with `docker exec`.
-For example, using the container name from above:
+    $ docker run --name=arango-container \
+        --volumes-from arangodb-persist \
+        -p 8529:8529 \
+        -e ARANGO_ROOT_PASSWORD=openSesame \
+        arangodb/arangodb:3.11.3
+
+If you will be uploading files from your filesystem to the container, such as with
+``arangorestore``, you will need to bind-mount the relevant directories like this:
+
+.. code-block:: console
+
+    $ docker run --name=arango-container \
+        -v <abs-path-on-your-system>:<abs-path-in-container> \
+        --volumes-from arangodb-persist \
+        -p 8529:8529 \
+        -e ARANGO_ROOT_PASSWORD=openSesame \
+        arangodb/arangodb:3.11.3
+
+
+Once the docker container is running, Arango commands will need to be preceded with ``docker
+exec``. For example, using the container name from above:
 
 .. code-block:: console
 
     $ docker exec arango-container arangorestore ...
+
+Native Installation (Windows Only)
+==================================
+
+1. Install **ArangoDB Community Edition** locally by following the instructions at
+   https://www.arangodb.com/download-major/. If asked and you plan to run dsgrid tests, set the
+   root password to openSesame to match the defaults.
+
+   Add the ``bin`` directory to your system path and customize the configuration files,
+   particularly regarding authentication, as desired.
+
+   The ``bin`` directory will be in a location like:
+
+   .. code-block:: pwsh
+
+       C:\Users\$USER\AppData\Local\ArangoDB3 3.11.3\usr\bin
+
+   and the executable installer will have already added it to your path (User variables,
+   Path).
+
+   The configuration files will be in a directory like:
+
+   .. code-block:: pwsh
+
+       C:\Users\$USER\AppData\Local\ArangoDB3 3.11.3\etc\arangodb3
+
+2. Start the database.
+
+   Start the database by running ``arangod``. It is preferable to run ``arangod`` from the
+   path like ``C:\Users\$USER\AppData\Local\ArangoDB3 3.11.3``. Alternatively, you can
+   directly use the ArangoDB Server shortcut on your Windows desktop.
 
 
 NREL HPC
 ========
 
 The dsgrid repository includes ``scripts/start_arangodb_on_kestrel.sh``. It will start an ArangoDB
-on a compute node using the debug partition. It stores Arango files in ``/scratch/${USER}/arangodb3``
-and ``/scratch/${USER}/arangodb3-apps``. If you would like to use a completely new database,
-delete those directories before running the script.
+instance on a compute node using the debug partition. It stores Arango files in
+``/scratch/${USER}/arangodb3`` and ``/scratch/${USER}/arangodb3-apps``. If you would like to use a
+completely new database, delete those directories before running the script.
 
 Note that Slurm will log stdout/stderr from ``arangod`` into ``./arango_<job-id>.o/e``.
 
-The repository also includes ``scripts/start_spark_and_arango_on_kestrel.sh``. It starts Spark as well
-as ArangoDB, but you must have cloned ``https://github.com/NREL/HPC.git``. It looks for the repo at
-``~/repos/HPC``, but you can set a custom value on the command line, such as the example below.
+The repository also includes ``scripts/start_spark_and_arango_on_kestrel.sh``. It starts Spark as
+well as ArangoDB, but you must have cloned ``https://github.com/NREL/HPC.git``. It looks for the
+repo at ``~/repos/HPC``, but you can set a custom value on the command line, such as the example
+below.
 
 You may want to adjust the number and type of nodes in the script based on your Spark requirements.
 

--- a/docs/source/how_tos/spark_cluster_on_kestrel.rst
+++ b/docs/source/how_tos/spark_cluster_on_kestrel.rst
@@ -1,18 +1,23 @@
-.. _how-to-start-spark-cluster-eagle:
+.. _how-to-start-spark-cluster-kestrel:
 
-*************************************
-How to start a Spark cluster on Eagle
-*************************************
+***************************************
+How to start a Spark cluster on Kestrel
+***************************************
 This section assumes that you have cloned the HPC Spark setup scripts from this `repo
 <https://github.com/NREL/HPC.git>`_. If you are unfamiliar with that, please read the full details
 at :ref:`spark-on-hpc`.
 
-This example will acquire one compute node from the ``debug`` partition. If you need more than two
-nodes or more than one hour of runtime, use the ``bigmem`` or ``gpu`` partition.
+Compute Node Types
+==================
+Spark works best with fast local storage. The standard Kestrel nodes do not have any local storage.
+The best candidates are the 256 standard nodes (no GPUs) with 1.92 TB NVMe M.2 drives. Please refer
+to the `Kestrel system configuration page
+<https://www.nrel.gov/hpc/kestrel-system-configuration.html>`_ for specific hardware information.
+The GPU nodes will work well, but at a greater cost in AUs.
 
-.. warning:: Do not use compute nodes from the standard partition on Eagle if your queries will
-   shuffle data. The local storage on those nodes are too slow and will cause timeouts. All bigmem
-   and gpu nodes have fast local storage.
+If those nodes are not available, you may be able to complete your queries by using the standard
+nodes and specifying a path on the Lustre filesystem in the Spark configuration file
+``conf/spark-env.sh``. Change ``SPARK_LOCAL_DIRS`` and ``SPARK_WORKER_DIR``.
 
 Steps
 =====
@@ -28,13 +33,13 @@ Steps
 
 .. code-block:: console
 
-    $ salloc -t 01:00:00 -N1 --account=dsgrid --partition=debug --mem=730G
+    $ salloc -t 01:00:00 -N1 --account=dsgrid --partition=debug --tmp=1600G
 
 4. Create the initial config file.
 
 .. code-block:: console
 
-   $ create_config.sh -c /datasets/images/apache_spark/spark341_py311.sif
+   $ create_config.sh -c /projects/dsgrid/containers/spark341_py311.sif
 
 5. Configure the Spark settings. Run -h to see the available options.
 

--- a/docs/source/spark_overview.rst
+++ b/docs/source/spark_overview.rst
@@ -173,13 +173,13 @@ available at port 4040. You can monitor and debug all aspects of your jobs in th
 can also inspect all cluster configuration settings.
 
 If your Spark cluster is running on a remote system, like an HPC, you may need to open an ssh
-tunnel to the master node. Here is how to do that on NREL's Eagle cluster.
+tunnel to the master node. Here is how to do that on NREL's Kestrel cluster.
 
 On your laptop:
 .. code-block:: console
 
     $ export COMPUTE_NODE=<compute_node_name>
-    $ ssh -L 4040:$COMPUTE_NODE:4040 -L 8080:$COMPUTE_NODE:8080 $USER@eagle.hpc.nrel.gov
+    $ ssh -L 4040:$COMPUTE_NODE:4040 -L 8080:$COMPUTE_NODE:8080 $USER@kestrel.hpc.nrel.gov
 
 
 Installing a Spark Standalone Cluster
@@ -281,7 +281,7 @@ HPC
 ---
 This section describes how you can run Spark jobs on any number of HPC compute nodes.
 The scripts and examples described here rely on the SLURM scheduling system and have been tested
-on NREL's Eagle cluster.
+on NREL's Kestrel cluster.
 
 NREL's HPC GitHub [repository](https://github.com/NREL/HPC) contains scripts that will create an
 ephemeral Spark cluster on compute nodes that you allocate.
@@ -301,7 +301,7 @@ calls out choices that you should make to run Spark jobs with dsgrid.
 
     $ salloc -t 01:00:00 -N1 --account=dsgrid --partition=debug --mem=730G
 
-- NREL's Eagle cluster will let you allocate two debug jobs each with two nodes. So, you can use
+- NREL's Kestrel cluster will let you allocate two debug jobs each with two nodes. So, you can use
   these scripts to create a four-node cluster for one hour.
 - If the debug partition is not too full, you can append ``--qos=standby`` to the command above
   and not be charged any AUs.
@@ -318,7 +318,7 @@ calls out choices that you should make to run Spark jobs with dsgrid.
     $ create_config.sh -c /projects/dsgrid/containers/spark341_py311.sif
 
 4. Configure Spark parameters based on the amount of memory and CPU in each compute node. dsgrid
-   jobs on Eagle seem to work better with dynamic allocation enabled.
+   jobs on Kestrel seem to work better with dynamic allocation enabled.
 
    This command must be run on a compute node. The script will check for the environment variable
    ``SLURM_JOB_ID``, which is set by ``SLURM``. If you ssh'd into the compute node, it won't be set and
@@ -517,9 +517,9 @@ We have not observed any downside to having this feature enabled.
 Slow local storage
 ------------------
 Spark will write lots of temporary data to local storage during shuffle operations. If your joins
-cause lots of shuffling, it is very important that your local storage be fast. If you use an Eagle
-node with a slow spinning disk (130 MB/s), your job will likely fail. Use a ``bigmem`` or ``gpu``
-node. They have SSDs that can write data at 2 GB/s.
+cause lots of shuffling, it is very important that your local storage be fast. If you direct Spark
+to use the Lustre filesystem for local storage, you mileage will vary. If the system is idle, it
+might work. If it is saturated, your job will likely fail.
 
 ### Too many executors are involved in a job
 Some of our Spark jobs, particularly those that create large, in-memory tables from dimension

--- a/docs/source/tutorials/create_derived_dataset.rst
+++ b/docs/source/tutorials/create_derived_dataset.rst
@@ -9,7 +9,7 @@ dataset. The tutorial uses the comstock_conus_2022_projected derived dataset fro
 `dsgrid-project-StandardScenarios <https://github.com/dsgrid/dsgrid-project-StandardScenarios>`_
 as an example.
 
-You can run all commands in this tutorial except the last one on NREL's HPC Eagle cluster (the
+You can run all commands in this tutorial except the last one on NREL's HPC Kestrel cluster (the
 dataset is already registered).
 
 Steps
@@ -17,7 +17,7 @@ Steps
 ssh to a login node to begin the tutorial.
 
 1. You will need at least four compute nodes to create this dataset in about an hour.
-   Follow the instructions at :ref:`how-to-run-dsgrid-eagle` if you have not already done so. The
+   Follow the instructions at :ref:`how-to-run-dsgrid-kestrel` if you have not already done so. The
    instructions now assume that you are logged in to the compute node that is running the Spark
    master process.
 

--- a/docs/source/tutorials/query_project.rst
+++ b/docs/source/tutorials/query_project.rst
@@ -5,7 +5,7 @@
 Query a project
 ***************
 In this tutorial you will learn how to query a dsgrid project for aggregated data. The query will
-use data from the dsgrid registry stored on NREL's HPC Eagle cluster.
+use data from the dsgrid registry stored on NREL's HPC Kestrel cluster.
 
 Query objectives
 ================
@@ -23,7 +23,7 @@ Steps
 =====
 ssh to a login node to begin the tutorial.
 
-1. Follow the instructions at :ref:`how-to-run-dsgrid-eagle` if you have not already done so.
+1. Follow the instructions at :ref:`how-to-run-dsgrid-kestrel` if you have not already done so.
 
 2. Add this content to a file called ``query.json5``:
 
@@ -146,7 +146,7 @@ params:
           }
 
 3. Start a Spark cluster with two compute nodes as described in
-   :ref:`how-to-start-spark-cluster-eagle`.
+   :ref:`how-to-start-spark-cluster-kestrel`.
 
 4. Activate a Python virtual environment that includes ``dsgrid``.
 

--- a/dsgrid/notebooks/connect_to_dsgrid_registry.ipynb
+++ b/dsgrid/notebooks/connect_to_dsgrid_registry.ipynb
@@ -98,7 +98,7 @@
    "id": "45a0e446",
    "metadata": {},
    "source": [
-    "To launch a standalone cluster or a cluster on Eagle, follow **instructions** here: \\\n",
+    "To launch a standalone cluster or a cluster on Kestrel, follow **instructions** here: \\\n",
     "https://github.com/dsgrid/dsgrid/tree/main/dev#spark-standalone-cluster\n",
     "\n",
     "accordingly, uncomment and update the cluster name below:"

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -289,7 +289,7 @@ class Project:
             # Results were not as good with that solution.
             # Observations on queries with comstock and resstock showed that Spark
             # used many fewer executors on the second query. That was with a standalone
-            # cluster on Eagle with dynamic allocation enabled.
+            # cluster on Kestrel with dynamic allocation enabled.
             # We don't understand why that is the case. It may not be an issue with YARN as
             # the cluster manager on AWS.
             # Queries on standalone clusters will be easier to debug if we restart the session

--- a/dsgrid/query/query_submitter.py
+++ b/dsgrid/query/query_submitter.py
@@ -41,7 +41,7 @@ class QuerySubmitterBase:
 
         # TODO #186: This location will need more consideration.
         # We might want to store cached datasets in the spark-warehouse and let Spark manage it
-        # for us. However, would we share them on Eagle? What happens on Eagle walltime timeouts
+        # for us. However, would we share them on the HPC? What happens on HPC walltime timeouts
         # where the tables are left in intermediate states?
         # This is even more of a problem on AWS.
         self._cached_project_mapped_datasets_dir().mkdir(exist_ok=True, parents=True)

--- a/dsgrid/utils/utilities.py
+++ b/dsgrid/utils/utilities.py
@@ -123,7 +123,14 @@ def convert_record_dicts_to_classes(iterable, cls, check_duplicates: None | list
     records = []
     check_duplicates = check_duplicates or []
     values = {x: set() for x in check_duplicates}
+    length = None
     for row in iterable:
+        if None in row:
+            raise ValueError(f"row has a key that is None: {row=}")
+        if length is None:
+            length = len(row)
+        elif len(row) != length:
+            raise ValueError(f"Rows have inconsistent length: first_row_length={length} {row=}")
         record = cls(**row)
         for name in check_duplicates:
             val = getattr(record, name)

--- a/scripts/create_simple_standard_scenarios.sh
+++ b/scripts/create_simple_standard_scenarios.sh
@@ -32,8 +32,8 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-module load singularity-container
-singularity run \
+module load apptainer
+apptainer run \
     -B /scratch:/scratch \
     /projects/dsgrid/containers/arangodb.sif \
     arangodump \

--- a/scripts/restore_simple_standard_scenarios.sh
+++ b/scripts/restore_simple_standard_scenarios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# HPC/Eagle-only script. Uses Singularity.
+# HPC-only script. Uses Apptainer.
 # Imports the archived simple_standard_scenarios database from your local dsgrid-test-data repo
 # into an ArangoDB instance.
 #
@@ -22,9 +22,9 @@ ARANGODB3_DIR=/scratch/$USER/arangodb3
 ARANGODB3_APPS_DIR=/scratch/$USER/arangodb3-apps
 ARANGODB_CONTAINER=/projects/dsgrid/containers/arangodb.sif
 
-module load singularity-container
+module load apptainer
 echo "${DSGRID_TEST_DATA} ${ARANGODB3_DIR} ${ARANGODB3_APPS_DIR} ${ARANGODB_CONTAINER}"
-singularity run \
+apptainer run \
     -B ${DSGRID_TEST_DATA}:/dsgrid-test-data \
     -B ${ARANGODB3_DIR}:/var/lib/arangodb3 \
     -B ${ARANGODB3_APPS_DIR}:/var/lib/arangodb3-apps \

--- a/scripts/start_arangodb_on_kestrel.sh
+++ b/scripts/start_arangodb_on_kestrel.sh
@@ -18,8 +18,8 @@ if [ ! -d ${ARANGODB3_APPS_DIR} ]; then
     mkdir ${ARANGODB3_APPS_DIR}
 fi
 
-module load singularity-container
-singularity run \
+module load apptainer
+apptainer run \
     -B ${ARANGODB3_DIR}:/var/lib/arangodb3 \
     -B ${ARANGODB3_APPS_DIR}:/var/lib/arangodb3-apps \
     --network-args "portmap=8529:8529" \

--- a/scripts/start_spark_and_arango_on_kestrel.sh
+++ b/scripts/start_spark_and_arango_on_kestrel.sh
@@ -36,8 +36,8 @@ printf "Run this command in your environment to use the same configuration:\n\n"
 printf "export SPARK_CONF_DIR=$(pwd)/conf\n\n"
 printf "Starting ArangoDB\n\n"
 
-module load singularity-container
-singularity run \
+module load apptainer
+apptainer run \
     -B ${ARANGODB3_DIR}:/var/lib/arangodb3 \
     -B ${ARANGODB3_APPS_DIR}:/var/lib/arangodb3-apps \
     --network-args "portmap=8529:8529" \

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,7 +180,7 @@ def test_list_table_format_types():
     assert response.types == sorted(list(TableFormatType), key=lambda x: x.value)
 
 
-# This doesn't work in all environments, especially Eagle. There are conflicts with the
+# This doesn't work in all environments, especially HPC. There are conflicts with the
 # metastore_db directory.
 @pytest.mark.skip
 def test_submit_project_query(setup_api_server):


### PR DESCRIPTION
Updates:
1. We no longer have access to Eagle, and so I need to change the instructions for running on Kestrel. Note that `Singularity` has been rebranded as `Apptainer`.
2. ArangoDB stopped providing binaries for Mac, so I removed that content.
3. Added some error checks for a condition exposed by the DECARB project registration.