### PR TITLE
Dt/fix skew

### DIFF
--- a/dsgrid/cli/query.py
+++ b/dsgrid/cli/query.py
@@ -293,6 +293,7 @@ def run_project_query(
     force,
 ):
     """Run a query on a dsgrid project."""
+    scratch_dir = get_value_from_context(ctx, "scratch_dir")
     query = ProjectQueryModel.from_file(query_definition_file)
     conn = DatabaseConnection.from_url(
         get_value_from_context(ctx, "url"),
@@ -312,6 +313,7 @@ def run_project_query(
         ctx,
         submitter.submit,
         query,
+        scratch_dir,
         persist_intermediate_table=persist_intermediate_table,
         load_cached_table=load_cached_table,
         zip_file=zip_file,

--- a/dsgrid/dataset/dataset_schema_handler_one_table.py
+++ b/dsgrid/dataset/dataset_schema_handler_one_table.py
@@ -180,6 +180,7 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
             # There is currently no case that needs model years or value columns.
             ld_df = self._convert_time_dimension(ld_df, project_config)
 
+        # TODO: This might need to handle data skew in the future.
         ld_df = self._remap_dimension_columns(ld_df, True)
         value_columns = set(ld_df.columns).intersection(self.get_value_columns_mapped_to_project())
         ld_df = self._apply_fraction(ld_df, value_columns)
@@ -212,7 +213,11 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
             ld_df = self._convert_time_dimension(ld_df, project_config)
 
         ld_df = self._remap_dimension_columns(
-            ld_df, True, filtered_records=context.get_record_ids()
+            ld_df,
+            True,
+            filtered_records=context.get_record_ids(),
+            handle_data_skew=True,
+            scratch_dir_context=context.scratch_dir_context,
         )
         value_columns = set(ld_df.columns).intersection(self.get_value_columns_mapped_to_project())
         ld_df = self._apply_fraction(ld_df, value_columns)
@@ -220,6 +225,12 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
             DimensionType.METRIC
         ).get_records_dataframe()
         ld_df = self._convert_units(ld_df, project_metric_records, value_columns)
+        # print("start write")
+        # breakpoint()
+        # ld_df.write.mode("overwrite").parquet("tmp.parquet")
+        # spark = get_spark_session()
+        # ld_df = spark.read.load("tmp.parquet")
+        # print("done with read back")
         if not convert_time_before_project_mapping:
             m_year_df = context.try_get_record_ids_by_dimension_type(DimensionType.MODEL_YEAR)
             if m_year_df is None:

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -74,6 +74,7 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
             # There is currently no case that needs model years or value columns.
             ld_df = self._convert_time_dimension(ld_df, project_config)
 
+        # TODO: This might need to handle data skew in the future.
         null_lk_df = self._remap_dimension_columns(null_lk_df, False)
         ld_df = self._remap_dimension_columns(ld_df, True)
         value_columns = set(ld_df.columns).intersection(self.get_value_columns_mapped_to_project())
@@ -115,7 +116,11 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
             ld_df = self._convert_time_dimension(ld_df, project_config)
 
         ld_df = self._remap_dimension_columns(
-            ld_df, True, filtered_records=context.get_record_ids()
+            ld_df,
+            True,
+            filtered_records=context.get_record_ids(),
+            handle_data_skew=True,
+            scratch_dir_context=context.scratch_dir_context,
         )
         value_columns = set(ld_df.columns).intersection(self.get_value_columns_mapped_to_project())
         if "scaling_factor" in ld_df.columns:

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -94,7 +94,7 @@ class Project:
         """
         if dataset_id not in self.list_datasets():
             raise DSGValueNotRegistered(
-                f"{dataset_id} is not expected by {self.config.project_id}"
+                f"{dataset_id} is not expected by {self.config.model.project_id}"
             )
 
         return dataset_id in self._dataset_configs

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -1126,7 +1126,6 @@ class ProjectRegistryManager(RegistryManagerBase):
         df = config.make_dimension_association_table(dataset_id, context)
         path = context.get_temp_filename(suffix=".parquet")
         df = write_dataframe_and_auto_partition(df, path)
-        context.add_tracked_path(path)
         logger.info("Wrote dimension associations for dataset %s", dataset_id)
         return df
 

--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -14,12 +14,10 @@ from dsgrid.utils.timing import timer_stats_collector, track_timing
 logger = logging.getLogger(__name__)
 
 
-@track_timing(timer_stats_collector)
 def map_and_reduce_stacked_dimension(df, records, column):
     if "fraction" not in df.columns:
         df = df.withColumn("fraction", F.lit(1.0))
     # map and consolidate from_fraction only
-    # TODO: can remove this if we do it at registration time
     records = records.filter("to_id IS NOT NULL")
 
     df = (
@@ -27,7 +25,7 @@ def map_and_reduce_stacked_dimension(df, records, column):
         .drop("from_id")
         .drop(column)
         .withColumnRenamed("to_id", column)
-    ).filter(f"{column} IS NOT NULL")
+    )
     nonfraction_cols = [x for x in df.columns if x not in {"fraction", "from_fraction"}]
     df = df.fillna(1.0, subset=["from_fraction"]).selectExpr(
         *nonfraction_cols, "fraction*from_fraction AS fraction"

--- a/dsgrid/utils/scratch_dir_context.py
+++ b/dsgrid/utils/scratch_dir_context.py
@@ -9,7 +9,7 @@ class ScratchDirContext:
 
     def __init__(self, scratch_dir: Path):
         self._scratch_dir = scratch_dir
-        self._paths: list[Path] = []
+        self._paths: set[Path] = set()
         if not self._scratch_dir.exists():
             self._scratch_dir.mkdir()
 
@@ -20,13 +20,13 @@ class ScratchDirContext:
 
     def add_tracked_path(self, path: Path) -> None:
         """Add tracking of a path in the scratch directory."""
-        self._paths.append(path)
+        self._paths.add(path)
 
     def list_tracked_paths(self) -> list[Path]:
         """Return a list of paths being tracked."""
-        return self._paths[:]
+        return list(self._paths)
 
-    def get_temp_filename(self, prefix=None, suffix=None) -> Path:
+    def get_temp_filename(self, prefix=None, suffix=None, add_tracked_path=True) -> Path:
         """Return a temporary filename based in the scratch directory.
 
         Parameters
@@ -35,8 +35,13 @@ class ScratchDirContext:
             Forwarded to NamedTemporaryFile.
         suffix : str | None
             Forwarded to NamedTemporaryFile.
+        add_tracked_path : bool
+            If True, add tracking of the path
         """
         with NamedTemporaryFile(dir=self._scratch_dir, prefix=prefix, suffix=suffix) as f:
+            path = Path(f.name)
+            if add_tracked_path:
+                self._paths.add(path)
             return Path(f.name)
 
     def finalize(self) -> None:

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -632,7 +632,6 @@ def create_dataframe_from_product(
         if not f_out.closed:
             f_out.close()
 
-    context.add_tracked_path(csv_dir)
     spark = get_spark_session()
     df = spark.read.csv(str(csv_dir), header=False, schema=schema)
     return df

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,15 +1,21 @@
+import logging
 import math
+import os
 
 import pyspark.sql.functions as F
 import pytest
 from pyspark.sql.types import StructType, IntegerType
 
+from dsgrid.config.dimension_mapping_base import DimensionMappingType
+from dsgrid.dimension.base_models import DimensionType
 from dsgrid.utils.dataset import (
     apply_scaling_factor,
     map_and_reduce_pivoted_dimension,
     is_noop_mapping,
     remove_invalid_null_timestamps,
+    repartition_if_needed_by_mapping,
 )
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import get_spark_session
 
 
@@ -269,6 +275,52 @@ def test_apply_scaling_factor():
     assert df2.select("a").agg(F.sum("a").alias("sum_a")).collect()[0].sum_a == 1 * 5 + 2 * 6 + 3
     assert df2.select("b").agg(F.sum("b").alias("sum_b")).collect()[0].sum_b == 2 * 5 + 3 * 6 + 4
     assert df2.select("bystander").agg(F.sum("bystander").alias("c")).collect()[0].c == 1 + 1 + 1
+
+
+def test_repartition_if_needed_by_mapping(tmp_path, caplog, dataframes):
+    df, _, value_columns = dataframes
+    context = ScratchDirContext(tmp_path)
+    with caplog.at_level(logging.INFO):
+        df = repartition_if_needed_by_mapping(
+            df,
+            value_columns,
+            DimensionMappingType.ONE_TO_MANY_DISAGGREGATION,
+            DimensionType.GEOGRAPHY,
+            context,
+        )
+        assert "Completed repartition" in caplog.text
+
+
+def test_repartition_if_needed_by_mapping_override(tmp_path, caplog, dataframes):
+    df, _, value_columns = dataframes
+    context = ScratchDirContext(tmp_path)
+    os.environ["DSGRID_SKIP_MAPPING_SKEW_REPARTITION"] = "true"
+    try:
+        with caplog.at_level(logging.INFO):
+            df = repartition_if_needed_by_mapping(
+                df,
+                value_columns,
+                DimensionMappingType.ONE_TO_MANY_DISAGGREGATION,
+                DimensionType.GEOGRAPHY,
+                context,
+            )
+            assert "DSGRID_SKIP_MAPPING_SKEW_REPARTITION is true" in caplog.text
+    finally:
+        os.environ.pop("DSGRID_SKIP_MAPPING_SKEW_REPARTITION")
+
+
+def test_repartition_if_needed_by_mapping_not_needed(tmp_path, caplog, dataframes):
+    df, _, value_columns = dataframes
+    context = ScratchDirContext(tmp_path)
+    with caplog.at_level(logging.DEBUG):
+        df = repartition_if_needed_by_mapping(
+            df,
+            value_columns,
+            DimensionMappingType.ONE_TO_ONE,
+            DimensionType.GEOGRAPHY,
+            context,
+        )
+        assert "Repartition is not needed" in caplog.text
 
 
 # TODO: enable this when we decide if and how to handle NULL values in mean operations.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,7 +5,9 @@ from dsgrid.project import Project
 from dsgrid.dataset.dataset import Dataset
 from dsgrid.dimension.base_models import DimensionType, DimensionCategory
 from dsgrid.exceptions import DSGValueNotRegistered, DSGInvalidDimensionMapping
+from dsgrid.dsgrid_rc import DsgridRuntimeConfig
 from dsgrid.registry.registry_manager import RegistryManager
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 
 
 PROJECT_ID = "test_efs"
@@ -80,7 +82,12 @@ def test_dimension_map_and_reduce_in_dataset(cached_registry):
 
     load_data_df = dataset._handler._load_data
     load_data_lookup_df = dataset._handler._load_data_lookup
-    mapped_load_data = dataset._handler._remap_dimension_columns(load_data_df, True)
+    mapped_load_data = dataset._handler._remap_dimension_columns(
+        load_data_df,
+        True,
+        handle_data_skew=True,
+        scratch_dir_context=ScratchDirContext(DsgridRuntimeConfig.load().get_scratch_dir()),
+    )
     mapped_load_data_lookup = dataset._handler._remap_dimension_columns(load_data_lookup_df, False)
 
     # [1] check that mapped tables contain all to_id records from mappings

--- a/tests/test_scratch_dir_context.py
+++ b/tests/test_scratch_dir_context.py
@@ -11,7 +11,6 @@ def add_content(context: ScratchDirContext) -> tuple[Path, list[Path]]:
         assert not filename.exists()
         filename.touch()
         files.append(filename)
-        context.add_tracked_path(filename)
 
     directory = context.scratch_dir / "my_dir"
     directory.mkdir()


### PR DESCRIPTION
This PR addresses an issue we experienced mapping the DECARB buildings dataset to project. The disaggregation of region to county caused a major issue where one Spark executor thread got stuck, seemingly indefinitely. A message like this was repeated continually. It appears to be caused by data skew, though the imbalance didn't seem too severe. The fact that this dataset uses the unpivoted format likely made the problem much worse.

I used a variation of what online sources call a "salting technique” to unblock the Spark workers. I basically just repartitioned and serialized the dataset immediately after mapping the geography dimension. The logic repartitions on the first value column, which is hopefully sufficiently random to always result in balanced partitions.

