### PR TITLE
Fix issues with running queries

### DIFF
--- a/docs/source/tutorials/query_project.rst
+++ b/docs/source/tutorials/query_project.rst
@@ -27,6 +27,10 @@ ssh to a login node to begin the tutorial.
 
 2. Add this content to a file called ``query.json5``:
 
+
+.. note:: There is a CLI command that can generate a query file for your project. Refer to
+   ``dsgrid query project create --help``.
+
 .. code-block:: JavaScript
 
     {

--- a/dsgrid/config/time_dimension_base_config.py
+++ b/dsgrid/config/time_dimension_base_config.py
@@ -23,7 +23,6 @@ from dsgrid.dimension.time_utils import (
 )
 from dsgrid.config.dimensions import TimeRangeModel
 from dsgrid.utils.scratch_dir_context import ScratchDirContext
-from dsgrid.utils.spark import persist_intermediate_table
 
 
 logger = logging.getLogger(__name__)
@@ -213,12 +212,6 @@ class TimeDimensionBaseConfig(DimensionBaseConfigWithoutFiles, abc.ABC):
         """
         if time_based_data_adjustment is None:
             time_based_data_adjustment = TimeBasedDataAdjustmentModel()
-
-        # At least in the case of DECARB-industrial, this is required to get through
-        # dataset-to-project mapping on one Kestrel node.
-        # That might not be true for other datasets, and so more customization might be
-        # required.
-        df = persist_intermediate_table(df, context)
 
         time_col = project_time_dim.get_load_data_time_columns()
         assert len(time_col) == 1, time_col

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -37,6 +37,7 @@ from dsgrid.utils.dataset import (
     repartition_if_needed_by_mapping,
 )
 from dsgrid.utils.scratch_dir_context import ScratchDirContext
+from dsgrid.utils.spark import persist_intermediate_table
 from dsgrid.utils.timing import timer_stats_collector, track_timing
 
 logger = logging.getLogger(__name__)
@@ -429,6 +430,12 @@ class DatasetSchemaHandlerBase(abc.ABC):
                 )
             msg = f"Cannot map AnnualTime for a dataset of type {self._config.model.dataset_type}"
             raise NotImplementedError(msg)
+
+        # In many cases we need to persist the current query before mapping time.
+        # This has been true for DECARB industrial and transportation.
+        load_data_df = persist_intermediate_table(
+            load_data_df, scratch_dir_context, tag="query before mapping time"
+        )
 
         load_data_df = time_dim.convert_dataframe(
             load_data_df,

--- a/dsgrid/project.py
+++ b/dsgrid/project.py
@@ -325,8 +325,8 @@ class Project:
                 dataset = self.load_dataset(dataset_id)
                 with Timer(timer_stats_collector, "build_project_mapped_dataset"):
                     df = dataset.make_project_dataframe_from_query(context, self._config)
-                    write_dataframe_and_auto_partition(df, cached_dataset_path)
                     context.serialize_dataset_metadata_to_file(dataset.dataset_id, metadata_file)
+                    write_dataframe_and_auto_partition(df, cached_dataset_path)
         else:
             assert metadata_file.exists(), metadata_file
             context.set_dataset_metadata_from_file(dataset_id, metadata_file)

--- a/dsgrid/query/query_submitter.py
+++ b/dsgrid/query/query_submitter.py
@@ -69,7 +69,7 @@ class QuerySubmitterBase:
 
     @staticmethod
     def query_filename(path: Path):
-        return path / "query.json"
+        return path / "query.json5"
 
     @staticmethod
     def table_filename(path: Path):
@@ -375,7 +375,7 @@ class CompositeDatasetQuerySubmitter(ProjectBasedQuerySubmitter):
             self._process_aggregations_and_save(df, context, repartition=False)
 
     def _load_composite_dataset_query(self, dataset_id):
-        filename = self._composite_datasets_dir() / dataset_id / "query.json"
+        filename = self._composite_datasets_dir() / dataset_id / "query.json5"
         return CreateCompositeDatasetQueryModel.from_file(filename)
 
     def _read_dataset(self, dataset_id):

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -68,6 +68,17 @@ def init_spark(name="dsgrid", check_env=True, spark_conf=None):
     if spark_conf is not None:
         for key, val in spark_conf.items():
             conf.set(key, val)
+
+    out_ts_type = conf.get("spark.sql.parquet.outputTimestampType")
+    if out_ts_type is None:
+        conf.set("spark.sql.parquet.outputTimestampType", "TIMESTAMP_MICROS")
+    elif out_ts_type != "TIMESTAMP_MICROS":
+        logger.warning(
+            "spark.sql.parquet.outputTimestampType is set to %s. Writing parquet files may "
+            "produced undesired results.",
+            out_ts_type,
+        )
+
     if check_env and cluster is not None:
         logger.info("Create SparkSession %s on existing cluster %s", name, cluster)
         conf.setMaster(cluster)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,7 +231,7 @@ def test_submit_project_query(client):
         with ZipFile(fp.name) as zipf:
             names = {os.path.basename(x) for x in zipf.namelist()}
             assert "metadata.json" in names
-            assert "query.json" in names
+            assert "query.json5" in names
 
 
 def check_response(client, endpoint, data=None, expected_status_code=200):


### PR DESCRIPTION
Fixes:

1. Fix the order of writing cached dataset files.
    This sequence was happening:
    - Write a valid dataset to cached Parquet files in an unbalanced way.
    - Start a rewrite to balance the files.
    - Hit a Slurm walltime timeout.
    
    The metadata file was not written. That caused an assert to trip if a
    subsequent query loaded the dataset but couldn't find the query file.

2. Add documentation for auto-generating a query file.

3. Serialize query files to JSON5 instead of JSON. This allows users to copy serialized query files and then add JSON5 content from the documentation.

4. Set Set `spark.sql.parquet.outputTimestampType` so that DuckDB and Pandas properly interpret Parquet timestamps.