### PR TITLE
Pre-check dataset_id in register_and_submit_dataset

### DIFF
--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -593,7 +593,7 @@ class DatasetConfig(ConfigBase):
         return config
 
     @classmethod
-    def load_from_user_path(cls, config_file, dataset_path):
+    def load_from_user_path(cls, config_file, dataset_path) -> "DatasetConfig":
         config = cls.load(config_file)
         schema_type = config.get_data_schema_type()
         if str(dataset_path).startswith("s3://"):


### PR DESCRIPTION
The code was not checking for proper status of the dataset in the project before registering the dataset. This was causing a lot of wasted time.