### PR TITLE
Simplify time dimension interfaces

### DIFF
--- a/dsgrid/config/annual_time_dimension_config.py
+++ b/dsgrid/config/annual_time_dimension_config.py
@@ -3,8 +3,10 @@ from datetime import timedelta
 
 import pandas as pd
 import pyspark.sql.functions as F
+from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType, StructField, IntegerType
 
+from dsgrid.config.date_time_dimension_config import DateTimeDimensionConfig
 from dsgrid.dimension.time import (
     MeasurementType,
     AnnualTimeRange,
@@ -13,7 +15,7 @@ from dsgrid.dimension.time import (
 from dsgrid.exceptions import DSGInvalidDataset
 from dsgrid.time.types import AnnualTimestampType
 from dsgrid.utils.timing import timer_stats_collector, track_timing
-from dsgrid.utils.spark import get_spark_session, custom_spark_conf, union
+from dsgrid.utils.spark import get_spark_session, custom_spark_conf
 from .dimensions import AnnualTimeDimensionModel
 from .time_dimension_base_config import TimeDimensionBaseConfig
 
@@ -55,13 +57,13 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
                 f"load_data {time_col}s do not match expected times. mismatch={mismatch}"
             )
 
-    def build_time_dataframe(self, model_years=None):
+    def build_time_dataframe(self):
         time_col = self.get_load_data_time_columns()
         assert len(time_col) == 1, time_col
         time_col = time_col[0]
         schema = StructType([StructField(time_col, IntegerType(), False)])
 
-        model_time = self.list_expected_dataset_timestamps(model_years=model_years)
+        model_time = self.list_expected_dataset_timestamps()
         df_time = get_spark_session().createDataFrame(model_time, schema=schema)
         return df_time
 
@@ -72,73 +74,71 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
         self,
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=None,
+        value_columns: set[str],
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):
-        assert model_years is not None
         assert value_columns is not None
         match self.model.measurement_type:
             case MeasurementType.MEASURED:
-                df = self.map_annual_time_measured_to_datetime(df, project_time_dim, model_years)
+                df = self.map_annual_time_measured_to_datetime(df, project_time_dim)
             case MeasurementType.TOTAL:
-                df = self.map_annual_total_to_datetime(
-                    df, project_time_dim, model_years, value_columns
-                )
+                df = self.map_annual_total_to_datetime(df, project_time_dim, value_columns)
             case _:
                 raise NotImplementedError(f"Unhandled: {self.model.measurement_type}")
 
         return df
 
-    def map_annual_time_measured_to_datetime(self, annual_df, dt_dim, model_years):
+    def map_annual_time_measured_to_datetime(
+        self, annual_df: DataFrame, dt_dim: DateTimeDimensionConfig
+    ):
         """Map a dataframe with MeasuredType.MEASURED to DateTime."""
-        time_col = self.get_load_data_time_columns()[0]
-        df = dt_dim.build_time_dataframe(model_years=model_years)
+        # Does this category even make sense? Why would someone report
+        # something other than total for annual?
         dt_time_col = dt_dim.get_load_data_time_columns()[0]
-        return df.join(annual_df, on=F.year(dt_time_col) == annual_df[time_col]).drop(time_col)
+        df = dt_dim.build_time_dataframe()
+        with custom_spark_conf(
+            {"spark.sql.session.timeZone": dt_dim.model.datetime_format.timezone.tz_name}
+        ):
+            years = df.withColumn("year", F.year(dt_time_col)).select("year").distinct().collect()
+            if len(years) != 1:
+                raise Exception("Bug: project time has more than one year: {years=}")
+        return df.crossJoin(annual_df)
 
-    def map_annual_total_to_datetime(self, annual_df, dt_dim, model_years, value_columns):
+    def map_annual_total_to_datetime(
+        self, annual_df: DataFrame, dt_dim: DateTimeDimensionConfig, value_columns: set[str]
+    ):
         """Map a dataframe with MeasuredType.TOTAL to DateTime."""
         assert (
             dt_dim.model.time_type == TimeDimensionType.DATETIME
         ), "dt_dim must be datetime type."
         frequency = dt_dim.model.frequency
-        time_col = self.get_load_data_time_columns()[0]
-        dfs = []
-        for model_year in model_years:
-            if self.model.include_leap_day and model_year % 4 == 0:
+        df = dt_dim.build_time_dataframe()
+        dt_time_col = dt_dim.get_load_data_time_columns()[0]
+        with custom_spark_conf(
+            {"spark.sql.session.timeZone": dt_dim.model.datetime_format.timezone.tz_name}
+        ):
+            years = df.withColumn("year", F.year(dt_time_col)).select("year").distinct().collect()
+            if len(years) != 1:
+                raise Exception("Bug: project time has more than one year: {years=}")
+            year = years[0].year
+            if self.model.include_leap_day and year % 4 == 0:
                 measured_duration = timedelta(days=366)
             else:
                 measured_duration = timedelta(days=365)
-            df = dt_dim.build_time_dataframe(model_years=[model_year])
-            dt_time_col = dt_dim.get_load_data_time_columns()[0]
-            with custom_spark_conf({"spark.sql.session.timeZone": "UTC"}):
-                tmp_col = f"{dt_time_col}_utc"
-                df = df.withColumn(
-                    tmp_col,
-                    F.from_utc_timestamp(
-                        dt_time_col, dt_dim.model.datetime_format.timezone.tz_name
-                    ),
-                )
-                df = df.join(annual_df, on=F.year(df[tmp_col]) == annual_df[time_col]).drop(
-                    time_col, tmp_col
-                )
-            for column in value_columns:
-                df = df.withColumn(column, F.col(column) / (measured_duration / frequency))
-            if not df.rdd.isEmpty():
-                dfs.append(df)
-
-        return union(dfs)
+        df2 = df.crossJoin(annual_df)
+        for column in value_columns:
+            df2 = df2.withColumn(column, F.col(column) / (measured_duration / frequency))
+        return df2
 
     def get_frequency(self):
         return timedelta(days=365)
 
-    def get_time_ranges(self, model_years=None):
+    def get_time_ranges(self):
         ranges = []
         frequency = self.get_frequency()
         for start, end in self._build_time_ranges(
-            self.model.ranges, self.model.str_format, model_years=model_years, tz=self.get_tzinfo()
+            self.model.ranges, self.model.str_format, tz=self.get_tzinfo()
         ):
             start = pd.Timestamp(start)
             end = pd.Timestamp(end)
@@ -161,13 +161,7 @@ class AnnualTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_time_interval_type(self):
         return None
 
-    def list_expected_dataset_timestamps(self, model_years=None):
-        if model_years is not None:
-            # We do not expect to need this.
-            raise NotImplementedError(
-                f"No support for {model_years=} in {type(self)}.list_expected_dataset_timestamps"
-            )
-
+    def list_expected_dataset_timestamps(self):
         timestamps = []
         for time_range in self.model.ranges:
             start, end = (int(time_range.start), int(time_range.end))

--- a/dsgrid/config/annual_time_dimension_config.py
+++ b/dsgrid/config/annual_time_dimension_config.py
@@ -11,6 +11,7 @@ from dsgrid.dimension.base_models import DimensionType
 from dsgrid.dimension.time import AnnualTimeRange
 from dsgrid.exceptions import DSGInvalidDataset
 from dsgrid.time.types import AnnualTimestampType
+from dsgrid.dimension.time_utils import is_leap_year
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import get_spark_session, custom_spark_conf
@@ -138,7 +139,7 @@ def map_annual_historical_time_to_date_time(
         if len(years) != 1:
             msg = "DateTime dimension has more than one year: {years=}"
             raise NotImplementedError(msg)
-        if annual_dim.model.include_leap_day and years[0].year % 4 == 0:
+        if annual_dim.model.include_leap_day and is_leap_year(years[0].year):
             measured_duration = timedelta(days=366)
         else:
             measured_duration = timedelta(days=365)

--- a/dsgrid/config/date_time_dimension_config.py
+++ b/dsgrid/config/date_time_dimension_config.py
@@ -99,14 +99,14 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
             )
         return
 
-    def build_time_dataframe(self, model_years=None):
+    def build_time_dataframe(self):
         # Note: DF.show() displays time in session time, which may be confusing.
         # But timestamps are stored correctly here
 
         time_col = self.get_load_data_time_columns()
         assert len(time_col) == 1, time_col
         time_col = time_col[0]
-        model_time = self.list_expected_dataset_timestamps(model_years=model_years)
+        model_time = self.list_expected_dataset_timestamps()
         schema = StructType([StructField(time_col, TimestampType(), False)])
         df_time = get_spark_session().createDataFrame(model_time, schema=schema)
         return df_time
@@ -140,8 +140,7 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
         self,
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=None,
+        value_columns: set[str],
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):
@@ -164,10 +163,10 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_frequency(self):
         return self.model.frequency
 
-    def get_time_ranges(self, model_years=None):
+    def get_time_ranges(self):
         ranges = []
         for start, end in self._build_time_ranges(
-            self.model.ranges, self.model.str_format, model_years=model_years, tz=self.get_tzinfo()
+            self.model.ranges, self.model.str_format, tz=self.get_tzinfo()
         ):
             ranges.append(
                 DatetimeRange(
@@ -193,9 +192,9 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_time_interval_type(self):
         return self.model.time_interval_type
 
-    def list_expected_dataset_timestamps(self, model_years=None):
+    def list_expected_dataset_timestamps(self):
         timestamps = []
-        for time_range in self.get_time_ranges(model_years=model_years):
+        for time_range in self.get_time_ranges():
             timestamps += [DatetimeTimestampType(x) for x in time_range.list_time_range()]
         return timestamps
 

--- a/dsgrid/config/date_time_dimension_config.py
+++ b/dsgrid/config/date_time_dimension_config.py
@@ -1,4 +1,5 @@
 import logging
+
 from pyspark.sql.types import (
     StructType,
     StructField,
@@ -10,6 +11,7 @@ from dsgrid.dimension.time import DatetimeRange, DatetimeFormat
 from dsgrid.exceptions import DSGInvalidDataset, DSGInvalidParameter
 from dsgrid.time.types import DatetimeTimestampType
 from dsgrid.utils.timing import timer_stats_collector, track_timing
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import get_spark_session
 from .dimensions import DateTimeDimensionModel
 from .time_dimension_base_config import TimeDimensionBaseConfig
@@ -141,6 +143,7 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
         df,
         project_time_dim,
         value_columns: set[str],
+        scratch_dir_context: ScratchDirContext,
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):
@@ -155,6 +158,7 @@ class DateTimeDimensionConfig(TimeDimensionBaseConfig):
         df = self._convert_time_to_project_time(
             df,
             project_time_dim,
+            scratch_dir_context,
             wrap_time=wrap_time_allowed,
             time_based_data_adjustment=time_based_data_adjustment,
         )

--- a/dsgrid/config/dimension_mapping_base.py
+++ b/dsgrid/config/dimension_mapping_base.py
@@ -190,7 +190,7 @@ class DimensionMappingBaseModel(DSGBaseModel):
         Field(
             title="from_fraction_tolerance",
             description="Tolerance to apply when checking from_fraction column sums",
-            default=1e-9,
+            default=1e-6,
         ),
     ]
     to_fraction_tolerance: Annotated[
@@ -198,7 +198,7 @@ class DimensionMappingBaseModel(DSGBaseModel):
         Field(
             title="to_fraction_tolerance",
             description="Tolerance to apply when checking to_fraction column sums",
-            default=1e-9,
+            default=1e-6,
         ),
     ]
     description: Annotated[
@@ -347,7 +347,7 @@ class DimensionMappingPreRegisteredBaseModel(DSGBaseModel):
         Field(
             title="from_fraction_tolerance",
             description="Tolerance value to apply to the from_fraction column",
-            default=1e-9,
+            default=1e-6,
         ),
     ]
     to_fraction_tolerance: Annotated[
@@ -355,7 +355,7 @@ class DimensionMappingPreRegisteredBaseModel(DSGBaseModel):
         Field(
             title="to_fraction_tolerance",
             description="Tolerance value to apply to the to_fraction column",
-            default=1e-9,
+            default=1e-6,
         ),
     ]
 

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -369,7 +369,7 @@ class DimensionModel(DimensionBaseModel):
                 )
             return records
 
-        with open(info.data["filename"], encoding="utf-8") as f_in:
+        with open(info.data["filename"], encoding="utf-8-sig") as f_in:
             records = convert_record_dicts_to_classes(
                 csv.DictReader(f_in), dim_class, check_duplicates=["id"]
             )

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -696,6 +696,16 @@ class AnnualTimeDimensionModel(TimeDimensionBaseModel):
             return ranges
         return _check_time_ranges(ranges, info.data["str_format"], timedelta(days=365))
 
+    @field_validator("measurement_type")
+    @classmethod
+    def check_measurement_type(cls, measurement_type: MeasurementType) -> MeasurementType:
+        # This restriction exists because any other measurement type would require a frequency,
+        # and that isn't part of the model definition.
+        if measurement_type != MeasurementType.TOTAL:
+            msg = f"Annual time currently only supports MeasurementType total: {measurement_type}"
+            raise ValueError(msg)
+        return measurement_type
+
     def is_time_zone_required_in_geography(self):
         return False
 

--- a/dsgrid/config/index_time_dimension_config.py
+++ b/dsgrid/config/index_time_dimension_config.py
@@ -23,6 +23,7 @@ from dsgrid.dimension.time_utils import (
 from dsgrid.exceptions import DSGInvalidDataset, DSGInvalidParameter
 from dsgrid.time.types import DatetimeTimestampType, IndexTimestampType
 from dsgrid.utils.timing import timer_stats_collector, track_timing
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import get_spark_session
 from .dimensions import IndexTimeDimensionModel
 from .time_dimension_base_config import TimeDimensionBaseConfig
@@ -90,6 +91,7 @@ class IndexTimeDimensionConfig(TimeDimensionBaseConfig):
         df,
         project_time_dim,
         value_columns: set[str],
+        scratch_dir_context: ScratchDirContext,
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):
@@ -104,6 +106,7 @@ class IndexTimeDimensionConfig(TimeDimensionBaseConfig):
         df = self._convert_time_to_project_time(
             df,
             project_time_dim,
+            scratch_dir_context,
             wrap_time=wrap_time_allowed,
         )
 

--- a/dsgrid/config/mapping_tables.py
+++ b/dsgrid/config/mapping_tables.py
@@ -162,7 +162,7 @@ class MappingTableModel(DimensionMappingBaseModel):
                 records = convert_record_dicts_to_classes(records, MappingTableRecordModel)
             return records
 
-        with open(info.data["filename"], encoding="utf8") as f_in:
+        with open(info.data["filename"], encoding="utf-8-sig") as f_in:
             return convert_record_dicts_to_classes(csv.DictReader(f_in), MappingTableRecordModel)
 
     @field_serializer("filename")

--- a/dsgrid/config/noop_time_dimension_config.py
+++ b/dsgrid/config/noop_time_dimension_config.py
@@ -14,7 +14,7 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
     def check_dataset_time_consistency(self, load_data_df, time_columns):
         pass
 
-    def build_time_dataframe(self, model_years=None):
+    def build_time_dataframe(self):
         raise NotImplementedError(f"Cannot build a time dataframe for a {type(self)}")
 
     # def build_time_dataframe_with_time_zone(self):
@@ -24,8 +24,7 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
         self,
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=None,
+        value_columns: set[str],
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):
@@ -34,7 +33,7 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_frequency(self):
         return timedelta(days=0)
 
-    def get_time_ranges(self, model_years=None):
+    def get_time_ranges(self):
         return []
 
     def get_load_data_time_columns(self):
@@ -46,5 +45,5 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_time_interval_type(self):
         return None
 
-    def list_expected_dataset_timestamps(self, model_years=None):
+    def list_expected_dataset_timestamps(self):
         return []

--- a/dsgrid/config/noop_time_dimension_config.py
+++ b/dsgrid/config/noop_time_dimension_config.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from .dimensions import NoOpTimeDimensionModel
 from .time_dimension_base_config import TimeDimensionBaseConfig
 
@@ -25,6 +26,7 @@ class NoOpTimeDimensionConfig(TimeDimensionBaseConfig):
         df,
         project_time_dim,
         value_columns: set[str],
+        scratch_dir_context: ScratchDirContext,
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):

--- a/dsgrid/config/representative_period_time_dimension_config.py
+++ b/dsgrid/config/representative_period_time_dimension_config.py
@@ -20,6 +20,7 @@ from dsgrid.time.types import (
     OneWeekdayDayAndOneWeekendDayPerMonthByHourType,
 )
 from dsgrid.utils.timing import track_timing, timer_stats_collector
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import get_spark_session
 from .dimensions import RepresentativePeriodTimeDimensionModel
 from .time_dimension_base_config import TimeDimensionBaseConfig
@@ -76,6 +77,7 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
         df,
         project_time_dim,
         value_columns: set[str],
+        scratch_dir_context: ScratchDirContext,
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):

--- a/dsgrid/config/representative_period_time_dimension_config.py
+++ b/dsgrid/config/representative_period_time_dimension_config.py
@@ -58,12 +58,12 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
             time_columns,
         )
 
-    def build_time_dataframe(self, model_years=None):
+    def build_time_dataframe(self):
         time_cols = self.get_load_data_time_columns()
         schema = StructType(
             [StructField(time_col, IntegerType(), False) for time_col in time_cols]
         )
-        model_time = self.list_expected_dataset_timestamps(model_years=model_years)
+        model_time = self.list_expected_dataset_timestamps()
         df_time = get_spark_session().createDataFrame(model_time, schema=schema)
 
         return df_time
@@ -75,8 +75,7 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
         self,
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=None,
+        value_columns: set[str],
         wrap_time_allowed=False,
         time_based_data_adjustment=None,
     ):
@@ -116,7 +115,7 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
 
         time_df = None
         try:
-            project_time_df = project_time_dim.build_time_dataframe(model_years=model_years)
+            project_time_df = project_time_dim.build_time_dataframe()
             map_time = "timestamp_to_map"
             project_time_df = shift_time_interval(
                 project_time_df,
@@ -165,11 +164,7 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_frequency(self):
         return self._format_handler.get_frequency()
 
-    def get_time_ranges(self, model_years=None):
-        if model_years is not None:
-            # We do not expect to need this.
-            raise NotImplementedError(f"No support for {model_years=} in {type(self)}")
-
+    def get_time_ranges(self):
         return self._format_handler.get_time_ranges(
             self.model.ranges,
             self.model.time_interval_type,
@@ -185,10 +180,7 @@ class RepresentativePeriodTimeDimensionConfig(TimeDimensionBaseConfig):
     def get_time_interval_type(self):
         return self.model.time_interval_type
 
-    def list_expected_dataset_timestamps(self, model_years=None):
-        if model_years is not None:
-            # We do not expect to need this.
-            raise NotImplementedError(f"No support for {model_years=} in {type(self)}")
+    def list_expected_dataset_timestamps(self):
         return self._format_handler.list_expected_dataset_timestamps(self.model.ranges)
 
 

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -46,16 +46,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         """
 
     @abc.abstractmethod
-    def build_time_dataframe(
-        self,
-        model_years: Optional[list[int]] = None,
-    ):
+    def build_time_dataframe(self):
         """Build time dimension as specified in config in a spark dataframe.
-
-        Parameters
-        ----------
-        model_years : None | list[int]
-            If specified, repeat the timestamps for each model year.
 
         Returns
         -------
@@ -80,8 +72,7 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         self,
         df,
         project_time_dim,
-        model_years: Optional[list[int]] = None,
-        value_columns: Optional[set[str]] = None,
+        value_columns: set[str],
         wrap_time_allowed: bool = False,
         time_based_data_adjustment: Optional[TimeBasedDataAdjustmentModel] = None,
     ):
@@ -91,11 +82,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         ----------
         df : pyspark.sql.DataFrame
         project_time_dim : TimeDimensionBaseConfig
-        model_years : None | list[int]
-            Model years required by the project. Not required for all time dimension types.
-        value_columns : None | set[str]
-            Columns in the dataframe that represent load values. Not required for all time
-            dimension types.
+        value_columns : set[str]
+            Columns in the dataframe that represent load values.
         wrapped_time_allowed : bool
             Whether to allow time-wrapping to align time zone
         time_based_data_adjustment : None | TimeBasedDataAdjustmentModel
@@ -160,17 +148,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         return df.withColumnRenamed(time_cols[0], self.model.dimension_query_name)
 
     @abc.abstractmethod
-    def get_time_ranges(
-        self,
-        model_years: Optional[list[int]] = None,
-    ):
+    def get_time_ranges(self):
         """Return time ranges with timezone applied.
-
-        Parameters
-        ----------
-        model_years : None | list[int]
-            If set, replace the base year in the time ranges with these model years. In this case
-            each range must be in the same year.
 
         Returns
         -------
@@ -200,17 +179,8 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         """
 
     @abc.abstractmethod
-    def list_expected_dataset_timestamps(
-        self,
-        model_years: Optional[list[int]] = None,
-    ):
+    def list_expected_dataset_timestamps(self):
         """Return a list of the timestamps expected in the load_data table.
-
-        Parameters
-        ----------
-        model_years : None | list[int]
-            If set, replace the base year in the time ranges with these model years. In this case
-            each range must be in the same year.
 
         Returns
         -------
@@ -321,7 +291,6 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         self,
         time_ranges: TimeRangeModel,
         str_format: str,
-        model_years: Optional[list[int]] = None,
         tz: Optional[TimeZone] = None,
     ):
-        return build_time_ranges(time_ranges, str_format, model_years=model_years, tz=tz)
+        return build_time_ranges(time_ranges, str_format, tz=tz)

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -79,7 +79,7 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         value_columns: set[str],
         scratch_dir_context: ScratchDirContext,
         wrap_time_allowed: bool = False,
-        data_adjustment: Optional[TimeBasedDataAdjustmentModel] = None,
+        time_based_data_adjustment: Optional[TimeBasedDataAdjustmentModel] = None,
     ) -> DataFrame:
         """Convert input df to use project's time format and time zone.
 

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -22,11 +22,8 @@ from dsgrid.dimension.time_utils import (
     apply_time_wrap,
 )
 from dsgrid.config.dimensions import TimeRangeModel
-
-
 from dsgrid.utils.scratch_dir_context import ScratchDirContext
-
-# from dsgrid.utils.spark import persist_intermediate_table
+from dsgrid.utils.spark import persist_intermediate_table
 
 
 logger = logging.getLogger(__name__)
@@ -214,9 +211,11 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         if time_based_data_adjustment is None:
             time_based_data_adjustment = TimeBasedDataAdjustmentModel()
 
-        # It's possible that we will want to enable this in some cases.
-        # Current results show about the same timings with and without.
-        # df = persist_intermediate_table(df, context)
+        # At least in the case of DECARB-industrial, this is required to get through
+        # dataset-to-project mapping on one Kestrel node.
+        # That might not be true for other datasets, and so more customization might be
+        # required.
+        df = persist_intermediate_table(df, context)
 
         time_col = project_time_dim.get_load_data_time_columns()
         assert len(time_col) == 1, time_col

--- a/dsgrid/dataset/dataset.py
+++ b/dsgrid/dataset/dataset.py
@@ -5,6 +5,7 @@ import logging
 
 from dsgrid.config.dataset_schema_handler_factory import make_dataset_schema_handler
 from dsgrid.query.query_context import QueryContext
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +61,8 @@ class Dataset(DatasetBase):
             )
         )
 
-    def make_project_dataframe(self, project_config):
-        return self._handler.make_project_dataframe(project_config)
+    def make_project_dataframe(self, project_config, scratch_dir_context: ScratchDirContext):
+        return self._handler.make_project_dataframe(project_config, scratch_dir_context)
 
     def make_project_dataframe_from_query(self, query: QueryContext, project_config):
         return self._handler.make_project_dataframe_from_query(query, project_config)

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -49,7 +49,7 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
     @track_timing(timer_stats_collector)
     def check_consistency(self):
         self._check_lookup_data_consistency()
-        self._check_dataset_time_consistency(self._load_data)
+        self._check_dataset_time_consistency(self._load_data.join(self._load_data_lookup, on="id"))
         self._check_dataset_internal_consistency()
 
     def make_dimension_association_table(self) -> DataFrame:

--- a/dsgrid/dimension/time_utils.py
+++ b/dsgrid/dimension/time_utils.py
@@ -624,3 +624,8 @@ def apply_time_wrap(df, project_time_dim, diff: set):
         )
 
     return df
+
+
+def is_leap_year(year: int) -> bool:
+    """Return True if the year is a leap year."""
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/dsgrid/dimension/time_utils.py
+++ b/dsgrid/dimension/time_utils.py
@@ -1,4 +1,5 @@
 """Functions related to time"""
+
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 import logging
@@ -26,7 +27,7 @@ from dsgrid.dimension.time import (
     adjust_timestamp_by_dst_offset,
 )
 from dsgrid.config.dimensions import TimeRangeModel
-from dsgrid.exceptions import DSGInvalidDimension, DSGInvalidOperation
+from dsgrid.exceptions import DSGInvalidOperation
 from dsgrid.time.types import DatetimeTimestampType, IndexTimestampType
 from dsgrid.utils.spark import get_spark_session
 
@@ -229,40 +230,31 @@ def get_dls_fallback_time_change_by_time_range(
 def build_time_ranges(
     time_ranges: TimeRangeModel,
     str_format: str,
-    model_years: Optional[list[int]] = None,
     tz: Optional[TimeZone] = None,
 ):
     ranges = []
-    allowed_year = None
     for time_range in time_ranges:
         start = datetime.strptime(time_range.start, str_format)
         end = datetime.strptime(time_range.end, str_format)
-        if model_years is not None:
-            if start.year != end.year or (allowed_year is not None and start.year != allowed_year):
-                raise DSGInvalidDimension(
-                    f"All time ranges must be in the same year if model_years is set: {model_years=}"
-                )
-            allowed_year = start.year
-        for year in model_years or [start.year]:
-            start_adj = datetime(
-                year=year,
-                month=start.month,
-                day=start.day,
-                hour=start.hour,
-                minute=start.minute,
-                second=start.second,
-                microsecond=start.microsecond,
-            )
-            end_adj = datetime(
-                year=end.year + year - start.year,
-                month=end.month,
-                day=end.day,
-                hour=end.hour,
-                minute=end.minute,
-                second=end.second,
-                microsecond=end.microsecond,
-            )
-            ranges.append((pd.Timestamp(start_adj, tz=tz), pd.Timestamp(end_adj, tz=tz)))
+        start_adj = datetime(
+            year=start.year,
+            month=start.month,
+            day=start.day,
+            hour=start.hour,
+            minute=start.minute,
+            second=start.second,
+            microsecond=start.microsecond,
+        )
+        end_adj = datetime(
+            year=end.year,
+            month=end.month,
+            day=end.day,
+            hour=end.hour,
+            minute=end.minute,
+            second=end.second,
+            microsecond=end.microsecond,
+        )
+        ranges.append((pd.Timestamp(start_adj, tz=tz), pd.Timestamp(end_adj, tz=tz)))
 
     ranges.sort(key=lambda x: x[0])
     return ranges
@@ -270,7 +262,6 @@ def build_time_ranges(
 
 def get_time_ranges(
     time_dimension_config,  #: DateTimeDimensionConfig,
-    model_years: Optional[list[int]] = None,
     timezone: TimeZone = None,
     time_based_data_adjustment: TimeBasedDataAdjustmentModel = None,
 ):
@@ -287,9 +278,7 @@ def get_time_ranges(
         raise ValueError(msg)
 
     ranges = []
-    for start, end in build_time_ranges(
-        dt_ranges, dim_model.str_format, model_years=model_years, tz=timezone
-    ):
+    for start, end in build_time_ranges(dt_ranges, dim_model.str_format, tz=timezone):
         ranges.append(
             DatetimeRange(
                 start=start,
@@ -304,7 +293,6 @@ def get_time_ranges(
 
 def get_index_ranges(
     time_dimension_config,  #: IndexTimeDimensionConfig,
-    model_years: Optional[list[int]] = None,
     timezone: TimeZone = None,
     time_based_data_adjustment: TimeBasedDataAdjustmentModel = None,
 ):
@@ -313,9 +301,7 @@ def get_index_ranges(
         timezone = dim_model.get_tzinfo()
     dt_ranges = time_dimension_config._create_represented_time_ranges()
     ranges = []
-    time_ranges = build_time_ranges(
-        dt_ranges, dim_model.str_format, model_years=model_years, tz=timezone
-    )
+    time_ranges = build_time_ranges(dt_ranges, dim_model.str_format, tz=timezone)
     for index_range, time_range in zip(dim_model.ranges, time_ranges):
         ranges.append(
             IndexTimeRange(
@@ -332,14 +318,12 @@ def get_index_ranges(
 
 def list_timestamps(
     time_dimension_config,  #: DateTimeDimensionConfig,
-    model_years: Optional[list[int]] = None,
     timezone: TimeZone = None,
     time_based_data_adjustment: TimeBasedDataAdjustmentModel = None,
 ):
     timestamps = []
     for time_range in get_time_ranges(
         time_dimension_config,
-        model_years=model_years,
         timezone=timezone,
         time_based_data_adjustment=time_based_data_adjustment,
     ):
@@ -349,14 +333,12 @@ def list_timestamps(
 
 def list_time_indices(
     time_dimension_config,  #: IndexTimeDimensionConfig,
-    model_years: Optional[list[int]] = None,
     timezone: TimeZone = None,
     time_based_data_adjustment: TimeBasedDataAdjustmentModel = None,
 ):
     indices = []
     for index_range in get_index_ranges(
         time_dimension_config,
-        model_years=model_years,
         timezone=timezone,
         time_based_data_adjustment=time_based_data_adjustment,
     ):
@@ -366,7 +348,6 @@ def list_time_indices(
 
 def build_index_time_map(
     time_dimension_config,  #: IndexTimeDimensionConfig,
-    model_years=None,
     timezone=None,
     time_based_data_adjustment: Optional[TimeBasedDataAdjustmentModel] = None,
 ):
@@ -375,13 +356,11 @@ def build_index_time_map(
     time_col = time_col[0]
     indices = list_time_indices(
         time_dimension_config,
-        model_years=model_years,
         timezone=timezone,
         time_based_data_adjustment=time_based_data_adjustment,
     )
     timestamps = list_timestamps(
         time_dimension_config,
-        model_years=model_years,
         timezone=timezone,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -401,7 +380,7 @@ def build_index_time_map(
 
 
 def build_datetime_dataframe(
-    time_dimension_config, model_years=None, timezone=None, time_based_data_adjustment=None
+    time_dimension_config, timezone=None, time_based_data_adjustment=None
 ):
 
     time_col = time_dimension_config.get_load_data_time_columns()
@@ -409,7 +388,6 @@ def build_datetime_dataframe(
     time_col = time_col[0]
     model_time = list_timestamps(
         time_dimension_config,
-        model_years=model_years,
         timezone=timezone,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -419,7 +397,7 @@ def build_datetime_dataframe(
 
 
 def build_index_time_dataframe(
-    time_dimension_config, model_years=None, timezone=None, time_based_data_adjustment=None
+    time_dimension_config, timezone=None, time_based_data_adjustment=None
 ):
 
     time_col = time_dimension_config.get_load_data_time_columns()
@@ -427,7 +405,6 @@ def build_index_time_dataframe(
     time_col = time_col[0]
     model_time = list_time_indices(
         time_dimension_config,
-        model_years=model_years,
         timezone=timezone,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -440,7 +417,6 @@ def create_adjustment_map_from_model_time(
     time_dimension_config,  #: IndexTimeDimensionConfig,
     time_based_data_adjustment: TimeBasedDataAdjustmentModel,
     time_zone: TimeZone,
-    model_years: Optional[list[int]] = None,
 ):
     """Create data adjustment mapping from model_time to prevailing time (timestamp) of input time_zone."""
     time_col = list(DatetimeTimestampType._fields)
@@ -452,7 +428,6 @@ def create_adjustment_map_from_model_time(
     TZ_st, TZ_pt = time_zone.get_standard_time(), time_zone.get_prevailing_time()
     ranges = get_time_ranges(
         time_dimension_config,
-        model_years=model_years,
         timezone=TZ_pt.tz,
         time_based_data_adjustment=time_based_data_adjustment,
     )

--- a/dsgrid/dsgrid_rc.py
+++ b/dsgrid/dsgrid_rc.py
@@ -34,7 +34,7 @@ class DsgridRuntimeConfig(DSGBaseModel):
         """Load the dsgrid runtime config if it exists or one with default values."""
         rc_file = cls.path()
         if rc_file.exists():
-            data = json5.loads(rc_file.read_text(encoding="utf-8"))
+            data = json5.loads(rc_file.read_text(encoding="utf-8-sig"))
             return cls(**data)
         return cls()
 

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import pyspark.sql.functions as F
-from pyspark.sql import SparkSession, DataFrame
+from pyspark.sql import SparkSession
 from pyspark.sql.types import DoubleType
 
 from dsgrid.common import VALUE_COLUMN
@@ -165,7 +165,7 @@ class Project:
         output_dir: Path,
         overwrite=False,
         scratch_dir: Optional[Path] = None,
-    ) -> DataFrame:
+    ) -> Path:
         """Transform a dataset by mapping its dimensions to the project's dimensions and write it
         to the filesystem.
         """
@@ -181,7 +181,8 @@ class Project:
         dataset = self.get_dataset(dataset_id)
         with ScratchDirContext(scratch_dir) as context:
             df = dataset.make_project_dataframe(self._config, context)
-            return write_dataframe_and_auto_partition(df, output_file)
+            write_dataframe_and_auto_partition(df, output_file)
+            return output_file
 
     def _iter_datasets(self):
         for dataset in self.config.model.datasets:

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -1,7 +1,9 @@
 """Interface to a dsgrid project."""
 
 import logging
+import shutil
 from pathlib import Path
+from typing import Optional
 
 import pyspark.sql.functions as F
 from pyspark.sql import SparkSession, DataFrame
@@ -17,7 +19,8 @@ from dsgrid.dimension.base_models import DimensionType, DimensionCategory
 from dsgrid.dimension.dimension_filters import (
     SubsetDimensionFilterModel,
 )
-from dsgrid.exceptions import DSGInvalidQuery, DSGValueNotRegistered
+from dsgrid.dsgrid_rc import DsgridRuntimeConfig
+from dsgrid.exceptions import DSGInvalidQuery, DSGValueNotRegistered, DSGInvalidParameter
 from dsgrid.query.query_context import QueryContext
 from dsgrid.query.models import (
     StandaloneDatasetModel,
@@ -25,6 +28,7 @@ from dsgrid.query.models import (
     DatasetConstructionMethod,
     ColumnType,
 )
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import (
     read_dataframe,
     try_read_dataframe,
@@ -155,10 +159,29 @@ class Project:
         """
         self._datasets.pop(dataset_id, None)
 
-    def transform_dataset(self, dataset_id: str) -> DataFrame:
-        """Transform a dataset by mapping its dimensions to the project's dimensions."""
+    def transform_dataset(
+        self,
+        dataset_id: str,
+        output_dir: Path,
+        overwrite=False,
+        scratch_dir: Optional[Path] = None,
+    ) -> DataFrame:
+        """Transform a dataset by mapping its dimensions to the project's dimensions and write it
+        to the filesystem.
+        """
+        output_file = output_dir / "table.parquet"
+        if output_file.exists():
+            if not overwrite:
+                msg = f"{output_file=} already exists. Set overwrite=True or pass a different base directory."
+                raise DSGInvalidParameter(msg)
+            shutil.rmtree(output_file)
+
+        output_dir.mkdir(exist_ok=True)
+        scratch_dir = scratch_dir or DsgridRuntimeConfig.load().get_scratch_dir()
         dataset = self.get_dataset(dataset_id)
-        return dataset.make_project_dataframe(self._config)
+        with ScratchDirContext(scratch_dir) as context:
+            df = dataset.make_project_dataframe(self._config, context)
+            return write_dataframe_and_auto_partition(df, output_file)
 
     def _iter_datasets(self):
         for dataset in self.config.model.datasets:

--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -283,7 +283,9 @@ class DatasetRegistryManager(RegistryManagerBase):
                 dst = dataset_path / filename
                 # Writing with Spark is much faster than copying or rsync if there are
                 # multiple nodes in the cluster - much more parallelism.
-                write_dataframe(read_dataframe(path), dst)
+                # We set overwrite=True because if the path exists, it's only because a previous
+                # attempt failed.
+                write_dataframe(read_dataframe(path), dst, overwrite=True)
                 found_files = True
         if not found_files:
             msg = f"Did not find any data files in {config.dataset_path}"

--- a/dsgrid/registry/dataset_registry_manager.py
+++ b/dsgrid/registry/dataset_registry_manager.py
@@ -7,11 +7,9 @@ from pathlib import Path
 from typing import Type, Union
 
 from prettytable import PrettyTable
-from dsgrid.config.annual_time_dimension_config import AnnualTimeDimensionConfig
 
 from dsgrid.config.dataset_config import (
     DatasetConfig,
-    InputDatasetType,
     ALLOWED_DATA_FILES,
 )
 from dsgrid.config.dataset_schema_handler_factory import make_dataset_schema_handler
@@ -19,7 +17,7 @@ from dsgrid.config.dimensions_config import (
     DimensionsConfig,
     DimensionsConfigModel,
 )
-from dsgrid.dimension.base_models import DimensionType, check_required_dimensions
+from dsgrid.dimension.base_models import check_required_dimensions
 from dsgrid.exceptions import DSGInvalidDataset
 from dsgrid.registry.dimension_registry_manager import DimensionRegistryManager
 from dsgrid.registry.dimension_mapping_registry_manager import DimensionMappingRegistryManager
@@ -102,25 +100,7 @@ class DatasetRegistryManager(RegistryManagerBase):
         schema_handler = make_dataset_schema_handler(
             config, self._dimension_mgr, self._dimension_mapping_mgr
         )
-        self._check_model_year_time_consistency(config)
         schema_handler.check_consistency()
-
-    def _check_model_year_time_consistency(self, config):
-        model_year_dim = config.get_dimension(DimensionType.MODEL_YEAR)
-        time_dim = config.get_dimension(DimensionType.TIME)
-        if config.model.dataset_type == InputDatasetType.HISTORICAL and isinstance(
-            time_dim, AnnualTimeDimensionConfig
-        ):
-            annual_col = time_dim.get_load_data_time_columns()[0]
-            model_years = [int(x) for x in model_year_dim.get_unique_ids()]
-            model_years.sort()
-            years = sorted((x[annual_col] for x in time_dim.list_expected_dataset_timestamps()))
-            if years != model_years:
-                msg = (
-                    "Cannot map annual time to date time unless the dataset model years "
-                    f"match the time dimension: {years=} {model_years=}"
-                )
-                raise DSGInvalidDataset(msg)
 
     @property
     def dimension_manager(self) -> DimensionRegistryManager:

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -62,7 +62,7 @@ from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import (
     models_to_dataframe,
     get_unique_values,
-    write_dataframe_and_auto_partition,
+    persist_intermediate_table,
 )
 from dsgrid.utils.utilities import check_uniqueness, display_table
 from .common import (
@@ -1122,8 +1122,7 @@ class ProjectRegistryManager(RegistryManagerBase):
     ):
         logger.info("Make dimension association table for %s", dataset_id)
         df = config.make_dimension_association_table(dataset_id, context)
-        path = context.get_temp_filename(suffix=".parquet")
-        df = write_dataframe_and_auto_partition(df, path)
+        df = persist_intermediate_table(df, context)
         logger.info("Wrote dimension associations for dataset %s", dataset_id)
         return df
 

--- a/dsgrid/utils/files.py
+++ b/dsgrid/utils/files.py
@@ -90,7 +90,7 @@ def dump_line_delimited_json(data, filename, mode="w"):
         Mode to use for opening the file, defaults to "w"
 
     """
-    with open(filename, mode, encoding="utf-8") as f_out:
+    with open(filename, mode, encoding="utf-8-sig") as f_out:
         for obj in data:
             f_out.write(json.dumps(obj))
             f_out.write("\n")

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import shutil
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterable, Type, Union, get_origin, get_args
@@ -514,36 +515,62 @@ def write_dataframe_and_auto_partition(
     DSGInvalidParameter
         Raised if a non-Parquet file is passed
     """
+    suffix = Path(filename).suffix
+    if suffix != ".parquet":
+        msg = "write_dataframe_and_auto_partition only supports Parquet files: {filename=}"
+        raise DSGInvalidParameter(msg)
+
     spark = get_spark_session()
+    start_initial_write = time.time()
     if filename.exists():
         df = overwrite_dataframe_file(filename, df)
     else:
         df.write.parquet(str(filename))
         df = spark.read.parquet(str(filename))
+    end_initial_write = time.time()
+    duration_first_write = end_initial_write - start_initial_write
     partition_size_bytes = partition_size_mb * 1024 * 1024
     total_size = sum((x.stat().st_size for x in filename.glob("*.parquet")))
     desired = math.ceil(total_size / partition_size_bytes)
-    actual = df.rdd.getNumPartitions()
+    actual = len(list(filename.glob("*.parquet")))
     if abs(actual - desired) / desired * 100 < rtol_pct:
-        logger.debug("No change in number of partitions is needed for %s.", filename)
+        logger.info("No change in number of partitions is needed for %s.", filename)
     elif actual > desired:
         df = df.coalesce(desired)
         df = overwrite_dataframe_file(filename, df)
-        logger.debug("Coalesced %s to partition count %s", filename, desired)
+        duration_second_write = time.time() - end_initial_write
+        logger.info(
+            "Coalesced %s from partition count %s to %s. "
+            "duration_first_write=%s duration_second_write=%s",
+            filename,
+            actual,
+            desired,
+            duration_first_write,
+            duration_second_write,
+        )
     else:
         if columns is None:
             df = df.repartition(desired)
         else:
             df = df.repartition(desired, *columns)
         df = overwrite_dataframe_file(filename, df)
-        logger.debug("Repartitioned %s to partition count", filename, desired)
+        duration_second_write = time.time() - end_initial_write
+        logger.info(
+            "Repartitioned %s from partition count %s to %s. "
+            "duration_first_write=%s duration_second_write=%s",
+            filename,
+            actual,
+            desired,
+            duration_first_write,
+            duration_second_write,
+        )
 
     logger.info("Wrote dataframe to %s", filename)
     return df
 
 
 @track_timing(timer_stats_collector)
-def write_dataframe(df: DataFrame, filename: str | Path) -> None:
+def write_dataframe(df: DataFrame, filename: str | Path, overwrite: bool = False) -> None:
     """Write a Spark DataFrame, accounting for different file types.
 
     Parameters
@@ -551,7 +578,14 @@ def write_dataframe(df: DataFrame, filename: str | Path) -> None:
     filename : str
     df : pyspark.sql.DataFrame
     """
-    suffix = Path(filename).suffix
+    path = Path(filename)
+    if overwrite and path.exists():
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    suffix = path.suffix
     name = str(filename)
     if suffix == ".parquet":
         df.write.parquet(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from dsgrid.registry.registry_database import DatabaseConnection, RegistryDatabase
 from dsgrid.utils.files import load_data
 from dsgrid.utils.run_command import run_command, check_run_command
+from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import init_spark, get_spark_session
 from dsgrid.tests.common import (
     TEST_DATASET_DIRECTORY,
@@ -156,3 +157,9 @@ def spark_time_zone(request):
     spark.conf.set("spark.sql.session.timeZone", request.param)
     yield
     spark.conf.set("spark.sql.session.timeZone", orig)
+
+
+@pytest.fixture
+def scratch_dir_context(tmp_path):
+    with ScratchDirContext(tmp_path) as context:
+        yield context

--- a/tests/data/dimension_models/minimal/dimension_test_time.json5
+++ b/tests/data/dimension_models/minimal/dimension_test_time.json5
@@ -104,7 +104,7 @@
       ],
       str_format: "%Y",
       include_leap_day: true,
-      measurement_type: "mean",
+      measurement_type: "total",
     },
     { // #[5]
       "class": "Time",

--- a/tests/simple_standard_scenarios_datasets.py
+++ b/tests/simple_standard_scenarios_datasets.py
@@ -216,8 +216,9 @@ def build_tempo():
     tempo = project.get_dataset(dataset_id)
     lookup = tempo._handler._load_data_lookup
     load_data = tempo._handler._load_data
+    value_columns = tempo._handler.config.get_value_columns()
     tempo_data_mapped_time = tempo._handler._convert_time_dimension(
-        load_data.join(lookup, on="id").drop("id"), project.config, [], ["L1andL2"]
+        load_data.join(lookup, on="id").drop("id"), project.config, value_columns, ["L1andL2"]
     )
     return tempo_data_mapped_time
 

--- a/tests/test_annual_time.py
+++ b/tests/test_annual_time.py
@@ -155,23 +155,6 @@ def test_map_annual_time_total_to_datetime(
     expected_by_year = {
         x.time_year: x.electricity_sales / (366 * 24) for x in annual_dataframe.collect()
     }
-    _check_values(annual_dataframe, date_time_dimension, df, expected_by_year)
-
-
-def test_historical_annual_model_year_consistency_valid(annual_dataframe_with_model_year_valid):
-    df, time_col, model_year_col = annual_dataframe_with_model_year_valid
-    check_historical_annual_time_model_year_consistency(df, time_col, model_year_col)
-
-
-def test_historical_annual_model_year_consistency_invalid(
-    annual_dataframe_with_model_year_invalid,
-):
-    df, time_col, model_year_col = annual_dataframe_with_model_year_invalid
-    with pytest.raises(DSGInvalidDataset):
-        check_historical_annual_time_model_year_consistency(df, time_col, model_year_col)
-
-
-def _check_values(annual_dataframe, date_time_dimension, df, expected_by_year):
     num_rows = annual_dataframe.count()
     num_timestamps = 24 * 7
     assert df.count() == num_rows * num_timestamps
@@ -192,3 +175,16 @@ def _check_values(annual_dataframe, date_time_dimension, df, expected_by_year):
     )
     assert len(count_timestamps_per_model_year) == 1
     assert count_timestamps_per_model_year[0]["count_timestamps"] == num_timestamps
+
+
+def test_historical_annual_model_year_consistency_valid(annual_dataframe_with_model_year_valid):
+    df, time_col, model_year_col = annual_dataframe_with_model_year_valid
+    check_historical_annual_time_model_year_consistency(df, time_col, model_year_col)
+
+
+def test_historical_annual_model_year_consistency_invalid(
+    annual_dataframe_with_model_year_invalid,
+):
+    df, time_col, model_year_col = annual_dataframe_with_model_year_invalid
+    with pytest.raises(DSGInvalidDataset):
+        check_historical_annual_time_model_year_consistency(df, time_col, model_year_col)

--- a/tests/test_create_time_dimensions.py
+++ b/tests/test_create_time_dimensions.py
@@ -14,6 +14,7 @@ from pyspark.sql.types import (
     DoubleType,
 )
 
+from dsgrid.common import VALUE_COLUMN
 from dsgrid.config.dimensions_config import DimensionsConfigModel
 from dsgrid.utils.files import load_data
 from tests.data.dimension_models.minimal.models import DIMENSION_CONFIG_FILE_TIME
@@ -308,11 +309,11 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
             "fall_back_hour": "duplicate",
         }
     )
+    value_columns = {VALUE_COLUMN}
     df2 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -334,8 +335,7 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
     df3 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=None,
     )
@@ -355,8 +355,7 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
     df2 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -389,11 +388,11 @@ def local_time_conversion_tests(config, project_time_dim, df):
             "fall_back_hour": "duplicate",
         }
     )
+    value_columns = {VALUE_COLUMN}
     df2 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -406,8 +405,7 @@ def local_time_conversion_tests(config, project_time_dim, df):
     df3 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=None,
     )
@@ -726,11 +724,11 @@ def test_index_time_conversion_subhourly(
             "fall_back_hour": "duplicate",
         }
     )
+    value_columns = {VALUE_COLUMN}
     df2 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -754,8 +752,7 @@ def test_index_time_conversion_subhourly(
     df3 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=None,
     )
@@ -774,8 +771,7 @@ def test_index_time_conversion_subhourly(
     df2 = config.convert_dataframe(
         df,
         project_time_dim,
-        model_years=None,
-        value_columns=["value"],
+        value_columns,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )

--- a/tests/test_create_time_dimensions.py
+++ b/tests/test_create_time_dimensions.py
@@ -297,7 +297,7 @@ def to_utc(time_change):
     return [x.astimezone(ZoneInfo("UTC")) for x in time_change]
 
 
-def industrial_model_time_conversion_tests(config, project_time_dim, df):
+def industrial_model_time_conversion_tests(config, project_time_dim, df, scratch_dir_context):
     values = np.arange(0.0, 8784.0).tolist()
     n_df = df.count()
 
@@ -314,6 +314,7 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -336,6 +337,7 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=None,
     )
@@ -356,6 +358,7 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -377,7 +380,7 @@ def industrial_model_time_conversion_tests(config, project_time_dim, df):
     ), f"Expecting interpolated value {itpl_val} for CO, but not found."
 
 
-def local_time_conversion_tests(config, project_time_dim, df):
+def local_time_conversion_tests(config, project_time_dim, df, scratch_dir_context):
     values = np.arange(0.0, 8784.0).tolist()
 
     # [1] Duplicating fallback 1AM
@@ -393,6 +396,7 @@ def local_time_conversion_tests(config, project_time_dim, df):
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -406,6 +410,7 @@ def local_time_conversion_tests(config, project_time_dim, df):
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=None,
     )
@@ -680,18 +685,22 @@ def test_data_adjustment_mapping_table(index_time_dimension_model):
     ), f"Expecting interpolated indices: {itpl_indices} but found {indices2}"
 
 
-def test_index_time_conversion(index_time_dimension_model, time_dimension_model0, df_index_time):
-    """test industrial time with time_based_data_adjustment"""
+def test_index_time_conversion(
+    index_time_dimension_model, time_dimension_model0, df_index_time, scratch_dir_context
+):
+    """test industrial time with data_adjustment"""
     df = df_index_time
     project_time_dim = DateTimeDimensionConfig(time_dimension_model0)
     config = IndexTimeDimensionConfig(index_time_dimension_model)
     time_cols = config.get_load_data_time_columns()
     config.check_dataset_time_consistency(df, time_cols)
-    industrial_model_time_conversion_tests(config, project_time_dim, df)
+    industrial_model_time_conversion_tests(config, project_time_dim, df, scratch_dir_context)
 
 
 @pytest.mark.skip
-def test_datetime_conversion(datetime_eq_index_time_model, time_dimension_model0, df_date_time):
+def test_datetime_conversion(
+    datetime_eq_index_time_model, time_dimension_model0, df_date_time, scratch_dir_context
+):
     """test datetime_format.LOCAL_AS_STRINGS"""
     df = df_date_time
     project_time_dim = DateTimeDimensionConfig(time_dimension_model0)
@@ -699,13 +708,14 @@ def test_datetime_conversion(datetime_eq_index_time_model, time_dimension_model0
     df = config.convert_time_format(df)
     time_cols = config.get_load_data_time_columns()
     config.check_dataset_time_consistency(df, time_cols)
-    local_time_conversion_tests(config, project_time_dim, df)
+    local_time_conversion_tests(config, project_time_dim, df, scratch_dir_context)
 
 
 def test_index_time_conversion_subhourly(
     index_time_dimension_model_subhourly,
     datetime_eq_index_time_model_subhourly,
     df_index_time_subhourly,
+    scratch_dir_context,
 ):
     """test subhourly industrial time with time_based_data_adjustment"""
     df = df_index_time_subhourly
@@ -729,6 +739,7 @@ def test_index_time_conversion_subhourly(
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )
@@ -753,6 +764,7 @@ def test_index_time_conversion_subhourly(
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=None,
     )
@@ -772,6 +784,7 @@ def test_index_time_conversion_subhourly(
         df,
         project_time_dim,
         value_columns,
+        scratch_dir_context,
         wrap_time_allowed=True,
         time_based_data_adjustment=time_based_data_adjustment,
     )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -45,7 +45,7 @@ def test_project_load(cached_registry):
         assert isinstance(project, Project)
 
 
-def test_dataset_load(cached_registry):
+def test_dataset_load(cached_registry, scratch_dir_context):
     conn = cached_registry
     mgr = RegistryManager.load(conn, offline_mode=True)
     project = mgr.project_manager.load_project(PROJECT_ID)
@@ -53,7 +53,7 @@ def test_dataset_load(cached_registry):
     dataset = project.get_dataset(DATASET_ID)
 
     assert isinstance(dataset, Dataset)
-    data = dataset.make_project_dataframe(project.config)
+    data = dataset.make_project_dataframe(project.config, scratch_dir_context)
     assert "timestamp" in data.columns
     assert "cooling" in data.columns
     assert "fans" in data.columns

--- a/tests/test_project_time.py
+++ b/tests/test_project_time.py
@@ -74,7 +74,7 @@ def test_build_time_dataframe(project, resstock, comstock):
     check_time_dataframe(comstock_time_dim)
 
 
-def test_convert_time_for_tempo(project, tempo):
+def test_convert_time_for_tempo(project, tempo, scratch_dir_context):
     project_time_dim = project.config.get_base_dimension(DimensionType.TIME)
 
     tempo_data = tempo._handler._load_data.join(tempo._handler._load_data_lookup, on="id").drop(
@@ -82,7 +82,7 @@ def test_convert_time_for_tempo(project, tempo):
     )
     value_columns = tempo._handler.config.get_value_columns()
     tempo_data_mapped_time = tempo._handler._convert_time_dimension(
-        tempo_data, project.config, value_columns
+        tempo_data, project.config, value_columns, scratch_dir_context
     )
     tempo_data_with_tz = add_time_zone(
         tempo_data, project.config.get_base_dimension(DimensionType.GEOGRAPHY)
@@ -96,7 +96,7 @@ def test_convert_time_for_tempo(project, tempo):
     )
 
 
-def test_convert_time_for_comstock(project, comstock):
+def test_convert_time_for_comstock(project, comstock, scratch_dir_context):
     comstock_time_dim = comstock._handler.config.get_dimension(DimensionType.TIME)
 
     comstock_data = comstock._handler._load_data.join(comstock._handler._load_data_lookup, on="id")
@@ -105,11 +105,14 @@ def test_convert_time_for_comstock(project, comstock):
     )
     value_columns = comstock._handler.config.get_value_columns()
     comstock_time_dim.convert_dataframe(
-        comstock_data_with_tz, project.config.get_base_dimension(DimensionType.TIME), value_columns
+        comstock_data_with_tz,
+        project.config.get_base_dimension(DimensionType.TIME),
+        value_columns,
+        scratch_dir_context,
     )
 
 
-def test_convert_to_project_time_1(project, resstock, comstock, tempo):
+def test_convert_to_project_time_1(project, resstock, comstock, tempo, scratch_dir_context):
     """test convert time for different time interval type"""
     project_time_dim = project.config.get_base_dimension(DimensionType.TIME)
     resstock_time_dim = resstock._handler.config.get_dimension(DimensionType.TIME)
@@ -120,40 +123,62 @@ def test_convert_to_project_time_1(project, resstock, comstock, tempo):
     )
     value_columns = tempo._handler.config.get_value_columns()
     tempo_data_mapped_time = tempo._handler._convert_time_dimension(
-        tempo_data, project.config, value_columns
+        tempo_data, project.config, value_columns, scratch_dir_context
     )
 
     # project: period-beginning, dataset: period-ending, same time range
-    compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=False)
-    compare_time_conversion(comstock_time_dim, project_time_dim, expect_error=False)
     compare_time_conversion(
-        tempo_time_dim, project_time_dim, df=tempo_data_mapped_time, expect_error=False
+        resstock_time_dim, project_time_dim, scratch_dir_context, expect_error=False
+    )
+    compare_time_conversion(
+        comstock_time_dim, project_time_dim, scratch_dir_context, expect_error=False
+    )
+    compare_time_conversion(
+        tempo_time_dim,
+        project_time_dim,
+        scratch_dir_context,
+        df=tempo_data_mapped_time,
+        expect_error=False,
     )
 
     # project, dataset same time range and time interval type
     project_time_dim.model.time_interval_type = resstock_time_dim.model.time_interval_type
-    compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=False)
     compare_time_conversion(
-        tempo_time_dim, project_time_dim, df=tempo_data_mapped_time, expect_error=False
+        resstock_time_dim, project_time_dim, scratch_dir_context, expect_error=False
+    )
+    compare_time_conversion(
+        tempo_time_dim,
+        project_time_dim,
+        scratch_dir_context,
+        df=tempo_data_mapped_time,
+        expect_error=False,
     )
 
     # project: period-ending, dataset: period-begining, same time range
     comstock_time_dim.model.time_interval_type = TimeIntervalType.PERIOD_BEGINNING
-    compare_time_conversion(comstock_time_dim, project_time_dim, expect_error=False)
+    compare_time_conversion(
+        comstock_time_dim, project_time_dim, scratch_dir_context, expect_error=False
+    )
     tempo_time_dim.model.time_interval_type = TimeIntervalType.PERIOD_BEGINNING
     compare_time_conversion(
-        tempo_time_dim, project_time_dim, df=tempo_data_mapped_time, expect_error=False
+        tempo_time_dim,
+        project_time_dim,
+        scratch_dir_context,
+        df=tempo_data_mapped_time,
+        expect_error=False,
     )
 
 
-def test_convert_to_project_time_2(project, resstock, comstock, tempo):
+def test_convert_to_project_time_2(project, resstock, comstock, tempo, scratch_dir_context):
     """test convert time for different time zone"""
     project_time_dim = project.config.get_base_dimension(DimensionType.TIME)
     resstock_time_dim = resstock._handler.config.get_dimension(DimensionType.TIME)
 
     resstock_time_dim.model.datetime_format.timezone = TimeZone.UTC
     # error b/c time wrap from time_interval_type alignment is applied differently than wrap_time_allowed
-    compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=True)
+    compare_time_conversion(
+        resstock_time_dim, project_time_dim, scratch_dir_context, expect_error=True
+    )
 
     # project, dataset same time range and time interval type but different time zone, wrap_time is needed
     resstock_time_dim.model.time_interval_type = project_time_dim.model.time_interval_type
@@ -161,29 +186,44 @@ def test_convert_to_project_time_2(project, resstock, comstock, tempo):
     wrap_time = project.config.get_dataset(dataset_id).wrap_time_allowed
     assert wrap_time is False, f"{wrap_time=} for {dataset_id=}, expecting False"
     compare_time_conversion(
-        resstock_time_dim, project_time_dim, wrap_time=wrap_time, expect_error=True
+        resstock_time_dim,
+        project_time_dim,
+        scratch_dir_context,
+        wrap_time=wrap_time,
+        expect_error=True,
     )
     compare_time_conversion(
-        resstock_time_dim, project_time_dim, wrap_time=True, expect_error=False
+        resstock_time_dim,
+        project_time_dim,
+        scratch_dir_context,
+        wrap_time=True,
+        expect_error=False,
     )
     project_time_dim.model.datetime_format.timezone = TimeZone.PST
     compare_time_conversion(
-        resstock_time_dim, project_time_dim, wrap_time=True, expect_error=False
+        resstock_time_dim,
+        project_time_dim,
+        scratch_dir_context,
+        wrap_time=True,
+        expect_error=False,
     )
 
 
-def test_make_project_dataframe(project, resstock, comstock, tempo):
-    tempo.make_project_dataframe(project.config)
-    comstock.make_project_dataframe(project.config)
-    resstock.make_project_dataframe(project.config)
+def test_make_project_dataframe(project, resstock, comstock, tempo, scratch_dir_context):
+    tempo.make_project_dataframe(project.config, scratch_dir_context)
+    comstock.make_project_dataframe(project.config, scratch_dir_context)
+    resstock.make_project_dataframe(project.config, scratch_dir_context)
 
 
-def _compare_time_conversion(dataset_time_dim, project_time_dim, df=None, wrap_time=False):
+def _compare_time_conversion(
+    dataset_time_dim, project_time_dim, scratch_dir_context, df=None, wrap_time=False
+):
     project_time = project_time_dim.build_time_dataframe()
     if df is None:
         converted_dataset_time = dataset_time_dim._convert_time_to_project_time(
             dataset_time_dim.build_time_dataframe(),
             project_time_dim,
+            context=scratch_dir_context,
             wrap_time=wrap_time,
         )
     else:
@@ -198,15 +238,22 @@ def _compare_time_conversion(dataset_time_dim, project_time_dim, df=None, wrap_t
 
 
 def compare_time_conversion(
-    dataset_time_dim, project_time_dim, df=None, wrap_time=False, expect_error=False
+    dataset_time_dim,
+    project_time_dim,
+    scratch_dir_context,
+    df=None,
+    wrap_time=False,
+    expect_error=False,
 ):
     if expect_error:
         with pytest.raises(DSGDatasetConfigError):
             _compare_time_conversion(
-                dataset_time_dim, project_time_dim, df=df, wrap_time=wrap_time
+                dataset_time_dim, project_time_dim, scratch_dir_context, df=df, wrap_time=wrap_time
             )
     else:
-        _compare_time_conversion(dataset_time_dim, project_time_dim, df=df, wrap_time=wrap_time)
+        _compare_time_conversion(
+            dataset_time_dim, project_time_dim, scratch_dir_context, df=df, wrap_time=wrap_time
+        )
 
 
 def check_time_dataframe(time_dim):

--- a/tests/test_project_time.py
+++ b/tests/test_project_time.py
@@ -80,9 +80,8 @@ def test_convert_time_for_tempo(project, tempo, scratch_dir_context):
     tempo_data = tempo._handler._load_data.join(tempo._handler._load_data_lookup, on="id").drop(
         "id"
     )
-    value_columns = tempo._handler.config.get_value_columns()
     tempo_data_mapped_time = tempo._handler._convert_time_dimension(
-        tempo_data, project.config, value_columns, scratch_dir_context
+        tempo_data, project.config, tempo._handler.config.get_value_columns(), scratch_dir_context
     )
     tempo_data_with_tz = add_time_zone(
         tempo_data, project.config.get_base_dimension(DimensionType.GEOGRAPHY)
@@ -103,11 +102,10 @@ def test_convert_time_for_comstock(project, comstock, scratch_dir_context):
     comstock_data_with_tz = add_time_zone(
         comstock_data, comstock._handler.config.get_dimension(DimensionType.GEOGRAPHY)
     )
-    value_columns = comstock._handler.config.get_value_columns()
     comstock_time_dim.convert_dataframe(
         comstock_data_with_tz,
         project.config.get_base_dimension(DimensionType.TIME),
-        value_columns,
+        comstock._handler.config.get_value_columns(),
         scratch_dir_context,
     )
 
@@ -121,9 +119,8 @@ def test_convert_to_project_time_1(project, resstock, comstock, tempo, scratch_d
     tempo_data = tempo._handler._load_data.join(tempo._handler._load_data_lookup, on="id").drop(
         "id"
     )
-    value_columns = tempo._handler.config.get_value_columns()
     tempo_data_mapped_time = tempo._handler._convert_time_dimension(
-        tempo_data, project.config, value_columns, scratch_dir_context
+        tempo_data, project.config, tempo._handler.config.get_value_columns(), scratch_dir_context
     )
 
     # project: period-beginning, dataset: period-ending, same time range

--- a/tests/test_project_time.py
+++ b/tests/test_project_time.py
@@ -80,7 +80,10 @@ def test_convert_time_for_tempo(project, tempo):
     tempo_data = tempo._handler._load_data.join(tempo._handler._load_data_lookup, on="id").drop(
         "id"
     )
-    tempo_data_mapped_time = tempo._handler._convert_time_dimension(tempo_data, project.config)
+    value_columns = tempo._handler.config.get_value_columns()
+    tempo_data_mapped_time = tempo._handler._convert_time_dimension(
+        tempo_data, project.config, value_columns
+    )
     tempo_data_with_tz = add_time_zone(
         tempo_data, project.config.get_base_dimension(DimensionType.GEOGRAPHY)
     )
@@ -100,8 +103,9 @@ def test_convert_time_for_comstock(project, comstock):
     comstock_data_with_tz = add_time_zone(
         comstock_data, comstock._handler.config.get_dimension(DimensionType.GEOGRAPHY)
     )
+    value_columns = comstock._handler.config.get_value_columns()
     comstock_time_dim.convert_dataframe(
-        comstock_data_with_tz, project.config.get_base_dimension(DimensionType.TIME)
+        comstock_data_with_tz, project.config.get_base_dimension(DimensionType.TIME), value_columns
     )
 
 
@@ -114,7 +118,10 @@ def test_convert_to_project_time_1(project, resstock, comstock, tempo):
     tempo_data = tempo._handler._load_data.join(tempo._handler._load_data_lookup, on="id").drop(
         "id"
     )
-    tempo_data_mapped_time = tempo._handler._convert_time_dimension(tempo_data, project.config)
+    value_columns = tempo._handler.config.get_value_columns()
+    tempo_data_mapped_time = tempo._handler._convert_time_dimension(
+        tempo_data, project.config, value_columns
+    )
 
     # project: period-beginning, dataset: period-ending, same time range
     compare_time_conversion(resstock_time_dim, project_time_dim, expect_error=False)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -388,10 +388,8 @@ def test_transform_unpivoted_dataset(tmp_path):
 
 def test_transform_pivoted_dataset(tmp_path):
     project = get_project(QueryTestBase.get_database_name(), QueryTestBase.get_project_id())
-    path = project.transform_dataset("resstock_conus_2022_projected", tmp_path).filter(
-        "geography == '06037'"
-    )
-    df = read_parquet(path)
+    path = project.transform_dataset("resstock_conus_2022_projected", tmp_path)
+    df = read_parquet(path).filter("geography == '06037'")
     cooling = (
         df.select("electricity_cooling")
         .agg(F.sum("electricity_cooling").alias("cooling"))

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -372,7 +372,8 @@ def test_dimension_query_names_model():
 
 def test_transform_unpivoted_dataset(tmp_path):
     project = get_project(QueryTestBase.get_database_name(), QueryTestBase.get_project_id())
-    df = project.transform_dataset("comstock_conus_2022_projected", tmp_path)
+    path = project.transform_dataset("comstock_conus_2022_projected", tmp_path)
+    df = read_parquet(path)
     actual = (
         df.filter("geography == '06037'")
         .filter(F.col("metric").isin(["electricity_cooling", "electricity_heating"]))
@@ -387,9 +388,10 @@ def test_transform_unpivoted_dataset(tmp_path):
 
 def test_transform_pivoted_dataset(tmp_path):
     project = get_project(QueryTestBase.get_database_name(), QueryTestBase.get_project_id())
-    df = project.transform_dataset("resstock_conus_2022_projected", tmp_path).filter(
+    path = project.transform_dataset("resstock_conus_2022_projected", tmp_path).filter(
         "geography == '06037'"
     )
+    df = read_parquet(path)
     cooling = (
         df.select("electricity_cooling")
         .agg(F.sum("electricity_cooling").alias("cooling"))

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -370,9 +370,9 @@ def test_dimension_query_names_model():
     assert not diff
 
 
-def test_transform_unpivoted_dataset():
+def test_transform_unpivoted_dataset(tmp_path):
     project = get_project(QueryTestBase.get_database_name(), QueryTestBase.get_project_id())
-    df = project.transform_dataset("comstock_conus_2022_projected")
+    df = project.transform_dataset("comstock_conus_2022_projected", tmp_path)
     actual = (
         df.filter("geography == '06037'")
         .filter(F.col("metric").isin(["electricity_cooling", "electricity_heating"]))
@@ -385,9 +385,11 @@ def test_transform_unpivoted_dataset():
     )
 
 
-def test_transform_pivoted_dataset():
+def test_transform_pivoted_dataset(tmp_path):
     project = get_project(QueryTestBase.get_database_name(), QueryTestBase.get_project_id())
-    df = project.transform_dataset("resstock_conus_2022_projected").filter("geography == '06037'")
+    df = project.transform_dataset("resstock_conus_2022_projected", tmp_path).filter(
+        "geography == '06037'"
+    )
     cooling = (
         df.select("electricity_cooling")
         .agg(F.sum("electricity_cooling").alias("cooling"))

--- a/tests/test_representative_time.py
+++ b/tests/test_representative_time.py
@@ -116,7 +116,9 @@ def test_time_consistency(one_weekday_day_and_one_weekend_day_per_month_by_hour_
 
 @pytest.mark.parametrize("spark_time_zone", ["America/Los_Angeles"], indirect=True)
 def test_time_mapping(
-    one_weekday_day_and_one_weekend_day_per_month_by_hour_table, spark_time_zone
+    one_weekday_day_and_one_weekend_day_per_month_by_hour_table,
+    spark_time_zone,
+    scratch_dir_context,
 ):
     # This test sets the Spark session time zone so that it can check times consistently
     # across computers.
@@ -127,7 +129,9 @@ def test_time_mapping(
     config = make_one_weekday_day_and_one_weekend_day_per_month_by_hour_config()
     project_time_config = make_date_time_config()
     value_columns = {VALUE_COLUMN}
-    mapped_df = config.convert_dataframe(df, project_time_config, value_columns)
+    mapped_df = config.convert_dataframe(
+        df, project_time_config, value_columns, scratch_dir_context
+    )
     timestamps = mapped_df.select("timestamp").distinct().sort("timestamp").collect()
     zi = ZoneInfo("EST")
     est_timestamps = [x.timestamp.astimezone(zi) for x in timestamps]

--- a/tests/test_representative_time.py
+++ b/tests/test_representative_time.py
@@ -126,7 +126,8 @@ def test_time_mapping(
     df = df.withColumn("time_zone", F.lit("PacificPrevailing"))
     config = make_one_weekday_day_and_one_weekend_day_per_month_by_hour_config()
     project_time_config = make_date_time_config()
-    mapped_df = config.convert_dataframe(df, project_time_config)
+    value_columns = {VALUE_COLUMN}
+    mapped_df = config.convert_dataframe(df, project_time_config, value_columns)
     timestamps = mapped_df.select("timestamp").distinct().sort("timestamp").collect()
     zi = ZoneInfo("EST")
     est_timestamps = [x.timestamp.astimezone(zi) for x in timestamps]

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,8 @@
+from dsgrid.dimension.time_utils import is_leap_year
+
+
+def test_is_leap_year():
+    assert is_leap_year(2020)
+    assert not is_leap_year(2021)
+    assert not is_leap_year(2100)
+    assert is_leap_year(2400)


### PR DESCRIPTION
The time conversion code was incorrectly using the model year dimension. Removed model year from the `TimeDimensionBaseConfig` interfaces. Mapping the time dimension now requires case-by-case conditionals to account for requirements that span dimension types.

Added persistence of the intermediate query before making time adjustments in order to avoid repeated evaluations of the query.