### PR TITLE
Add instructions for connecting Tableau to dsgrid data

### DIFF
--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -3,27 +3,31 @@
 
 # USAGE:
 # Do not run this while connected to the VPN. You may get a certificate error while downloading spark.
-# docker build --tag spark_py312 --build-arg VERSION=x.y.z .
+# If you have a Mac with Apple silicon (not Intel CPUs), set this environment variable so that the
+# container will run on Intel CPUs.
+#   $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
+# Build the container:
+#   $ docker build --tag spark_py311 --build-arg VERSION=x.y.z .
 
 # This container can be converted to an Apptainer container on Kestrel with these commands:
 # Save and upload the docker image to Kestrel.
-# $ docker save -o spark_py312_vx.y.z.tar spark_py312
-# $ scp spark_py312_vx.y.z.tar <username>@kestrel.hpc.nrel.gov:/projects/dsgrid/containers
+# $ docker save -o spark_py311_vx.y.z.tar spark_py311
+# $ scp spark_py311_vx.y.z.tar <username>@kestrel.hpc.nrel.gov:/projects/dsgrid/containers
 # Acquire a compute node with local storage (salloc --tmp=1600G).
 # $ export APPTAINER_CACHEDIR=$TMPDIR
 # $ module load apptainer
 # Create writable image for testing and development or read-only image for production.
 # Writable
-# $ apptainer build --sandbox spark_py312 docker-archive://spark_py312_v0.1.0.tar
+# $ apptainer build --sandbox spark_py311 docker-archive://spark_py311_v0.1.0.tar
 # Read-only
-# $ apptainer build spark_py312_v0.1.0.sif docker-archive://spark_py312_v0.1.0.tar
+# $ apptainer build spark_py311_v0.1.0.sif docker-archive://spark_py311_v0.1.0.tar
 
 # Note: Apache provides a container with Spark and Python installed, but as of now it is Python 3.9
 # and dsgrid requires 3.10+. Whenever they have a newer Python, we can simplify this.
 # The Apache container is
 # FROM apache/spark-py
 
-FROM python:3.12-slim
+FROM python:3.11-slim
 USER root
 
 ARG VERSION
@@ -38,7 +42,7 @@ ENV CONTAINER_VERSION ${VERSION}
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y ca-certificates jq git nano default-jdk procps sysstat build-essential \
-    tini tmux tree vim wget openssh-client dropbear locales \
+    tini tmux tree unzip vim wget openssh-client dropbear locales \
     && rm -rf /var/lib/apt/lists/*
 
 # This prevents bash warnings on Kestrel.
@@ -73,7 +77,12 @@ RUN wget https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/${FULL_STR}.tgz \
 	&& cp ${SPARK_HOME}/kubernetes/dockerfiles/spark/entrypoint.sh /opt/entrypoint.sh \
 	&& chmod +x ${SPARK_HOME}/conf/spark-env.sh
 
-RUN pip install ipython jupyter pandas pyarrow
+RUN wget https://github.com/duckdb/duckdb/releases/download/v1.0.0/duckdb_cli-linux-amd64.zip \
+    && unzip duckdb_cli-linux-amd64.zip \
+    && rm duckdb_cli-linux-amd64.zip \
+    && mv duckdb /usr/local/bin
+
+RUN pip install ipython jupyter pandas pyarrow duckdb
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV PATH $PATH:${SPARK_HOME}/bin:${SPARK_HOME}/sbin

--- a/docs/source/how_tos/index.rst
+++ b/docs/source/how_tos/index.rst
@@ -16,6 +16,7 @@ This guide lists the steps to perform common dsgrid operations.
    set_up_standalone_registry
    run_dsgrid_on_kestrel
    spark_cluster_on_kestrel
+   visualize_data_with_tableau
 .. create_project_base_dimensions
    create_project_supplemental_dimensions
    create_derived_dataset

--- a/docs/source/how_tos/spark_cluster_on_kestrel.rst
+++ b/docs/source/how_tos/spark_cluster_on_kestrel.rst
@@ -7,6 +7,9 @@ This section assumes that you have cloned the HPC Spark setup scripts from this 
 <https://github.com/NREL/HPC.git>`_. If you are unfamiliar with that, please read the full details
 at :ref:`spark-on-hpc`.
 
+.. note:: The latest scripts currently supporting Kestrel are at this branch:
+   https://github.com/daniel-thom/HPC/tree/kestrel-update
+
 Compute Node Types
 ==================
 Spark works best with fast local storage. The standard Kestrel nodes do not have any local storage.
@@ -39,7 +42,7 @@ Steps
 
 .. code-block:: console
 
-    $ configure_and_start_spark.sh -M 10 -c /datasets/images/apache_spark/spark351_py312.sif
+    $ configure_and_start_spark.sh
 
 5. Set the Spark configuration environment variable.
 

--- a/docs/source/how_tos/visualize_data_with_tableau.rst
+++ b/docs/source/how_tos/visualize_data_with_tableau.rst
@@ -1,0 +1,46 @@
+***************************
+Visualize Data with Tableau
+***************************
+`Tableau <https://www.tableau.com/>`_ is a nice commercial tool for exploring and visualizing
+tabular data. Licenses are available to NRELians.
+
+In addition to making visualizations, Tableau makes it easy to select, filter, group, and describe
+your data in tables. This can be easier than the same operations in a Python REPL with ``pyspark``
+or ``pandas``.
+
+This page describes various ways to connect Tableau to dsgrid data after you've installed Tableau
+Desktop on your local computer.
+
+Parquet files on a local computer
+=================================
+This can be accomplished by connecting Tableau to DuckDB.
+
+1. Copy the Parquet files to your computer.
+
+2. Install `DuckDB <https://duckdb.org/docs/installation/>`_. Next to ``Environment``, select
+   ``Command line``.
+
+3. Install a JDBC driver and connect Tableau to DuckDB by following `DuckDB's
+   <https://duckdb.org/docs/guides/data_viewers/tableau>`_ instructions.
+
+   The documentation provides instructions for a "taco" connector. This does not appear to be
+   necessary for basic operations. You will likely benefit from it if you perform advanced SQL
+   operations.
+
+4. Create a view of your data as noted `here
+   <https://duckdb.org/docs/guides/data_viewers/tableau#database-creation>`_. You can also import
+   your data from Parquet files to a DuckDB database file if you prefer.
+
+5. Use Tableau with your DuckDB data source.
+
+Parquet files on an HPC
+========================
+This can be accomplished by connecting Tableau to a Spark cluster on the HPC.
+
+Follow the
+[Spark-on-HPC instructions](https://github.com/daniel-thom/HPC/blob/kestrel-update/applications/spark/README.md#visualize-data-with-tableau)
+
+CSV files on a local computer
+=============================
+1. Export the dsgrid data in Parquet files to CSV.
+2. Load the CSV files directly in Tableau.

--- a/docs/source/how_tos/visualize_data_with_tableau.rst
+++ b/docs/source/how_tos/visualize_data_with_tableau.rst
@@ -1,8 +1,8 @@
 ***************************
 Visualize Data with Tableau
 ***************************
-`Tableau <https://www.tableau.com/>`_ is a nice commercial tool for exploring and visualizing
-tabular data. Licenses are available to NRELians.
+`Tableau <https://www.tableau.com/>`_ is a commercial tool for exploring and visualizing
+tabular data.
 
 In addition to making visualizations, Tableau makes it easy to select, filter, group, and describe
 your data in tables. This can be easier than the same operations in a Python REPL with ``pyspark``
@@ -11,21 +11,23 @@ or ``pandas``.
 This page describes various ways to connect Tableau to dsgrid data after you've installed Tableau
 Desktop on your local computer.
 
+Install Tableau
+===============
+Licenses are available to NREL employees. Go to theSOURCE, then IT Service Portal, Service
+Catalog, search for Tableau, and submit a ticket to get ``Tableau Creator`` installed (IT will
+install ``Tableau Desktop``).
+
 Parquet files on a local computer
 =================================
 This can be accomplished by connecting Tableau to DuckDB.
 
 1. Copy the Parquet files to your computer.
 
-2. Install `DuckDB <https://duckdb.org/docs/installation/>`_. Next to ``Environment``, select
-   ``Command line``.
+2. Install `DuckDB <https://duckdb.org/docs/installation/>`_. You want the ``Command line``
+   ``Environment``.
 
 3. Install a JDBC driver and connect Tableau to DuckDB by following `DuckDB's
    <https://duckdb.org/docs/guides/data_viewers/tableau>`_ instructions.
-
-   The documentation provides instructions for a "taco" connector. This does not appear to be
-   necessary for basic operations. You will likely benefit from it if you perform advanced SQL
-   operations.
 
 4. Create a view of your data as noted `here
    <https://duckdb.org/docs/guides/data_viewers/tableau#database-creation>`_. You can also import

--- a/docs/source/spark_overview.rst
+++ b/docs/source/spark_overview.rst
@@ -295,6 +295,9 @@ The [README](https://github.com/NREL/HPC/blob/master/applications/spark/README.m
 repository has generic instructions to run Spark in a variety of ways. The rest of this section
 calls out choices that you should make to run Spark jobs with dsgrid.
 
+.. note:: The latest scripts currently supporting Kestrel are at this branch:
+   https://github.com/daniel-thom/HPC/tree/kestrel-update. Please follow its README instead.
+
 1. Clone the repository.
 
 .. code-block:: console
@@ -312,12 +315,14 @@ calls out choices that you should make to run Spark jobs with dsgrid.
 - If the debug partition is not too full, you can append ``--qos=standby`` to the command above
   and not be charged any AUs.
 
-3. Select a Spark container compatible with dsgrid, which currently requires Spark v3.5.1 and
-   Python 3.12. The team has validated the container below. It was created with this Dockerfile
+3. Select a Spark container compatible with dsgrid, which currently requires Spark v3.5.1.
+   The team has validated the container below. It was created with this Dockerfile
    in dsgrid: ``docker/spark/Dockerfile``. The container includes ipython, jupyter, pyspark, pandas,
-   and pyarrow, but not dsgrid.
+   duckdb, and pyarrow, but not dsgrid. The ``configure_and_start_spark.sh`` will normally be
+   updated to use the currently-supported dsgrid container, but there may be some cases where
+   you need to specify it manually with the ``-c`` option.
 
-   ``/datasets/images/apache_spark/spark351_py312.sif``
+   ``/datasets/images/apache_spark/spark351_py311.sif``
 
 4. Configure Spark parameters based on the amount of memory and CPU in each compute node.
 
@@ -337,15 +342,15 @@ calls out choices that you should make to run Spark jobs with dsgrid.
 
 .. code-block:: console
 
-    $ configure_and_start_spark.sh -M 10 -c /datasets/images/apache_spark/spark351_py312.sif
+    $ configure_and_start_spark.sh
 
 .. code-block:: console
 
-    $ configure_and_start_spark.sh -M 10 -c /datasets/images/apache_spark/spark351_py312.sif <SLURM_JOB_ID>
+    $ configure_and_start_spark.sh <SLURM_JOB_ID>
 
 .. code-block:: console
 
-    $ configure_and_start_spark.sh -M 10 -c /datasets/images/apache_spark/spark351_py312.sif <SLURM_JOB_ID1> <SLURM_JOB_ID2>
+    $ configure_and_start_spark.sh <SLURM_JOB_ID1> <SLURM_JOB_ID2>
 
 Run ``configure_and_start_spark.sh --help`` to see all options.
 

--- a/docs/source/spark_overview.rst
+++ b/docs/source/spark_overview.rst
@@ -316,13 +316,16 @@ calls out choices that you should make to run Spark jobs with dsgrid.
   and not be charged any AUs.
 
 3. Select a Spark container compatible with dsgrid, which currently requires Spark v3.5.1.
-   The team has validated the container below. It was created with this Dockerfile
-   in dsgrid: ``docker/spark/Dockerfile``. The container includes ipython, jupyter, pyspark, pandas,
-   duckdb, and pyarrow, but not dsgrid. The ``configure_and_start_spark.sh`` will normally be
-   updated to use the currently-supported dsgrid container, but there may be some cases where
-   you need to specify it manually with the ``-c`` option.
+   The team has validated the container ``/datasets/images/apache_spark/spark351_py311.sif``. It
+   was created with this Dockerfile in dsgrid: ``docker/spark/Dockerfile``. The container includes
+   ipython, jupyter, pyspark, pandas, duckdb, and pyarrow, but not dsgrid. The
+   ``configure_and_start_spark.sh`` will normally be updated to use the currently-supported dsgrid
+   container by default, but there may be some cases where you need to specify it manually with the
+   ``-c`` option.
 
-   ``/datasets/images/apache_spark/spark351_py311.sif``
+.. code-block:: console
+
+   $ configure_and_start_spark.sh -c <path_to_custom_container.sif>
 
 4. Configure Spark parameters based on the amount of memory and CPU in each compute node.
 

--- a/scripts/start_spark_and_arango_on_kestrel.sh
+++ b/scripts/start_spark_and_arango_on_kestrel.sh
@@ -25,7 +25,7 @@ else
 fi
 
 SCRIPT_DIR=${HPC_REPO_DIR}/applications/spark/spark_scripts
-${SCRIPT_DIR}/configure_and_start_spark.sh -M 10 -c /datasets/images/apache_spark/spark351_py312.sif
+${SCRIPT_DIR}/configure_and_start_spark.sh
 
 printf "\nThe Spark cluster is running at spark://$(hostname):7077 from a configuration at $(pwd)/conf\n\n"
 printf "Run this command in your environment to use the same configuration:\n\n"


### PR DESCRIPTION
1. Add Tableau instructions.
2. Update our Spark Docker container to use Python 3.11, which is the default version on Kestrel (3.12 is not installed). Also, install DuckDB in the container.
3. Update the Spark instructions to use the latest version of the HPC Spark scripts, which will remain on a branch until two issues are fixed, unfortunately.
