### PR TITLE
Support aggregating mapped datasets individually

### DIFF
--- a/dsgrid/dataset/table_format_handler_base.py
+++ b/dsgrid/dataset/table_format_handler_base.py
@@ -52,7 +52,9 @@ class TableFormatHandlerBase(abc.ABC):
             query_name = column.dimension_query_name
             dim = self._project_config.get_dimension(query_name)
             expected_base_dim_cols = context.get_dimension_column_names_by_query_name(
-                dim.model.dimension_type, dim_type_to_query_name[dim.model.dimension_type]
+                dim.model.dimension_type,
+                dim_type_to_query_name[dim.model.dimension_type],
+                dataset_id=self._dataset_id,
             )
             if query_name in base_query_names:
                 assert columns.issuperset(
@@ -176,7 +178,12 @@ class TableFormatHandlerBase(abc.ABC):
         column_to_dim_type[name] = dim_type
 
     def _build_group_by_columns(
-        self, columns, context, column_to_dim_type, dim_type_to_query_name, final_metadata
+        self,
+        columns,
+        context: QueryContext,
+        column_to_dim_type,
+        dim_type_to_query_name,
+        final_metadata,
     ):
         group_by_cols = []
         for column in columns:
@@ -184,7 +191,7 @@ class TableFormatHandlerBase(abc.ABC):
             match context.model.result.column_type:
                 case ColumnType.DIMENSION_TYPES:
                     column_names = context.get_dimension_column_names_by_query_name(
-                        dim_type, dim_type_to_query_name[dim_type]
+                        dim_type, dim_type_to_query_name[dim_type], dataset_id=self._dataset_id
                     )
                     if dim_type == DimensionType.TIME:
                         group_by_cols += column_names
@@ -220,9 +227,8 @@ class TableFormatHandlerBase(abc.ABC):
                 expr = expr.alias(column.alias)
         return expr
 
-    @staticmethod
     @track_timing(timer_stats_collector)
-    def _remove_invalid_null_timestamps(df: DataFrame, orig_id, context: QueryContext):
+    def _remove_invalid_null_timestamps(self, df: DataFrame, orig_id, context: QueryContext):
         if id(df) != orig_id:
             # The table could have NULL timestamps that designate expected-missing data.
             # Those rows could be obsolete after aggregating stacked dimensions.
@@ -230,7 +236,9 @@ class TableFormatHandlerBase(abc.ABC):
             value_columns = context.get_value_columns()
             if not value_columns:
                 raise Exception("Bug: value_columns cannot be empty")
-            time_columns = context.get_dimension_column_names(DimensionType.TIME)
+            time_columns = context.get_dimension_column_names(
+                DimensionType.TIME, dataset_id=self._dataset_id
+            )
             if time_columns:
                 # Persist the query up to this point to avoid multiple evaluations.
                 df = persist_intermediate_query(df, context.scratch_dir_context)

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -486,6 +486,18 @@ class QueryResultParamsModel(CacheableQueryBaseModel):
             default=[],
         ),
     ]
+    aggregate_each_dataset: Annotated[
+        bool,
+        Field(
+            description="Aggregate each dataset before applying the expression to create one "
+            "overall dataset. The default behavior is to perform one aggregation on the overall "
+            "dataset. This parameter must be set to True for queries that will be adding or "
+            "subtracting datasets with different dimensionality. Warning: setting this value to "
+            "True could produce rows with duplicate dimension combinations when performing a "
+            "union of datasets while also dropping one or more dimensions.",
+            default=False,
+        ),
+    ]
     reports: Annotated[
         list[ReportInputModel],
         Field(description="Run these pre-defined reports on the result.", default=[]),

--- a/dsgrid/query/query_context.py
+++ b/dsgrid/query/query_context.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Optional
 
 from pyspark.sql import DataFrame
 
@@ -98,15 +99,29 @@ class QueryContext:
     ) -> set[str]:
         return self._get_metadata(dataset_id).dimensions.get_column_names(dimension_type)
 
+    def get_all_dimension_column_names(
+        self, dataset_id: Optional[str] = None, exclude: Optional[set[DimensionType]] = None
+    ):
+        names = set()
+        for dimension_type in DimensionType:
+            if exclude is not None and dimension_type in exclude:
+                continue
+            names.update(self.get_dimension_column_names(dimension_type, dataset_id=dataset_id))
+        return names
+
     def get_dimension_query_names(
         self, dimension_type: DimensionType, dataset_id=None
     ) -> set[str]:
         return self._get_metadata(dataset_id).dimensions.get_dimension_query_names(dimension_type)
 
-    def get_all_dimension_query_names(self):
+    def get_all_dimension_query_names(
+        self, dataset_id: Optional[str] = None, exclude: Optional[set[DimensionType]] = None
+    ):
         names = set()
         for dimension_type in DimensionType:
-            names.update(self._metadata.dimensions.get_dimension_query_names(dimension_type))
+            if exclude is not None and dimension_type in exclude:
+                continue
+            names.update(self.get_dimension_query_names(dimension_type, dataset_id=dataset_id))
         return names
 
     def set_dataset_metadata(


### PR DESCRIPTION
Closes GitHub Issue #321 

## Description
I added a parameter called `aggregate_each_dataset` to the query data model and then use it to
1.	Apply the expression (such as union, add, subtract) to make one dataset and then apply the aggregation.
2.	Apply the aggregation to each dataset and then apply the expression. Required if performing addition or subtraction on datasets with different dimensionality.

`aggregate_each_dataset` is not always valid. Suppose the query drops the subsector and sector dimensions to find total electricity demand. The result will have duplicate values because the aggregation needs to be applied again.

It’s possible that we could determine when a second aggregation is needed, but that could be challenging. What should we do now? I vote for the easy way out and leave this to the query writer. I wouldn’t judge the added complexity to be worthwhile.

What do you think?

