### PR TITLE
Ll/time wrap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = dt/unpivoted-format
+	branch = ll/wrap_time
 [submodule "dsgrid-project-StandardScenarios"]
 	path = dsgrid-project-StandardScenarios
 	url = https://github.com/dsgrid/dsgrid-project-StandardScenarios

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = ll/wrap_time
+	branch = dt/unpivoted-format
 [submodule "dsgrid-project-StandardScenarios"]
 	path = dsgrid-project-StandardScenarios
 	url = https://github.com/dsgrid/dsgrid-project-StandardScenarios

--- a/docs/make_config_model_rst.py
+++ b/docs/make_config_model_rst.py
@@ -39,7 +39,7 @@ def get_class_path(cls_name):
         try:
             mod = importlib.import_module(module)
             if hasattr(mod, cls_name):
-                dsgrid_path = Path(__file__).resolve().parent.parent
+                dsgrid_path = Path(__file__).resolve().parents[1]
                 module_file = dsgrid_path / (module.replace(".", "/") + ".py")
                 with open(module_file, "r") as f:
                     if f"class {cls_name}" in f.read():

--- a/docs/make_example_configs.py
+++ b/docs/make_example_configs.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 
-PROJECT_REPO = Path(__file__).resolve().parent.parent / "dsgrid-test-data" / "test_efs"
+PROJECT_REPO = Path(__file__).resolve().parents[1] / "dsgrid-test-data" / "test_efs"
 
 base_dir = PROJECT_REPO / "dsgrid_project"
 dataset_dir = base_dir / "datasets" / "modeled" / "comstock"

--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -898,7 +898,7 @@ def update_dataset(
 )
 def data_sync(ctx, registry_manager, project_id, dataset_id):
     """Sync the official dsgrid registry data to the local system."""
-    no_prompts = ctx.parent.parent.params["no_prompts"]
+    no_prompts = ctx.parents[1].params["no_prompts"]
     registry_manager.data_sync(project_id, dataset_id, no_prompts)
 
 

--- a/dsgrid/config/annual_time_dimension_config.py
+++ b/dsgrid/config/annual_time_dimension_config.py
@@ -64,7 +64,9 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
     # def build_time_dataframe_with_time_zone(self):
     #     return self.build_time_dataframe()
 
-    def convert_dataframe(self, df, project_time_dim, model_years=None, value_columns=None):
+    def convert_dataframe(
+        self, df, project_time_dim, model_years=None, value_columns=None, wrap_time_allowed=False
+    ):
         assert model_years is not None
         assert value_columns is not None
         match self.model.measurement_type:

--- a/dsgrid/config/date_time_dimension_config.py
+++ b/dsgrid/config/date_time_dimension_config.py
@@ -90,8 +90,12 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
     #     )
     #     return df2
 
-    def convert_dataframe(self, df, project_time_dim, model_years=None, value_columns=None):
-        df = self._convert_time_to_project_time_interval(df=df, project_time_dim=project_time_dim)
+    def convert_dataframe(
+        self, df, project_time_dim, model_years=None, value_columns=None, wrap_time_allowed=False
+    ):
+        df = self._convert_time_to_project_time_interval(
+            df=df, project_time_dim=project_time_dim, wrap_time=wrap_time_allowed
+        )
         return df
 
     def get_frequency(self):

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -546,6 +546,14 @@ class DateTimeDimensionModel(TimeDimensionBaseModel):
             },
         ),
     ]
+    wrap_time_allowed: Annotated[
+        Optional[bool],
+        Field(
+            title="wrap_time_allowed",
+            description="Whether to allow dataset time to be wrapped to project time if different",
+            default=False,
+        ),
+    ]
 
     @model_validator(mode="after")
     def check_time_type_and_class_consistency(self):

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -546,14 +546,6 @@ class DateTimeDimensionModel(TimeDimensionBaseModel):
             },
         ),
     ]
-    wrap_time_allowed: Annotated[
-        Optional[bool],
-        Field(
-            title="wrap_time_allowed",
-            description="Whether to allow dataset time to be wrapped to project time if different",
-            default=False,
-        ),
-    ]
 
     @model_validator(mode="after")
     def check_time_type_and_class_consistency(self):

--- a/dsgrid/config/noop_time_dimension_config.py
+++ b/dsgrid/config/noop_time_dimension_config.py
@@ -21,7 +21,9 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
     # def build_time_dataframe_with_time_zone(self):
     #     pass
 
-    def convert_dataframe(self, df, project_time_dim, model_years=None, value_columns=None):
+    def convert_dataframe(
+        self, df, project_time_dim, model_years=None, value_columns=None, wrap_time_allowed=False
+    ):
         return df
 
     def get_frequency(self):

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -543,6 +543,14 @@ class InputDatasetModel(DSGBaseModel):
             },
         ),
     ]
+    wrap_time_allowed: Annotated[
+        bool,
+        Field(
+            title="wrap_time_allowed",
+            description="Whether to allow dataset time to be wrapped to project time if different",
+            default=False,
+        ),
+    ]
 
 
 class DimensionMappingsModel(DSGBaseModel):

--- a/dsgrid/config/representative_period_time_dimension_config.py
+++ b/dsgrid/config/representative_period_time_dimension_config.py
@@ -64,7 +64,9 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
     # def build_time_dataframe_with_time_zone(self):
     #     return self.build_time_dataframe()
 
-    def convert_dataframe(self, df, project_time_dim, model_years=None, value_columns=None):
+    def convert_dataframe(
+        self, df, project_time_dim, model_years=None, value_columns=None, wrap_time_allowed=False
+    ):
         # in spark.dayofweek: 1=Sunday, 7=Saturday
         # dsgrid uses python standard library (same for pandas), which has day_of_week: 0=Monday, 6=Sunday
         # the mapping is: python.dt.day_of_week = [(i+7-2)%7 for i in spark.dayofweek]
@@ -103,7 +105,7 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
         try:
             project_time_df = project_time_dim.build_time_dataframe()
             map_time = "timestamp_to_map"
-            project_time_df = self._align_time_interval_type(
+            project_time_df = self._shift_time_interval(
                 project_time_df,
                 ptime_col,
                 project_time_dim.get_time_interval_type(),

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -181,10 +181,12 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
 
         """
 
-    def _convert_time_to_project_time_interval(self, df, project_time_dim=None, wrap_time=True):
+    def _convert_time_to_project_time_interval(self, df, project_time_dim=None):
         """Shift time to match project time based on TimeIntervalType
-        If time range spills over into another year after time interval alignment,
+        If wrap_time_allowed in project_time_dim:
+        - If time range spills over into another year after time interval alignment,
         the time range will be wrapped around so it's bounded within the year
+        - Time will also wrapped if dataset has a different time zone than project
         """
         if project_time_dim is None:
             return df
@@ -200,7 +202,7 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
             df, time_col, dtime_interval, ptime_interval, self.get_frequency()
         )
 
-        if wrap_time:
+        if project_time_dim.model.wrap_time_allowed:
             df = self._apply_time_wrap(df, project_time_dim)
 
         return df

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -1,19 +1,20 @@
 import abc
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pandas as pd
 import pyspark.sql.functions as F
 
 from .dimension_config import DimensionBaseConfigWithoutFiles
-from dsgrid.dimension.time import TimeIntervalType
+from dsgrid.dimension.time import TimeZone, TimeIntervalType
 from dsgrid.exceptions import DSGInvalidOperation, DSGInvalidDimension
+from dsgrid.config.dimensions import TimeRangeModel
 
 
 class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
     """Base class for all time dimension configs"""
 
     @abc.abstractmethod
-    def check_dataset_time_consistency(self, load_data_df, time_columns):
+    def check_dataset_time_consistency(self, load_data_df, time_columns: list):
         """Check consistency of the load data with the time dimension.
 
         Parameters
@@ -29,7 +30,7 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         """
 
     @abc.abstractmethod
-    def build_time_dataframe(self, model_years=None):
+    def build_time_dataframe(self, model_years: list = None):
         """Build time dimension as specified in config in a spark dataframe.
 
         Parameters
@@ -56,7 +57,14 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
     #     """
 
     @abc.abstractmethod
-    def convert_dataframe(self, df, project_time_dim, model_years=None, value_columns=None):
+    def convert_dataframe(
+        self,
+        df,
+        project_time_dim,
+        model_years: list = None,
+        value_columns: set = None,
+        wrap_time_allowed: bool = False,
+    ):
         """Convert input df to use project's time format and time zone.
 
         Parameters
@@ -68,6 +76,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         value_columns : None | set[str]
             Columns in the dataframe that represent load values. Not required for all time
             dimension types.
+        wrapped_time_allowed : bool
+            Whether to allow time-wrapping to align time zone
 
         Returns
         -------
@@ -128,7 +138,7 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         return df.withColumnRenamed(time_cols[0], self.model.dimension_query_name)
 
     @abc.abstractmethod
-    def get_time_ranges(self, model_years=None):
+    def get_time_ranges(self, model_years: list = None):
         """Return time ranges with timezone applied.
 
         Parameters
@@ -165,7 +175,7 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         """
 
     @abc.abstractmethod
-    def list_expected_dataset_timestamps(self, model_years=None):
+    def list_expected_dataset_timestamps(self, model_years: list = None):
         """Return a list of the timestamps expected in the load_data table.
 
         Parameters
@@ -181,16 +191,31 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
 
         """
 
-    def _convert_time_to_project_time_interval(self, df, project_time_dim=None):
+    def _convert_time_to_project_time_interval(
+        self, df, project_time_dim=None, wrap_time: bool = False
+    ):
         """Shift time to match project time based on TimeIntervalType
         If wrap_time_allowed in project_time_dim:
-        - If time range spills over into another year after time interval alignment,
-        the time range will be wrapped around so it's bounded within the year
+        -
+
         - Time will also wrapped if dataset has a different time zone than project
         """
         if project_time_dim is None:
             return df
 
+        df = self._align_time_interval_type(df, project_time_dim)
+
+        if wrap_time:
+            diff = self._time_difference(df, project_time_dim, difference="left")
+            df = self._apply_time_wrap(df, project_time_dim, diff)
+
+        return df
+
+    def _align_time_interval_type(self, df, project_time_dim):
+        """Align time interval type between df and project_time_dim
+        If time range spills over into another year after time interval alignment,
+        the time range will be wrapped around so it's bounded within the year.
+        """
         dtime_interval = self.get_time_interval_type()
         ptime_interval = project_time_dim.get_time_interval_type()
         time_col = project_time_dim.get_load_data_time_columns()
@@ -198,25 +223,35 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         assert len(time_col) == 1, time_col
         time_col = time_col[0]
 
-        df = self._align_time_interval_type(
+        if dtime_interval == ptime_interval:
+            return df
+
+        df = self._shift_time_interval(
             df, time_col, dtime_interval, ptime_interval, self.get_frequency()
         )
 
-        if project_time_dim.model.wrap_time_allowed:
-            df = self._apply_time_wrap(df, project_time_dim)
+        diff = self._time_difference(df, project_time_dim, difference="left")
+        if diff:
+            df = self._apply_time_wrap(df, project_time_dim, diff)
 
         return df
 
     @staticmethod
-    def _align_time_interval_type(
-        df, time_column, from_time_interval, to_time_interval, time_step, new_time_column=None
+    def _shift_time_interval(
+        df,
+        time_column: str,
+        from_time_interval: TimeIntervalType,
+        to_time_interval: TimeIntervalType,
+        time_step: timedelta,
+        new_time_column: str = None,
     ):
         """
         Shift time_column by time_step in df as needed by comparing from_time_interval to to_time_interval.
-        If new_time_column is None, time_column is shifted in place, else shifted time is added as new_time_column in df
+        If new_time_column is None, time_column is shifted in place, else shifted time is added as new_time_column in df.
         """
-        if from_time_interval == to_time_interval:
-            return df
+        assert (
+            from_time_interval != to_time_interval
+        ), f"{from_time_interval=} is the same as {to_time_interval=}"
 
         if new_time_column is None:
             new_time_column = time_column
@@ -241,8 +276,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         return df
 
     @staticmethod
-    def _apply_time_wrap(df, project_time_dim):
-        """If dataset_time does not match project_time, apply time-wrapping"""
+    def _time_difference(df, project_time_dim, difference: str = "left"):
+        """Compare the time col in df and project_time_dim"""
 
         time_col = project_time_dim.get_load_data_time_columns()
         assert len(time_col) == 1, time_col
@@ -260,10 +295,34 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
             row[0]
             for row in df.select(time_col).filter(f"{time_col} IS NOT NULL").distinct().collect()
         }
-        diff = dataset_time.difference(project_time)
 
-        if not diff:
-            return df
+        if difference == "left":
+            return dataset_time.difference(project_time)
+
+        if difference == "right":
+            return project_time.difference(dataset_time)
+
+        if difference == "symmetric":
+            return dataset_time.symmetric_difference(project_time)
+
+        raise ValueError(f"Unsupport function input {difference=}")
+
+    @staticmethod
+    def _apply_time_wrap(df, project_time_dim, diff: set):
+        """apply time-wrapping"""
+
+        time_col = project_time_dim.get_load_data_time_columns()
+        assert len(time_col) == 1, time_col
+        time_col = time_col[0]
+
+        project_time = {
+            row[0]
+            for row in project_time_dim.build_time_dataframe()
+            .select(time_col)
+            .filter(f"{time_col} IS NOT NULL")
+            .distinct()
+            .collect()
+        }
 
         # extract time_delta based on if diff is to the left or right of project_time
         time_delta = (
@@ -286,6 +345,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
             row[0]
             for row in df.select(time_col).filter(f"{time_col} IS NOT NULL").distinct().collect()
         }
+
+        # check
         if dataset_time.symmetric_difference(project_time):
             left_msg, right_msg = "", ""
             if left_diff := dataset_time.difference(project_time):
@@ -298,7 +359,13 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
 
         return df
 
-    def _build_time_ranges(self, time_ranges, str_format, model_years=None, tz=None):
+    def _build_time_ranges(
+        self,
+        time_ranges: TimeRangeModel,
+        str_format: str,
+        model_years: list = None,
+        tz: TimeZone = None,
+    ):
         ranges = []
         allowed_year = None
         for time_range in time_ranges:

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -525,6 +525,8 @@ class DatasetSchemaHandlerBase(abc.ABC):
     def _convert_time_dimension(
         self, load_data_df, project_config, model_years=None, value_columns=None
     ):
+        input_dataset_model = project_config.get_dataset(self._config.model.dataset_id)
+        wrap_time_allowed = input_dataset_model.wrap_time_allowed
         time_dim = self._config.get_dimension(DimensionType.TIME)
         if time_dim.model.is_time_zone_required_in_geography():
             if self._config.model.use_project_geography_time_zone:
@@ -540,6 +542,7 @@ class DatasetSchemaHandlerBase(abc.ABC):
             self._project_time_dim,
             model_years=model_years,
             value_columns=value_columns,
+            wrap_time_allowed=wrap_time_allowed,
         )
 
         if time_dim.model.is_time_zone_required_in_geography():

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -1044,8 +1044,13 @@ class ProjectRegistryManager(RegistryManagerBase):
         dtime = dataset_config.get_dimension(DimensionType.TIME)
         ptime = project_config.get_base_dimension(DimensionType.TIME)
 
+        dataset_id = dataset_config.model.dataset_id
+        wrap_time = project_config.get_dataset(dataset_id).wrap_time_allowed
+
         df = dtime.build_time_dataframe()
-        dtime._convert_time_to_project_time_interval(df, project_time_dim=ptime)
+        dtime._convert_time_to_project_time_interval(
+            df, project_time_dim=ptime, wrap_time=wrap_time
+        )
 
     @track_timing(timer_stats_collector)
     def _check_dataset_base_to_project_base_mappings(

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -1045,7 +1045,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         ptime = project_config.get_base_dimension(DimensionType.TIME)
 
         df = dtime.build_time_dataframe()
-        dtime._convert_time_to_project_time_interval(df=df, project_time_dim=ptime, wrap_time=True)
+        dtime._convert_time_to_project_time_interval(df, project_time_dim=ptime)
 
     @track_timing(timer_stats_collector)
     def _check_dataset_base_to_project_base_mappings(

--- a/dsgrid/tests/common.py
+++ b/dsgrid/tests/common.py
@@ -12,7 +12,7 @@ from dsgrid.registry.common import VersionUpdateType
 from dsgrid.registry.registry_database import DatabaseConnection
 from dsgrid.utils.files import dump_data, load_data
 
-TEST_PROJECT_PATH = Path(__file__).absolute().parent.parent.parent / "dsgrid-test-data"
+TEST_PROJECT_PATH = Path(__file__).absolute().parents[2] / "dsgrid-test-data"
 TEST_PROJECT_REPO = TEST_PROJECT_PATH / "test_efs"
 TEST_STANDARD_SCENARIOS_PROJECT_REPO = TEST_PROJECT_PATH / "standard_scenarios_2021"
 TEST_DATASET_DIRECTORY = TEST_PROJECT_PATH / "datasets"

--- a/emr/launch_emr.py
+++ b/emr/launch_emr.py
@@ -22,7 +22,7 @@ def build_package():
     :return: path to package
     :rtype: pathlib.Path
     """
-    pkgdir = Path(__file__).resolve().parent.parent
+    pkgdir = Path(__file__).resolve().parents[1]
 
     subprocess.run(
         [sys.executable, "setup.py", "sdist"],

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -15,10 +15,8 @@ from dsgrid.tests.common import (
     replace_dimension_names_with_current_ids,
 )
 
-STANDARD_SCENARIOS_PROJECT_REPO = (
-    Path(__file__).parent.parent.parent / "dsgrid-project-StandardScenarios"
-)
-DECARB_PROJECT_REPO = Path(__file__).parent.parent.parent / "dsgrid-project-DECARB"
+STANDARD_SCENARIOS_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-StandardScenarios"
+DECARB_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-DECARB"
 
 
 def test_register_dimensions_and_mappings(tmp_registry_db):

--- a/tests/test_derived_datasets.py
+++ b/tests/test_derived_datasets.py
@@ -30,7 +30,7 @@ from dsgrid.utils.spark import read_dataframe
 
 
 REGISTRY_PATH = (
-    Path(__file__).absolute().parent.parent
+    Path(__file__).absolute().parents[1]
     / "dsgrid-test-data"
     / "filtered_registries"
     / "simple_standard_scenarios"

--- a/tests/test_project_time.py
+++ b/tests/test_project_time.py
@@ -65,7 +65,6 @@ def test_no_unexpected_timezone():
 
 def test_build_time_dataframe(project, resstock, comstock):
     project_time_dim = project.config.get_base_dimension(DimensionType.TIME)
-    # alteratively, project_time_dim = resstock._handler._project_time_dim
     resstock_time_dim = resstock.config.get_dimension(DimensionType.TIME)
     comstock_time_dim = comstock.config.get_dimension(DimensionType.TIME)
     check_time_dataframe(project_time_dim)

--- a/tests/test_project_time.py
+++ b/tests/test_project_time.py
@@ -146,9 +146,15 @@ def test_convert_to_project_time_2(project, resstock, comstock, tempo):
     resstock_time_dim.model.timezone = TimeZone.UTC
     # no error expected because time is being wrapped from time_interval_type alignment
     compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=False)
+
     # project, dataset same time range and time interval type but different time zone, wrap_time is needed
     resstock_time_dim.model.time_interval_type = project_time_dim.model.time_interval_type
-    compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=True)
+    dataset_id = "resstock_conus_2022_reference"
+    wrap_time = project.config.get_dataset(dataset_id).wrap_time_allowed
+    assert wrap_time is False, f"{wrap_time=} for {dataset_id=}, expecting False"
+    compare_time_conversion(
+        resstock_time_dim, project_time_dim, wrap_time=wrap_time, expect_error=True
+    )
     compare_time_conversion(
         resstock_time_dim, project_time_dim, wrap_time=True, expect_error=False
     )
@@ -158,7 +164,7 @@ def test_convert_to_project_time_2(project, resstock, comstock, tempo):
     )
 
 
-def test_make_project_datafrme(project, resstock, comstock, tempo):
+def test_make_project_dataframe(project, resstock, comstock, tempo):
     tempo.make_project_dataframe(project.config)
     comstock.make_project_dataframe(project.config)
     resstock.make_project_dataframe(project.config)

--- a/tests/test_project_time.py
+++ b/tests/test_project_time.py
@@ -79,7 +79,6 @@ def test_convert_to_project_time(registry_mgr):
         converted_data=tempo_data_mapped_time,
     )
 
-    project_time_dim.model.wrap_time_allowed = True  # <--- TODO turn to comment
     # [2.1] test time-wrap when dataset and project have different time interval type
     # expect no error with original dataset and project time configs
     compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=False)


### PR DESCRIPTION
Completes JIRA Story DSGRID-
Closes GitHub Issue #274 

## Description
Add "wrap_time_allowed" as a project InputDatasetModel parameter. Via this parameter, project can tell dsgrid whether time-wrapping is allowed when mapping dataset time to project time due to difference in time zone.

Note: when aligning time_interval_type, time-wrapping is automatically applied if the time range spills out to a different year after shifting for the interval type.

dsgrid-test-data PR: https://github.com/dsgrid/dsgrid-test-data/pull/39

If dGen dataset is being registered with CY2018 in UTC, we'll need a Decarb PR as well to add wrap_time_allowed=True to project.json5's dGen input dataset config.

@ashreeta - I think this PR is ready to be tested with dGen's UTC dataset submission to project.

### Graphical explanation of time-wrapping
![dsgrid_time_wrapping](https://github.com/dsgrid/dsgrid/assets/36629962/6fa3737b-036e-439e-96be-56ebbb0e1e23)


## Checklist

- [x] Tests exercising the new feature or bug fix
- [x] All tests pass
- [ ] At least one code review approval
- [ ] Consider transferring TODOs to JIRA or GitHub
