### PR TITLE
Fix handling of single/multi dimension requirements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 	url = https://github.com/dsgrid/dsgrid-project-StandardScenarios
 	branch = main
 [submodule "dsgrid-project-DECARB"]
-	path = dsgrid-project-DECARB
+	path = main
 	url = https://github.com/dsgrid/dsgrid-project-DECARB
 	branch = dt/multi-dim-requirements

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "dsgrid-project-DECARB"]
 	path = dsgrid-project-DECARB
 	url = https://github.com/dsgrid/dsgrid-project-DECARB
-	branch = main
+	branch = dt/multi-dim-requirements

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -462,12 +462,14 @@ class RequiredDimensionsModel(DSGBaseModel):
                         )
                         raise ValueError(msg)
                     dims.append(field)
+
             if len(dims) < 2:
                 msg = (
                     "A multi_dimensional dimension requirement must contain at least two "
                     f"dimensions: {item}"
                 )
                 raise ValueError(msg)
+
             dim_combo = tuple(sorted(dims))
             if dim_combo not in dim_combos:
                 for other in dim_combos:

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -9,6 +9,7 @@ from dsgrid.cli.dsgrid_admin import cli as admin_cli
 from dsgrid.registry.registry_database import DatabaseConnection
 from dsgrid.registry.registry_manager import RegistryManager
 from dsgrid.utils.files import load_data
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.tests.common import TEST_DATASET_DIRECTORY
 from dsgrid.tests.common import (
     map_dimension_names_to_ids,
@@ -308,3 +309,10 @@ def test_register_dsgrid_projects(tmp_registry_db):
             ],
         )
         assert result.exit_code == 0
+
+    conn = DatabaseConnection(database=db_name)
+    manager = RegistryManager.load(conn, offline_mode=True)
+    project = manager.project_manager.load_project("US_DOE_DECARB_2023")
+    config = project.config
+    context = ScratchDirContext(tmpdir)
+    config.make_dimension_association_table("decarb_2023_transport", context)

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -11,7 +11,6 @@ from dsgrid.config.project_config import (
     ProjectDimensionQueryNamesModel,
     RequiredDimensionsModel,
     RequiredDimensionRecordsModel,
-    _get_needed_base_dimensions,
 )
 from dsgrid.registry.registry_manager import RegistryManager
 from dsgrid.tests.common import (
@@ -110,7 +109,7 @@ def test_duplicate_dimension_requirements():
         )
 
 
-def test_invalid_multi_dimensional_requirement():
+def test_invalid_multi_dimensional_requirement_too_few():
     single_dim_data = {"subsector": {"base": ["subsectors"]}}
     multi_dim_data = [{"metric": {"base": ["electricity_ev_ldv_home_l1"]}}]
     with pytest.raises(ValueError, match="at least two"):
@@ -120,51 +119,21 @@ def test_invalid_multi_dimensional_requirement():
         )
 
 
-def test_get_needed_base_dimensions():
-    data = [
+def test_invalid_multi_dimensional_requirement_partial_intersection():
+    single_dim_data = {"sector": {"base": ["sector1"]}}
+    multi_dim_data = [
         {
-            "subsector": {
-                "base": ["bev_compact"],
-            },
-            "metric": {
-                "base": ["electricity_ev_ldv_home_l1"],
-            },
-            "model_year": {
-                "base": ["2028", "2030", "2035"],
-            },
+            "metric": {"base": ["metric1"]},
+            "subsector": {"base": ["subsector1"]},
         },
         {
-            "metric": {
-                "base": ["electricity_ev_mhdv_depot_ac", "electricity_ev_mhdv_depot_dc"],
-            },
-            "subsector": {
-                "base": ["bev_light_medium_truck", "bev_medium_truck"],
-            },
-        },
-        {
-            "subsector": {
-                "base": ["rail_transit"],
-            },
-            "metric": {
-                "base": ["electricity_rail_transit"],
-            },
-            "geography": {"base": ["04013", "04019", "05119", "06001"]},
-        },
-        {
-            "sector": {
-                "subset": [{"name": "test", "selectors": ["transportation_sectors"]}],
-            },
-            "scenario": {
-                "base": ["high"],
-            },
+            "metric": {"base": ["metric2"]},
+            "subsector": {"base": ["subsector2"]},
+            "geography": {"base": ["geography1"]},
         },
     ]
-    models = [RequiredDimensionRecordsModel(**x) for x in data]
-    res = _get_needed_base_dimensions(models)
-    assert res.get(("metric", "subsector")) == (
-        "geography",
-        "model_year",
-    )
-    assert res.get(("metric", "model_year", "subsector")) == ("geography",)
-    assert res.get(("geography", "metric", "subsector")) == ("model_year",)
-    assert ("scenario", "sector") not in res
+    with pytest.raises(ValueError, match="must have a full intersection"):
+        RequiredDimensionsModel(
+            single_dimensional=RequiredDimensionRecordsModel(**single_dim_data),
+            multi_dimensional=[RequiredDimensionRecordsModel(**x) for x in multi_dim_data],
+        )


### PR DESCRIPTION
Fixes two issues:
1. We were not properly checking for redundancy in the single and multi-dimensional requirements in the project config.
2. We did not handle the case where one multi-dimensional requirement has a partial overlap in dimensions with another requirement. We can assume that any missing dimension should use the base dimension records.

Requires https://github.com/dsgrid/dsgrid-project-DECARB/pull/22