### PR TITLE
Optimize queries

### DIFF
--- a/dsgrid/dataset/pivoted_table.py
+++ b/dsgrid/dataset/pivoted_table.py
@@ -65,8 +65,6 @@ class PivotedTableHandler(TableFormatHandlerBase):
         )
         for agg in aggregations:
             dimension_query_name = None
-            # The metric dimension must be included in an aggregation so that we can handle
-            # possible unit conversions.
             metric_dim_config = None
             for dim_type, column in agg.iter_dimensions_to_keep():
                 query_name = column.dimension_query_name
@@ -87,6 +85,8 @@ class PivotedTableHandler(TableFormatHandlerBase):
                             msg = f"Bug: encountered {dimension_query_name=} twice"
                             raise Exception(msg)
                         dimension_query_name = query_name
+            if metric_dim_config is None:
+                raise Exception(f"Bug: A metric dimension is not included in {agg}")
             if dimension_query_name is None:
                 continue
             dim_config = self.project_config.get_dimension(dimension_query_name)

--- a/dsgrid/dataset/pivoted_table.py
+++ b/dsgrid/dataset/pivoted_table.py
@@ -187,5 +187,6 @@ class PivotedTableHandler(TableFormatHandlerBase):
             metadata = final_metadata.get_metadata(dim_type)
             if dim_type in dropped_dimensions and metadata:
                 metadata.clear()
-            context.replace_dimension_metadata(dim_type, metadata, dataset_id=self.dataset_id)
+            if dim_type != pivoted_dimension_type:
+                context.replace_dimension_metadata(dim_type, metadata, dataset_id=self.dataset_id)
         return df

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -153,6 +153,13 @@ class AggregationModel(DSGBaseModel):
             raise ValueError("aggregation_function cannot be None")
         return aggregation_function
 
+    @field_validator("dimensions")
+    @classmethod
+    def check_for_metric(cls, dimensions):
+        if not dimensions.metric:
+            raise ValueError("An AggregationModel must include the metric dimension.")
+        return dimensions
+
     @field_serializer("aggregation_function")
     def serialize_aggregation_function(self, function, _):
         return function.__name__

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -62,7 +62,7 @@ from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import (
     models_to_dataframe,
     get_unique_values,
-    write_dataframe_and_auto_partition,
+    persist_intermediate_query,
 )
 from dsgrid.utils.utilities import check_uniqueness, display_table
 from .common import (
@@ -1124,8 +1124,7 @@ class ProjectRegistryManager(RegistryManagerBase):
     ):
         logger.info("Make dimension association table for %s", dataset_id)
         df = config.make_dimension_association_table(dataset_id, context)
-        path = context.get_temp_filename(suffix=".parquet")
-        df = write_dataframe_and_auto_partition(df, path)
+        df = persist_intermediate_query(df, context, auto_partition=True)
         logger.info("Wrote dimension associations for dataset %s", dataset_id)
         return df
 

--- a/dsgrid/units/energy.py
+++ b/dsgrid/units/energy.py
@@ -241,6 +241,10 @@ def convert_units_unpivoted(
             .selectExpr("to_id AS id", "from_unit")
             .distinct()
         )
+    if unit_df.exceptAll(to_unit_records.selectExpr("id", "unit AS from_unit")).rdd.isEmpty():
+        logger.info("Return early because the units match.")
+        return df
+
     df = df.join(unit_df, on=df[metric_column] == unit_df["id"]).drop("id")
     tmp3 = to_unit_records.select("id", "unit").withColumnRenamed(unit_col, "to_unit")
     df = df.join(tmp3, on=df[metric_column] == tmp3["id"]).drop("id")

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -473,6 +473,34 @@ def overwrite_dataframe_file(filename: Path | str, df: DataFrame) -> DataFrame:
 
 
 @track_timing(timer_stats_collector)
+def persist_intermediate_query(
+    df: DataFrame, scratch_dir_context: ScratchDirContext, auto_partition=False
+) -> DataFrame:
+    """Persist the current query to files and then read it back and return it.
+
+    This is advised when the query has become too complex or when the query might be evaluated
+    twice.
+
+    Parameters
+    ----------
+    df : DataFrame
+    scratch_dir_context : ScratchDirContext
+    auto_partition : bool
+        If True, call write_dataframe_and_auto_partition.
+
+    Returns
+    -------
+    DataFrame
+    """
+    spark = get_spark_session()
+    tmp_file = scratch_dir_context.get_temp_filename(suffix=".parquet")
+    if auto_partition:
+        return write_dataframe_and_auto_partition(df, tmp_file)
+    df.write.parquet(str(tmp_file))
+    return spark.read.parquet(str(tmp_file))
+
+
+@track_timing(timer_stats_collector)
 def write_dataframe_and_auto_partition(
     df: DataFrame,
     filename: Path,

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -170,10 +170,25 @@ def test_unit_mapping(cached_registry):
 
 
 def test_invalid_drop_pivoted_dimension(tmp_path):
+    with pytest.raises(ValueError):
+        AggregationModel(
+            dimensions=DimensionQueryNamesModel(
+                geography=["county"],
+                metric=[],
+                model_year=["model_year"],
+                scenario=["scenario"],
+                sector=["sector"],
+                subsector=["subsector"],
+                time=["time_est"],
+                weather_year=["weather_2012"],
+            ),
+            aggregation_function="sum",
+        )
+
     invalid_agg = AggregationModel(
         dimensions=DimensionQueryNamesModel(
             geography=["county"],
-            metric=[],
+            metric=["end_use"],
             model_year=["model_year"],
             scenario=["scenario"],
             sector=["sector"],
@@ -183,6 +198,7 @@ def test_invalid_drop_pivoted_dimension(tmp_path):
         ),
         aggregation_function="sum",
     )
+    invalid_agg.dimensions.metric.clear()
     query = ProjectQueryModel(
         name="test",
         project=ProjectQueryParamsModel(


### PR DESCRIPTION
1. Queries on unpivoted datasets were running unit conversion when it wasn't necessary, causing a slow-down.
2. Persist the query before evaluating the function remove_invalid_null_timestamps. This removes redundant processing and caused a 2x speed-up in the TEMPO dataset.
3. Improve metric dimension checks. We can validate that an aggregation query includes the metric dimension up front.
4. Fix aggregation query when the target dataset is pivoted and the source has expected-missing data.