### PR TITLE
Remove unnecessary unpivoted rows

### DIFF
--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -217,4 +217,9 @@ def unpivot_dataframe(
     new_rows = df.filter(f"{VALUE_COLUMN} IS NULL").select(*cols).distinct()
     for col in time_columns:
         new_rows = new_rows.withColumn(col, F.lit(None))
-    return df.filter(f"{VALUE_COLUMN} IS NOT NULL").union(new_rows.select(*df.columns))
+
+    return (
+        df.filter(f"{VALUE_COLUMN} IS NOT NULL")
+        .union(new_rows.select(*df.columns))
+        .select(*ids, variable_column, VALUE_COLUMN)
+    )

--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -1,11 +1,12 @@
 import logging
 import os
+from typing import Iterable
 
 import pyspark
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 
-from dsgrid.common import SCALING_FACTOR_COLUMN
+from dsgrid.common import SCALING_FACTOR_COLUMN, VALUE_COLUMN
 from dsgrid.config.dimension_mapping_base import DimensionMappingType
 from dsgrid.exceptions import DSGInvalidField, DSGInvalidDimensionMapping, DSGInvalidDataset
 from dsgrid.utils.scratch_dir_context import ScratchDirContext
@@ -198,3 +199,22 @@ def repartition_if_needed_by_mapping(
         logger.debug("Repartition is not needed for mapping_type %s", mapping_type)
 
     return df
+
+
+def unpivot_dataframe(
+    df: DataFrame, value_columns: Iterable[str], variable_column: str, time_columns: list[str]
+) -> DataFrame:
+    """Unpivot the dataframe, accounting for time columns."""
+    values = value_columns if isinstance(value_columns, set) else set(value_columns)
+    ids = [x for x in df.columns if x != VALUE_COLUMN and x not in values]
+    df = df.unpivot(
+        ids,
+        value_columns,
+        variable_column,
+        VALUE_COLUMN,
+    )
+    cols = set(df.columns).difference(time_columns)
+    new_rows = df.filter(f"{VALUE_COLUMN} IS NULL").select(*cols).distinct()
+    for col in time_columns:
+        new_rows = new_rows.withColumn(col, F.lit(None))
+    return df.filter(f"{VALUE_COLUMN} IS NOT NULL").union(new_rows.select(*df.columns))

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -302,8 +302,8 @@ def test_repartition_if_needed_by_mapping_not_needed(tmp_path, caplog, dataframe
 def test_unpivot(pivoted_dataframe_with_time):
     df, time_columns, value_columns = pivoted_dataframe_with_time
     unpivoted = unpivot_dataframe(df, value_columns, "end_use", time_columns)
-    expected_columns = {*time_columns, "end_use", VALUE_COLUMN, "county"}
-    assert not expected_columns.difference(unpivoted.columns)
+    expected_columns = [*time_columns, "county", "end_use", VALUE_COLUMN]
+    assert unpivoted.columns == expected_columns
     null_data = unpivoted.filter("county = 'Boulder' and end_use = 'heating'").collect()
     assert len(null_data) == 1
     assert null_data[0].time_index is None


### PR DESCRIPTION
The code that unpivoted a dataframe at dataset registration was adding a row for every timestamp. Only one row is needed and its timestamp needs to be NULL.
