### PR TITLE
Update Spark instructions for Kestrel

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -45,8 +45,8 @@ pre-commit install
 
 ## Spark
 You need to have some familiarity with Spark in order to run non-trivial tasks in dsgrid.
-This [page](spark_overview.md) provides an overview and explains various ways to use Spark in
-dsgrid.
+This [page](https://dsgrid.github.io/dsgrid/spark_overview.html) provides an overview and explains
+various ways to use Spark in dsgrid.
 
 ## ArangoDB
 dsgrid stores registry information in an ArangoDB database. You must install it locally in

--- a/docs/source/how_tos/set_up_standalone_registry.rst
+++ b/docs/source/how_tos/set_up_standalone_registry.rst
@@ -98,9 +98,9 @@ completely new database, delete those directories before running the script.
 Note that Slurm will log stdout/stderr from ``arangod`` into ``./arango_<job-id>.o/e``.
 
 The repository also includes ``scripts/start_spark_and_arango_on_kestrel.sh``. It starts Spark as
-well as ArangoDB, but you must have cloned ``https://github.com/NREL/HPC.git``. It looks for the
-repo at ``~/repos/HPC``, but you can set a custom value on the command line, such as the example
-below.
+well as ArangoDB, but you must have cloned ``https://github.com/daniel-thom/HPC.git``
+(``kestrel-update`` branch). It looks for the repo at ``~/repos/HPC``, but you can set a custom
+value on the command line, such as the example below.
 
 You may want to adjust the number and type of nodes in the script based on your Spark requirements.
 

--- a/docs/source/how_tos/spark_cluster_on_kestrel.rst
+++ b/docs/source/how_tos/spark_cluster_on_kestrel.rst
@@ -4,8 +4,8 @@
 How to start a Spark cluster on Kestrel
 ***************************************
 This section assumes that you have cloned the HPC Spark setup scripts from this `repo
-<https://github.com/NREL/HPC.git>`_. If you are unfamiliar with that, please read the full details
-at :ref:`spark-on-hpc`.
+<https://github.com/daniel-thom/HPC.git>`_ (``kestrel-update`` branch). If you are unfamiliar with
+that, please read the full details at :ref:`spark-on-hpc`.
 
 Compute Node Types
 ==================
@@ -35,25 +35,13 @@ Steps
 
     $ salloc -t 01:00:00 -N1 --account=dsgrid --partition=debug --tmp=1600G
 
-4. Create the initial config file.
+4. Configure the Spark settings and start the cluster. Run -h to see the available options.
 
 .. code-block:: console
 
-   $ create_config.sh -c /projects/dsgrid/containers/spark341_py311.sif
+    $ configure_and_start_spark.sh -c /projects/dsgrid/containers/spark341_py311.sif
 
-5. Configure the Spark settings. Run -h to see the available options.
-
-.. code-block:: console
-
-    $ configure_spark.sh
-
-6. Start the cluster.
-
-.. code-block:: console
-
-    $ start_spark_cluster.sh
-
-7. Set the Spark configuration environment variable.
+5. Set the Spark configuration environment variable.
 
 .. code-block:: console
 

--- a/docs/source/spark_overview.rst
+++ b/docs/source/spark_overview.rst
@@ -53,7 +53,7 @@ Spark Overview
 
 Cluster Mode
 ------------
-Apache provides an overview at https://spark.apache.org/docs/3.3.1/cluster-overview.html
+Apache provides an overview at https://spark.apache.org/docs/latest/cluster-overview.html
 
 The most important parts to understand are how dsgrid uses different cluster modes in different
 environments.
@@ -283,10 +283,10 @@ This section describes how you can run Spark jobs on any number of HPC compute n
 The scripts and examples described here rely on the SLURM scheduling system and have been tested
 on NREL's Kestrel cluster.
 
-NREL's HPC GitHub [repository](https://github.com/NREL/HPC) contains scripts that will create an
-ephemeral Spark cluster on compute nodes that you allocate.
+NREL's HPC GitHub [repository](https://github.com/daniel-thom/HPC) (``kestrel-update`` branch)
+contains scripts that will create an ephemeral Spark cluster on compute nodes that you allocate.
 
-The [README](https://github.com/NREL/HPC/blob/master/applications/spark/README.md) in the
+The [README](https://github.com/daniel-thom/HPC/blob/kestrel-update/applications/spark/README.md) in the
 repository has generic instructions to run Spark in a variety of ways. The rest of this section
 calls out choices that you should make to run Spark jobs with dsgrid.
 
@@ -294,28 +294,25 @@ calls out choices that you should make to run Spark jobs with dsgrid.
 
 .. code-block:: console
 
-    $ git clone https://github.com/NREL/HPC.git
+    $ git clone https://github.com/daniel-thom/HPC.git
+    $ git checkout kestrel-update
 
 2. Choose compute node(s) with fast local storage. This example will allocate one node.
 .. code-block:: console
 
-    $ salloc -t 01:00:00 -N1 --account=dsgrid --partition=debug --mem=730G
+    $ salloc -t 01:00:00 -N1 --account=dsgrid --partition=debug --tmp=1600G
 
-- NREL's Kestrel cluster will let you allocate two debug jobs each with two nodes. So, you can use
-  these scripts to create a four-node cluster for one hour.
+- NREL's Kestrel cluster will let you allocate one debug job each with two nodes. So, you can use
+  these scripts to create a two-node cluster for one hour.
 - If the debug partition is not too full, you can append ``--qos=standby`` to the command above
   and not be charged any AUs.
 
-3. Select a Spark container compatible with dsgrid, which currently requires Spark v3.3.1 and
-   Python 3.10. The team has validated the container below. It was created with this Dockerfile
+3. Select a Spark container compatible with dsgrid, which currently requires Spark v3.4.1 and
+   Python 3.11. The team has validated the container below. It was created with this Dockerfile
    in dsgrid: ``docker/spark/Dockerfile``. The container includes ipython, jupyter, pyspark, pandas,
    and pyarrow, but not dsgrid.
 
-    This command can be run on a login node or a compute node.
-
-.. code-block:: console
-
-    $ create_config.sh -c /projects/dsgrid/containers/spark341_py311.sif
+   ``/projects/dsgrid/containers/spark341_py311.sif``
 
 4. Configure Spark parameters based on the amount of memory and CPU in each compute node. dsgrid
    jobs on Kestrel seem to work better with dynamic allocation enabled.
@@ -328,17 +325,17 @@ calls out choices that you should make to run Spark jobs with dsgrid.
 
 .. code-block:: console
 
-    $ configure_spark.sh --dynamic-allocation
+    $ configure_and_start_spark.sh -D -c /projects/dsgrid/containers/spark341_py311.sif
 
 .. code-block:: console
 
-    $ configure_spark.sh --dynamic-allocation <SLURM_JOB_ID>
+    $ configure_and_start_spark.sh -D -c /projects/dsgrid/containers/spark341_py311.sif <SLURM_JOB_ID>
 
 .. code-block:: console
 
-    $ configure_spark.sh --dynamic-allocation <SLURM_JOB_ID1> <SLURM_JOB_ID2>
+    $ configure_and_start_spark.sh -D -c /projects/dsgrid/containers/spark341_py311.sif <SLURM_JOB_ID1> <SLURM_JOB_ID2>
 
-Run ``configure_spark.sh --help`` to see all options.
+Run ``configure_and_start_spark.sh --help`` to see all options.
 
 Alternatively, or in conjunction with the above command, customize the Spark configuration files
 in ``./conf`` as necessary per the HPC instructions.

--- a/scripts/start_spark_and_arango_on_kestrel.sh
+++ b/scripts/start_spark_and_arango_on_kestrel.sh
@@ -25,11 +25,7 @@ else
 fi
 
 SCRIPT_DIR=${HPC_REPO_DIR}/applications/spark/spark_scripts
-${SCRIPT_DIR}/create_config.sh -c /projects/dsgrid/containers/spark341_py311.sif
-sed -i "s/master_node_memory_overhead_gb = 10/master_node_memory_overhead_gb = 15/" config
-sed -i "s/worker_node_memory_overhead_gb = 5/worker_node_memory_overhead_gb = 10/" config
-${SCRIPT_DIR}/configure_spark.sh
-${SCRIPT_DIR}/start_spark_cluster.sh
+${SCRIPT_DIR}/configure_and_start_spark.sh -c /projects/dsgrid/containers/spark341_py311.sif
 
 printf "\nThe Spark cluster is running at spark://$(hostname):7077 from a configuration at $(pwd)/conf\n\n"
 printf "Run this command in your environment to use the same configuration:\n\n"


### PR DESCRIPTION
This is a documention-only PR. I updated our HPC spark-creation scripts for Kestrel. I also streamlined the workflow a bit. It would be great if one of you could checkout the new scripts and documentation at https://github.com/daniel-thom/HPC/tree/kestrel-update/applications/spark. I will open a PR in that repository as soon as we are comfortable with it.