### PR TITLE
Allow multi-dim requirements to specify missing base dimensions

### DIFF
--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -137,3 +137,16 @@ def test_invalid_multi_dimensional_requirement_partial_intersection():
             single_dimensional=RequiredDimensionRecordsModel(**single_dim_data),
             multi_dimensional=[RequiredDimensionRecordsModel(**x) for x in multi_dim_data],
         )
+
+
+def test_invalid_multi_dimensional_requirement_base_and_base_missing():
+    multi_dim_data = [
+        {
+            "metric": {"base": ["metric1"], "base_missing": ["metric2"]},
+            "subsector": {"base": ["subsector1"]},
+        },
+    ]
+    with pytest.raises(ValueError, match="base and base_missing cannot both be set"):
+        RequiredDimensionsModel(
+            multi_dimensional=[RequiredDimensionRecordsModel(**x) for x in multi_dim_data],
+        )


### PR DESCRIPTION
This allows https://github.com/dsgrid/dsgrid-project-DECARB/pull/30 to specify dimension requirements in a more concise way. When that PR is merged I will add a test that registers the new project and exercises this code.
