### PR TITLE
Multiple metric dimensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,8 +5,8 @@
 [submodule "dsgrid-project-StandardScenarios"]
 	path = dsgrid-project-StandardScenarios
 	url = https://github.com/dsgrid/dsgrid-project-StandardScenarios
-	branch = duckdb
+	branch = main
 [submodule "dsgrid-project-IEF"]
-	path = dsgrid-project-IEF
+	path = dsgrid-project-DECARB
 	url = https://github.com/dsgrid/dsgrid-project-IEF
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dsgrid-test-data"]
 	path = dsgrid-test-data
 	url = https://github.com/dsgrid/dsgrid-test-data
-	branch = duckdb
+	branch = multiple-metric-dimensions
 [submodule "dsgrid-project-StandardScenarios"]
 	path = dsgrid-project-StandardScenarios
 	url = https://github.com/dsgrid/dsgrid-project-StandardScenarios

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	path = dsgrid-project-StandardScenarios
 	url = https://github.com/dsgrid/dsgrid-project-StandardScenarios
 	branch = duckdb
-[submodule "dsgrid-project-DECARB"]
-	path = dsgrid-project-DECARB
-	url = https://github.com/dsgrid/dsgrid-project-DECARB
+[submodule "dsgrid-project-IEF"]
+	path = dsgrid-project-IEF
+	url = https://github.com/dsgrid/dsgrid-project-IEF
 	branch = main

--- a/docs/source/reference/dsgrid_api/registry.rst
+++ b/docs/source/reference/dsgrid_api/registry.rst
@@ -29,7 +29,7 @@ Project
    :members: get_dataset, version
 
 .. autoclass:: dsgrid.config.project_config.ProjectConfig
-   :members: get_base_dimension, get_base_dimension_to_query_name_mapping, get_base_to_supplemental_config, get_base_to_supplemental_dimension_mappings_by_types, get_base_to_supplemental_mapping_records, get_dimension, get_dimension_records, get_required_dimension_record_ids, get_supplemental_dimension_to_query_name_mapping, list_dimension_query_names, list_registered_dataset_ids, list_supplemental_dimensions, list_unregistered_dataset_ids
+   :members: get_base_dimension, get_dimension_type_to_base_query_name_mapping, get_base_to_supplemental_config, get_base_to_supplemental_dimension_mappings_by_types, get_base_to_supplemental_mapping_records, get_dimension, get_dimension_records, get_required_dimension_record_ids, get_supplemental_dimension_to_query_name_mapping, list_dimension_query_names, list_registered_dataset_ids, list_supplemental_dimensions, list_unregistered_dataset_ids
 
 .. autopydantic_model:: dsgrid.config.project_config.ProjectDimensionQueryNamesModel
 

--- a/dsgrid/api/app.py
+++ b/dsgrid/api/app.py
@@ -53,9 +53,9 @@ logger = setup_logging(__name__, "dsgrid_api.log")
 DSGRID_REGISTRY_DATABASE_URL = os.environ.get("DSGRID_REGISTRY_DATABASE_URL")
 if DSGRID_REGISTRY_DATABASE_URL is None:
     raise Exception("The environment variable DSGRID_REGISTRY_DATABASE_URL must be set.")
-QUERY_OUTPUT_DIR = os.environ.get("DSGRID_QUERY_OUTPUT_DIR")
-if QUERY_OUTPUT_DIR is None:
+if "DSGRID_QUERY_OUTPUT_DIR" not in os.environ:
     raise Exception("The environment variable DSGRID_QUERY_OUTPUT_DIR must be set.")
+QUERY_OUTPUT_DIR = os.environ["DSGRID_QUERY_OUTPUT_DIR"]
 API_SERVER_STORE_DIR = os.environ.get("DSGRID_API_SERVER_STORE_DIR")
 if API_SERVER_STORE_DIR is None:
     raise Exception("The environment variable DSGRID_API_SERVER_STORE_DIR must be set.")
@@ -132,9 +132,11 @@ async def list_project_dimensions(project_id: str):
     project = mgr.get_by_id(project_id)
     dimensions = []
     for item in project.get_dimension_query_names_model().model_dump().values():
-        dimension = create_project_dimension_model(
-            project.get_dimension(item["base"]).model, DimensionCategory.BASE
-        )
+        for query_name in item["base"]:
+            dimension = create_project_dimension_model(
+                project.get_dimension(query_name).model, DimensionCategory.BASE
+            )
+            dimensions.append(dimension)
         dimensions.append(dimension)
         for query_name in item["subset"]:
             dimension = create_project_dimension_model(

--- a/dsgrid/cli/query.py
+++ b/dsgrid/cli/query.py
@@ -231,9 +231,10 @@ def create_project_query(
         query.project.dataset.params.dimension_filters.append(flt)
 
     if default_result_aggregation:
-        default_aggs = {}
-        for dim_type, name in project.config.get_base_dimension_to_query_name_mapping().items():
-            default_aggs[dim_type.value] = [name]
+        default_aggs = {
+            k.value: v
+            for k, v in project.config.get_dimension_type_to_base_query_name_mapping().items()
+        }
         if default_result_aggregation:
             query.result.aggregations = [
                 AggregationModel(

--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -608,13 +608,13 @@ $ dsgrid registry projects submit-dataset \\ \n
 )
 @click.pass_obj
 def submit_dataset(
-    registry_manager,
-    dataset_id,
-    project_id,
-    dimension_mapping_file,
-    dimension_mapping_references_file,
-    autogen_reverse_supplemental_mappings,
-    log_message,
+    registry_manager: RegistryManager,
+    dataset_id: str,
+    project_id: str,
+    dimension_mapping_file: Path,
+    dimension_mapping_references_file: Path,
+    autogen_reverse_supplemental_mappings: list[DimensionType],
+    log_message: str,
 ):
     """Submit a dataset to a dsgrid project."""
     submitter = getpass.getuser()
@@ -1116,7 +1116,7 @@ def list_project_dimension_query_names(
         ctx.exit(res[1])
 
     project_config = res[0]
-    base = None if exclude_base else project_config.get_base_dimension_to_query_name_mapping()
+    base = None if exclude_base else project_config.get_dimension_type_to_base_query_name_mapping()
     sub = None if exclude_subset else project_config.get_subset_dimension_to_query_name_mapping()
     supp = (
         None
@@ -1129,7 +1129,8 @@ def list_project_dimension_query_names(
     for dim_type in dimensions:
         lines.append(f"  {dim_type.value}:")
         if base:
-            lines.append(f"    base: {base[dim_type]}")
+            base_str = " ".join(base[dim_type])
+            lines.append(f"    base: {base_str}")
         if sub:
             lines.append("    subset: " + " ".join(sub[dim_type]))
         if supp:

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -532,7 +532,7 @@ class DatasetConfig(ConfigBase):
         raise DSGValueNotRegistered(msg)
 
     def get_time_dimension(self) -> TimeDimensionBaseConfig:
-        """Return the dimension matching dimension_type."""
+        """Return the time dimension of the dataset."""
         dim = self.get_dimension(DimensionType.TIME)
         assert isinstance(dim, TimeDimensionBaseConfig)
         return dim

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -547,7 +547,7 @@ class DatasetConfig(ConfigBase):
             ):
                 return dim_config
 
-        msg = f"Dimension {dimension_type} not found in dataset {self.config_id}"
+        msg = f"Dimension {dimension_type} not found in dataset {self.config_id} or does not have records"
         raise DSGValueNotRegistered(msg)
 
     def get_pivoted_dimension_type(self) -> DimensionType | None:

--- a/dsgrid/config/dimension_config.py
+++ b/dsgrid/config/dimension_config.py
@@ -19,6 +19,17 @@ class DimensionBaseConfigWithFiles(ConfigWithRecordFileBase, abc.ABC):
     def config_id(self):
         return self.model.dimension_id
 
+    def get_unique_ids(self):
+        """Return the unique IDs in a dimension's records.
+
+        Returns
+        -------
+        set
+            set of str
+
+        """
+        return {x.id for x in self.model.records}
+
 
 class DimensionBaseConfigWithoutFiles(ConfigBase, abc.ABC):
     """Base class for dimension configs"""
@@ -38,17 +49,6 @@ class DimensionConfig(DimensionBaseConfigWithFiles):
     @staticmethod
     def model_class():
         return DimensionModel
-
-    def get_unique_ids(self):
-        """Return the unique IDs in a dimension's records.
-
-        Returns
-        -------
-        set
-            set of str
-
-        """
-        return {x.id for x in self.model.records}
 
 
 DimensionBaseConfig = Union[DimensionBaseConfigWithFiles, DimensionBaseConfigWithoutFiles]

--- a/dsgrid/config/dimension_mapping_base.py
+++ b/dsgrid/config/dimension_mapping_base.py
@@ -273,6 +273,12 @@ class DimensionMappingPreRegisteredBaseModel(DSGBaseModel):
         description="Tolerance value to apply to the to_fraction column",
         default=1e-6,
     )
+    from_dimension_name: Optional[str] = Field(
+        default=None,
+        description="Name of the base dimension for which the mapping is being registered. "
+        "This is required in cases where the project has multiple base dimensions of the same "
+        "type. If None, there must only be one base dimension of this type in the project.",
+    )
 
 
 class DimensionMappingDatasetToProjectBaseModel(DimensionMappingPreRegisteredBaseModel):

--- a/dsgrid/config/dimension_mapping_base.py
+++ b/dsgrid/config/dimension_mapping_base.py
@@ -273,7 +273,7 @@ class DimensionMappingPreRegisteredBaseModel(DSGBaseModel):
         description="Tolerance value to apply to the to_fraction column",
         default=1e-6,
     )
-    from_dimension_name: Optional[str] = Field(
+    project_base_dimension_name: Optional[str] = Field(
         default=None,
         description="Name of the base dimension for which the mapping is being registered. "
         "This is required in cases where the project has multiple base dimensions of the same "

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -228,6 +228,11 @@ class DimensionBaseModel(DSGBaseDatabaseModel):
             info.data["class_name"],
         )
 
+    @property
+    def label(self) -> str:
+        """Return a label for the dimension to be used in user messages."""
+        return f"{self.dimension_type} {self.dimension_query_name}"
+
 
 class DimensionModel(DimensionBaseModel):
     """Defines a non-time dimension"""
@@ -557,7 +562,8 @@ class AnnualTimeDimensionModel(TimeDimensionBaseModel):
             ),
         },
     )
-    ranges: list[TimeRangeModel] = Field(
+    ranges: Optional[list[TimeRangeModel]] = Field(
+        default=None,
         title="time_ranges",
         description="Defines the contiguous ranges of time in the data, inclusive of start and end time.",
     )
@@ -855,7 +861,7 @@ class ProjectDimensionModel(DimensionCommonModel):
     category: DimensionCategory
 
 
-def create_dimension_common_model(model):
+def create_dimension_common_model(model) -> DimensionCommonModel:
     """Constructs an instance of DimensionBaseModel from subclasses in order to give the API
     one common model for all dimensions. Avoids the complexity of dealing with
     DimensionBaseModel validators.
@@ -865,13 +871,13 @@ def create_dimension_common_model(model):
     return DimensionCommonModel(**data)
 
 
-def create_project_dimension_model(model, category: DimensionCategory):
+def create_project_dimension_model(model, category: DimensionCategory) -> ProjectDimensionModel:
     data = create_dimension_common_model(model).model_dump()
     data["category"] = category.value
     return ProjectDimensionModel(**data)
 
 
-def check_display_name(display_name: str):
+def check_display_name(display_name: str) -> str:
     """Check that a dimension display name meets all requirements.
 
     Raises

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -562,7 +562,7 @@ class AnnualTimeDimensionModel(TimeDimensionBaseModel):
             ),
         },
     )
-    ranges: Optional[list[TimeRangeModel]] = Field(
+    ranges: list[TimeRangeModel] = Field(
         default=None,
         title="time_ranges",
         description="Defines the contiguous ranges of time in the data, inclusive of start and end time.",

--- a/dsgrid/config/mapping_tables.py
+++ b/dsgrid/config/mapping_tables.py
@@ -10,6 +10,7 @@ from dsgrid.config.dimension_mapping_base import (
     DimensionMappingDatasetToProjectBaseModel,
     DimensionMappingPreRegisteredBaseModel,
 )
+from dsgrid.config.dimensions import DimensionReferenceModel
 from dsgrid.data_models import DSGBaseModel
 from dsgrid.utils.files import compute_file_hash
 from dsgrid.utils.utilities import convert_record_dicts_to_classes
@@ -146,7 +147,10 @@ class MappingTableModel(DimensionMappingBaseModel):
 
     @classmethod
     def from_pre_registered_model(
-        cls, model: DimensionMappingPreRegisteredBaseModel, from_dimension, to_dimension
+        cls,
+        model: MappingTableByNameModel | DatasetBaseToProjectMappingTableModel,
+        from_dimension: DimensionReferenceModel,
+        to_dimension: DimensionReferenceModel,
     ):
         return MappingTableModel(
             mapping_type=model.mapping_type,
@@ -154,7 +158,7 @@ class MappingTableModel(DimensionMappingBaseModel):
             from_dimension=from_dimension,
             to_dimension=to_dimension,
             description=model.description,
-            filename=model.filename,
+            file=model.filename,
             from_fraction_tolerance=model.from_fraction_tolerance,
             to_fraction_tolerance=model.to_fraction_tolerance,
         )

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -1019,29 +1019,6 @@ class ProjectConfig(ConfigBase):
         msg = f"No mapping is stored for base = {base_dim.model.label}, supplemental = {supp_dim.model.label}"
         raise DSGValueNotRegistered(msg)
 
-    def list_base_to_supplemental_mapping_configs(
-        self,
-        base_dimension_id: Optional[str] = None,
-        supplemental_dimension_id: Optional[str] = None,
-    ) -> list[MappingTableConfig]:
-        """Return all base-to-supplemental dimension mapping configs, optionally filtering by
-        dimension IDs."""
-        configs = []
-        for config in self._base_to_supplemental_mappings.values():
-            if (
-                base_dimension_id is not None
-                and config.model.from_dimension.dimension_id != base_dimension_id
-            ):
-                continue
-            if (
-                supplemental_dimension_id is not None
-                and config.model.to_dimension.dimension_id != supplemental_dimension_id
-            ):
-                continue
-            configs.append(config)
-
-        return configs
-
     def get_base_to_supplemental_mapping_records(
         self, base_dim: DimensionBaseConfigWithFiles, supp_dim: DimensionBaseConfigWithFiles
     ) -> DataFrame:

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -24,7 +24,6 @@ from dsgrid.dimension.base_models import (
 from dsgrid.exceptions import (
     DSGInvalidField,
     DSGInvalidDimension,
-    DSGInvalidOperation,
     DSGInvalidParameter,
     DSGInvalidDimensionAssociation,
     DSGValueNotRegistered,
@@ -792,14 +791,18 @@ class ProjectConfig(ConfigBase):
         """Return the dimension with dimension_query_name."""
         dim = self._dimensions_by_query_name.get(dimension_query_name)
         if dim is None:
-            raise DSGInvalidDimension(f"dimension_query_name={dimension_query_name} is not stored")
+            raise DSGValueNotRegistered(
+                f"dimension_query_name={dimension_query_name} is not stored"
+            )
         return dim
 
     def get_time_dimension(self, dimension_query_name: str) -> TimeDimensionBaseConfig:
         """Return the time dimension with dimension_query_name."""
         dim = self._dimensions_by_query_name.get(dimension_query_name)
         if dim is None:
-            raise DSGInvalidDimension(f"dimension_query_name={dimension_query_name} is not stored")
+            raise DSGValueNotRegistered(
+                f"dimension_query_name={dimension_query_name} is not stored"
+            )
         if not isinstance(dim, TimeDimensionBaseConfig):
             msg = f"{dim.model.label} is not a time dimension"
             raise DSGInvalidParameter(msg)
@@ -929,7 +932,7 @@ class ProjectConfig(ConfigBase):
                 return mapping
 
         msg = f"No mapping is stored for base = {base_dim.model.label}, supplemental = {supp_dim.model.label}"
-        raise DSGInvalidParameter(msg)
+        raise DSGValueNotRegistered(msg)
 
     def list_base_to_supplemental_mapping_configs(
         self,
@@ -982,7 +985,7 @@ class ProjectConfig(ConfigBase):
         dim = self.get_base_dimension_by_id(dimension_id)
         if not isinstance(dim, DimensionBaseConfigWithFiles):
             msg = f"{dim.model.label} does not have records"
-            raise DSGInvalidOperation(msg)
+            raise DSGInvalidParameter(msg)
         return dim.get_records_dataframe()
 
     def _check_not_base_dimension(self, dim: DimensionBaseConfig) -> None:

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -16,7 +16,6 @@ from dsgrid.config.annual_time_dimension_config import (
 from dsgrid.config.date_time_dimension_config import DateTimeDimensionConfig
 from dsgrid.config.project_config import ProjectConfig
 from dsgrid.dsgrid_rc import DsgridRuntimeConfig
-import dsgrid.units.energy as energy
 from dsgrid.common import VALUE_COLUMN, BackendEngine
 from dsgrid.config.dataset_config import DatasetConfig, InputDatasetType
 from dsgrid.config.dimension_mapping_base import (
@@ -35,6 +34,7 @@ from dsgrid.query.query_context import QueryContext
 from dsgrid.query.models import ColumnType
 from dsgrid.spark.functions import join, make_temp_view_name
 from dsgrid.spark.types import DataFrame, F
+from dsgrid.units.convert import convert_units_unpivoted
 from dsgrid.utils.dataset import (
     check_historical_annual_time_model_year_consistency,
     is_noop_mapping,
@@ -46,6 +46,7 @@ from dsgrid.utils.dataset import (
     ordered_subset_columns,
     repartition_if_needed_by_mapping,
 )
+
 from dsgrid.utils.scratch_dir_context import ScratchDirContext
 from dsgrid.utils.spark import (
     persist_intermediate_table,
@@ -283,7 +284,7 @@ class DatasetSchemaHandlerBase(abc.ABC):
         if VALUE_COLUMN not in df.columns:
             raise DSGInvalidDataset(f"value_column={VALUE_COLUMN} is not in columns={df.columns}")
 
-    def _convert_units(self, df, project_metric_records, value_columns):
+    def _convert_units(self, df: DataFrame, project_metric_records: DataFrame):
         if not self._config.model.enable_unit_conversion:
             return df
 
@@ -298,8 +299,9 @@ class DatasetSchemaHandlerBase(abc.ABC):
                 ).get_records_dataframe()
                 break
 
-        dataset_records = self._config.get_dimension(DimensionType.METRIC).get_records_dataframe()
-        return energy.convert_units_unpivoted(
+        dataset_dim = self._config.get_dimension_with_records(DimensionType.METRIC)
+        dataset_records = dataset_dim.get_records_dataframe()
+        return convert_units_unpivoted(
             df,
             DimensionType.METRIC.value,
             dataset_records,
@@ -314,14 +316,16 @@ class DatasetSchemaHandlerBase(abc.ABC):
             dataset_id=self.dataset_id,
         )
 
-        if context.model.result.column_type == ColumnType.DIMENSION_QUERY_NAMES:
-            df = table_handler.convert_columns_to_query_names(df)
-
         context.set_dataset_metadata(
             self.dataset_id,
             context.model.result.column_type,
             project_config,
         )
+
+        if context.model.result.column_type == ColumnType.DIMENSION_QUERY_NAMES:
+            df = table_handler.convert_columns_to_query_names(
+                df, self._config.model.dataset_id, context
+            )
 
         return df
 
@@ -361,6 +365,25 @@ class DatasetSchemaHandlerBase(abc.ABC):
             if ref.from_dimension_type == dimension_type:
                 return ref
         return
+
+    def _get_project_metric_records(self, project_config: ProjectConfig) -> DataFrame:
+        metric_dim_query_name = getattr(
+            project_config.get_dataset_base_dimension_query_names(self._config.model.dataset_id),
+            DimensionType.METRIC.value,
+        )
+        if metric_dim_query_name is None:
+            # This is a workaround for dsgrid projects created before the field
+            # base_dimension_query_names was added to InputDatasetModel.
+            metric_dims = project_config.list_base_dimensions(dimension_type=DimensionType.METRIC)
+            if len(metric_dims) > 1:
+                msg = (
+                    "The dataset's base_dimension_query_names value is not set and "
+                    "there are multiple metric dimensions in the project. Please re-register the "
+                )
+                f"dataset with dataset_id={self._config.model.dataset_id}."
+                raise DSGInvalidDataset(msg)
+            metric_dim_query_name = metric_dims[0].model.dimension_query_name
+        return project_config.get_dimension_records(metric_dim_query_name)
 
     def _get_time_dimension_columns(self):
         time_dim = self._config.get_dimension(DimensionType.TIME)
@@ -523,7 +546,7 @@ class DatasetSchemaHandlerBase(abc.ABC):
                     table_name=table_name,
                     value_column=value_column,
                     from_time_dim=time_dim,
-                    to_time_dim=project_config.get_base_dimension(DimensionType.TIME),
+                    to_time_dim=project_config.get_base_time_dimension(),
                 )
 
             case (BackendEngine.SPARK, False, True):
@@ -537,7 +560,7 @@ class DatasetSchemaHandlerBase(abc.ABC):
                     filename=filename,
                     value_column=value_column,
                     from_time_dim=time_dim,
-                    to_time_dim=project_config.get_base_dimension(DimensionType.TIME),
+                    to_time_dim=project_config.get_base_time_dimension(),
                     scratch_dir_context=scratch_dir_context,
                 )
             case (BackendEngine.SPARK, _, False):
@@ -559,7 +582,7 @@ class DatasetSchemaHandlerBase(abc.ABC):
                     df=load_data_df,
                     value_column=value_column,
                     from_time_dim=time_dim,
-                    to_time_dim=project_config.get_base_dimension(DimensionType.TIME),
+                    to_time_dim=project_config.get_base_time_dimension(),
                 )
             case (BackendEngine.DUCKDB, _, False):
                 load_data_df = time_dim.convert_dataframe(

--- a/dsgrid/dataset/dataset_schema_handler_base.py
+++ b/dsgrid/dataset/dataset_schema_handler_base.py
@@ -379,8 +379,8 @@ class DatasetSchemaHandlerBase(abc.ABC):
                 msg = (
                     "The dataset's base_dimension_query_names value is not set and "
                     "there are multiple metric dimensions in the project. Please re-register the "
+                    f"dataset with dataset_id={self._config.model.dataset_id}."
                 )
-                f"dataset with dataset_id={self._config.model.dataset_id}."
                 raise DSGInvalidDataset(msg)
             metric_dim_query_name = metric_dims[0].model.dimension_query_name
         return project_config.get_dimension_records(metric_dim_query_name)

--- a/dsgrid/dataset/dataset_schema_handler_one_table.py
+++ b/dsgrid/dataset/dataset_schema_handler_one_table.py
@@ -145,10 +145,8 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
         # TODO: This might need to handle data skew in the future.
         ld_df = self._remap_dimension_columns(ld_df, scratch_dir_context=scratch_dir_context)
         ld_df = self._apply_fraction(ld_df, {VALUE_COLUMN})
-        project_metric_records = project_config.get_base_dimension(
-            DimensionType.METRIC
-        ).get_records_dataframe()
-        ld_df = self._convert_units(ld_df, project_metric_records, {VALUE_COLUMN})
+        project_metric_records = self._get_project_metric_records(project_config)
+        ld_df = self._convert_units(ld_df, project_metric_records)
         return self._convert_time_dimension(
             ld_df, project_config, VALUE_COLUMN, scratch_dir_context
         )
@@ -164,10 +162,8 @@ class OneTableDatasetSchemaHandler(DatasetSchemaHandlerBase):
             scratch_dir_context=context.scratch_dir_context,
         )
         ld_df = self._apply_fraction(ld_df, {VALUE_COLUMN})
-        project_metric_records = project_config.get_base_dimension(
-            DimensionType.METRIC
-        ).get_records_dataframe()
-        ld_df = self._convert_units(ld_df, project_metric_records, {VALUE_COLUMN})
+        project_metric_records = self._get_project_metric_records(project_config)
+        ld_df = self._convert_units(ld_df, project_metric_records)
         ld_df = self._convert_time_dimension(
             ld_df, project_config, VALUE_COLUMN, context.scratch_dir_context
         )

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from dsgrid.common import SCALING_FACTOR_COLUMN, VALUE_COLUMN
 from dsgrid.config.dataset_config import DatasetConfig
+from dsgrid.config.project_config import ProjectConfig
 from dsgrid.config.simple_models import DimensionSimpleModel
 from dsgrid.dataset.models import TableFormatType
 from dsgrid.dataset.dataset_schema_handler_base import DatasetSchemaHandlerBase
@@ -82,7 +83,9 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
         ).drop("fraction")
         return self._add_null_values(df, cross_join(null_lk_df, df.select(*dim_cols).distinct()))
 
-    def make_project_dataframe(self, project_config, scratch_dir_context: ScratchDirContext):
+    def make_project_dataframe(
+        self, project_config: ProjectConfig, scratch_dir_context: ScratchDirContext
+    ):
         # TODO: Can we remove NULLs at registration time?
         null_lk_df = self._load_data_lookup.filter("id is NULL")
         lk_df = self._load_data_lookup.filter("id is not NULL")
@@ -95,16 +98,16 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
         if SCALING_FACTOR_COLUMN in ld_df.columns:
             ld_df = apply_scaling_factor(ld_df, {VALUE_COLUMN})
         ld_df = self._apply_fraction(ld_df, {VALUE_COLUMN})
-        project_metric_records = project_config.get_base_dimension(
-            DimensionType.METRIC
-        ).get_records_dataframe()
-        ld_df = self._convert_units(ld_df, project_metric_records, {VALUE_COLUMN})
+        project_metric_records = self._get_project_metric_records(project_config)
+        ld_df = self._convert_units(ld_df, project_metric_records)
         ld_df = self._convert_time_dimension(
             ld_df, project_config, VALUE_COLUMN, scratch_dir_context
         )
         return self._add_null_values(ld_df, null_lk_df)
 
-    def make_project_dataframe_from_query(self, context: QueryContext, project_config):
+    def make_project_dataframe_from_query(
+        self, context: QueryContext, project_config: ProjectConfig
+    ):
         lk_df = self._load_data_lookup
         ld_df = self._load_data
 
@@ -124,10 +127,8 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
             ld_df = apply_scaling_factor(ld_df, {VALUE_COLUMN})
 
         ld_df = self._apply_fraction(ld_df, {VALUE_COLUMN})
-        project_metric_records = project_config.get_base_dimension(
-            DimensionType.METRIC
-        ).get_records_dataframe()
-        ld_df = self._convert_units(ld_df, project_metric_records, {VALUE_COLUMN})
+        project_metric_records = self._get_project_metric_records(project_config)
+        ld_df = self._convert_units(ld_df, project_metric_records)
         null_lk_df = self._remap_dimension_columns(
             null_lk_df, filtered_records=context.get_record_ids()
         )

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -103,6 +103,7 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
         ld_df = self._convert_time_dimension(
             ld_df, project_config, VALUE_COLUMN, scratch_dir_context
         )
+        # TODO DT: this has a bug...does not account for duplicates
         return self._add_null_values(ld_df, null_lk_df)
 
     def make_project_dataframe_from_query(

--- a/dsgrid/dataset/dataset_schema_handler_standard.py
+++ b/dsgrid/dataset/dataset_schema_handler_standard.py
@@ -103,7 +103,8 @@ class StandardDatasetSchemaHandler(DatasetSchemaHandlerBase):
         ld_df = self._convert_time_dimension(
             ld_df, project_config, VALUE_COLUMN, scratch_dir_context
         )
-        # TODO DT: this has a bug...does not account for duplicates
+        # TODO: this has a bug...does not account for duplicates
+        # Also, the metric column is showing up as null.
         return self._add_null_values(ld_df, null_lk_df)
 
     def make_project_dataframe_from_query(

--- a/dsgrid/dataset/table_format_handler_base.py
+++ b/dsgrid/dataset/table_format_handler_base.py
@@ -169,7 +169,7 @@ class TableFormatHandlerBase(abc.ABC):
         assert not {"id", "name"}.intersection(df.columns), df.columns
         orig = df
         all_query_names = self._project_config.get_dimension_query_names_mapped_to_type()
-        for dimension_query_name in set(df.columns).intersection(all_query_names):
+        for dimension_query_name in set(df.columns).intersection(all_query_names.keys()):
             if all_query_names[dimension_query_name] != DimensionType.TIME:
                 # Time doesn't have records.
                 dim_config = self._project_config.get_dimension_with_records(dimension_query_name)

--- a/dsgrid/dataset/table_format_handler_base.py
+++ b/dsgrid/dataset/table_format_handler_base.py
@@ -3,12 +3,13 @@ import logging
 from typing import Iterable
 
 from dsgrid.config.project_config import ProjectConfig
-from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.base_models import DimensionCategory, DimensionType
 from dsgrid.query.query_context import QueryContext
 from dsgrid.query.models import (
     AggregationModel,
     ColumnModel,
     ColumnType,
+    DatasetDimensionsMetadataModel,
     DimensionMetadataModel,
 )
 from dsgrid.spark.types import DataFrame
@@ -34,7 +35,8 @@ class TableFormatHandlerBase(abc.ABC):
         context: QueryContext,
         value_columns: Iterable[str],
     ) -> DataFrame:
-        """Add columns to the dataframe.
+        """Add columns to the dataframe. For example, suppose the geography dimension is at
+        county resolution and the user wants to add a column for state.
 
         Parameters
         ----------
@@ -45,34 +47,45 @@ class TableFormatHandlerBase(abc.ABC):
             Columns in the dataframe that contain load values.
         """
         columns = set(df.columns)
-        dim_type_to_query_name = self.project_config.get_base_dimension_to_query_name_mapping()
-        base_query_names = set(dim_type_to_query_name.values())
+        all_base_query_names = self.project_config.list_dimension_query_names(
+            category=DimensionCategory.BASE
+        )
         for column in column_models:
             query_name = column.dimension_query_name
-            dim = self._project_config.get_dimension(query_name)
-            expected_base_dim_cols = context.get_dimension_column_names_by_query_name(
-                dim.model.dimension_type,
-                dim_type_to_query_name[dim.model.dimension_type],
-                dataset_id=self._dataset_id,
+            if query_name in all_base_query_names or query_name in columns:
+                continue
+            supp_dim = self._project_config.get_dimension_with_records(query_name)
+            existing_metadata = context.get_dimension_metadata(
+                supp_dim.model.dimension_type, dataset_id=self._dataset_id
             )
-            if query_name in base_query_names:
-                assert columns.issuperset(
-                    expected_base_dim_cols
-                ), f"{columns=} {expected_base_dim_cols=}"
-                continue
-            elif query_name in columns:
-                continue
-            if dim.model.dimension_type == DimensionType.TIME:
-                raise NotImplementedError(
-                    "Adding time columns through supplemental mappings is not supported yet."
+            existing_base_metadata = [
+                x for x in existing_metadata if x.dimension_query_name in all_base_query_names
+            ]
+            if len(existing_base_metadata) != 1:
+                msg = (
+                    f"Bug: expected one base metadata object for {supp_dim.model.dimension_type}: "
+                    "{existing_base_metadata}"
                 )
-            records = self._project_config.get_base_to_supplemental_mapping_records(query_name)
+                raise Exception(msg)
+            base_dim_query_name = existing_base_metadata[0].dimension_query_name
+            if base_dim_query_name not in all_base_query_names:
+                msg = f"Bug: Expected {base_dim_query_name} to be a base dimension."
+                raise Exception(msg)
+            base_dim = self._project_config.get_dimension_with_records(base_dim_query_name)
+            records = self._project_config.get_base_to_supplemental_mapping_records(
+                base_dim, supp_dim
+            )
 
             if column.function is not None:
                 # TODO #200: Do we want to allow this?
                 raise NotImplementedError(
                     f"Applying a SQL function to added column={query_name} is not supported yet"
                 )
+            expected_base_dim_cols = context.get_dimension_column_names_by_query_name(
+                supp_dim.model.dimension_type,
+                base_dim.model.dimension_query_name,
+                dataset_id=self._dataset_id,
+            )
             if len(expected_base_dim_cols) > 1:
                 raise Exception(
                     "Bug: Non-time dimensions cannot have more than one base dimension column"
@@ -86,21 +99,19 @@ class TableFormatHandlerBase(abc.ABC):
                 to_column=query_name,
             )
             if context.model.result.column_type == ColumnType.DIMENSION_QUERY_NAMES:
-                if dim.model.dimension_type == DimensionType.TIME:
-                    column_names = dim.list_load_data_columns_for_query_name()
-                else:
-                    column_names = [query_name]
+                assert supp_dim.model.dimension_type != DimensionType.TIME
+                column_names = [query_name]
             else:
                 column_names = [expected_base_dim_col]
             context.add_dimension_metadata(
-                dim.model.dimension_type,
+                supp_dim.model.dimension_type,
                 DimensionMetadataModel(dimension_query_name=query_name, column_names=column_names),
                 dataset_id=self.dataset_id,
             )
 
         if "fraction" in df.columns:
-            for column in value_columns:
-                df = df.withColumn(column, df[column] * df["fraction"])
+            for col in value_columns:
+                df = df.withColumn(col, df[col] * df["fraction"])
             df = df.drop("fraction")
 
         return df
@@ -129,21 +140,24 @@ class TableFormatHandlerBase(abc.ABC):
         return self._project_config
 
     @property
-    def dataset_id(self) -> str:
+    def dataset_id(self) -> str | None:
         """Return the ID of the dataset being processed."""
         return self._dataset_id
 
-    def convert_columns_to_query_names(self, df: DataFrame) -> DataFrame:
+    def convert_columns_to_query_names(
+        self, df: DataFrame, dataset_id: str, context: QueryContext
+    ) -> DataFrame:
         """Convert columns from dimension types to dimension query names."""
-        base_to_query_name_mapping = self.project_config.get_base_dimension_to_query_name_mapping()
         columns = set(df.columns)
         for dim_type in DimensionType:
             if dim_type == DimensionType.TIME:
-                time_dim = self._project_config.get_base_dimension(dim_type)
+                time_dim = self._project_config.get_base_time_dimension()
                 df = time_dim.map_timestamp_load_data_columns_for_query_name(df)
             elif dim_type.value in columns:
                 existing_col = dim_type.value
-                new_col = base_to_query_name_mapping[dim_type]
+                new_cols = context.get_dimension_column_names(dim_type, dataset_id=dataset_id)
+                assert len(new_cols) == 1, f"{dim_type=} {new_cols=}"
+                new_col = next(iter(new_cols))
                 if existing_col != new_col:
                     df = df.withColumnRenamed(existing_col, new_col)
                     logger.debug("Converted column from %s to %s", existing_col, new_col)
@@ -152,25 +166,26 @@ class TableFormatHandlerBase(abc.ABC):
 
     def replace_ids_with_names(self, df: DataFrame) -> DataFrame:
         """Replace dimension record IDs with names."""
+        assert not {"id", "name"}.intersection(df.columns), df.columns
         orig = df
-        all_query_names = set(self._project_config.list_dimension_query_names())
+        all_query_names = self._project_config.get_dimension_query_names_mapped_to_type()
         for dimension_query_name in set(df.columns).intersection(all_query_names):
-            assert not {"id", "name"}.intersection(df.columns), df.columns
-            dim_config = self._project_config.get_dimension(dimension_query_name)
-            if dim_config.model.dimension_type == DimensionType.TIME:
+            if all_query_names[dimension_query_name] != DimensionType.TIME:
                 # Time doesn't have records.
-                continue
-            records = dim_config.get_records_dataframe().select("id", "name")
-            df = (
-                df.join(records, on=df[dimension_query_name] == records["id"])
-                .drop("id", dimension_query_name)
-                .withColumnRenamed("name", dimension_query_name)
-            )
+                dim_config = self._project_config.get_dimension_with_records(dimension_query_name)
+                records = dim_config.get_records_dataframe().select("id", "name")
+                df = (
+                    df.join(records, on=df[dimension_query_name] == records["id"])
+                    .drop("id", dimension_query_name)
+                    .withColumnRenamed("name", dimension_query_name)
+                )
         assert df.count() == orig.count(), f"counts changed {df.count()} {orig.count()}"
         return df
 
     @staticmethod
-    def _add_column_to_dim_type(column, dim_type, column_to_dim_type):
+    def _add_column_to_dim_type(
+        column: ColumnModel, dim_type: DimensionType, column_to_dim_type: dict[str, DimensionType]
+    ) -> None:
         name = column.get_column_name()
         if name in column_to_dim_type:
             assert dim_type == column_to_dim_type[name], f"{name=} {column_to_dim_type}"
@@ -178,19 +193,18 @@ class TableFormatHandlerBase(abc.ABC):
 
     def _build_group_by_columns(
         self,
-        columns,
+        columns: list[ColumnModel],
         context: QueryContext,
-        column_to_dim_type,
-        dim_type_to_query_name,
-        final_metadata,
+        final_metadata: DatasetDimensionsMetadataModel,
     ):
-        group_by_cols = []
+        group_by_cols: list[str] = []
         for column in columns:
-            dim_type = column_to_dim_type[column.get_column_name()]
+            dim = self._project_config.get_dimension(column.dimension_query_name)
+            dim_type = dim.model.dimension_type
             match context.model.result.column_type:
                 case ColumnType.DIMENSION_TYPES:
                     column_names = context.get_dimension_column_names_by_query_name(
-                        dim_type, dim_type_to_query_name[dim_type], dataset_id=self._dataset_id
+                        dim_type, column.dimension_query_name, dataset_id=self._dataset_id
                     )
                     if dim_type == DimensionType.TIME:
                         group_by_cols += column_names

--- a/dsgrid/dataset/unpivoted_table.py
+++ b/dsgrid/dataset/unpivoted_table.py
@@ -1,16 +1,17 @@
 import logging
 
-import dsgrid.units.energy as energy
 from dsgrid.common import VALUE_COLUMN
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.query.models import (
     AggregationModel,
+    ColumnModel,
     ColumnType,
     DatasetDimensionsMetadataModel,
 )
 from dsgrid.query.query_context import QueryContext
 from dsgrid.spark.types import DataFrame
-from .table_format_handler_base import TableFormatHandlerBase
+from dsgrid.units.convert import convert_units_unpivoted
+from dsgrid.dataset.table_format_handler_base import TableFormatHandlerBase
 
 
 logger = logging.getLogger(__name__)
@@ -47,12 +48,14 @@ class UnpivotedTableHandler(TableFormatHandlerBase):
             return df
 
         final_metadata = DatasetDimensionsMetadataModel()
-        dim_type_to_query_name = self.project_config.get_base_dimension_to_query_name_mapping()
-        column_to_dim_type = {}
+        dim_type_to_base_query_name = (
+            self.project_config.get_dimension_type_to_base_query_name_mapping()
+        )
+        column_to_dim_type: dict[str, DimensionType] = {}
         dropped_dimensions = set()
         for agg in aggregations:
             metric_query_name = None
-            columns = []
+            columns: list[ColumnModel] = []
             for dim_type, column in agg.iter_dimensions_to_keep():
                 assert dim_type not in dropped_dimensions, dim_type
                 columns.append(column)
@@ -61,31 +64,38 @@ class UnpivotedTableHandler(TableFormatHandlerBase):
                     metric_query_name = column.dimension_query_name
 
             if metric_query_name is None:
-                raise Exception(f"Bug: A metric dimension is not included in {agg}")
+                msg = f"Bug: A metric dimension is not included in {agg}"
+                raise Exception(msg)
 
             dropped_dimensions.update(set(agg.list_dropped_dimensions()))
             if not columns:
                 continue
 
             df = self.add_columns(df, columns, context, [VALUE_COLUMN])
-            group_by_cols = self._build_group_by_columns(
-                columns, context, column_to_dim_type, dim_type_to_query_name, final_metadata
-            )
+            group_by_cols = self._build_group_by_columns(columns, context, final_metadata)
             op = agg.aggregation_function
             df = df.groupBy(*group_by_cols).agg(op(VALUE_COLUMN).alias(VALUE_COLUMN))
 
-            if metric_query_name != dim_type_to_query_name[DimensionType.METRIC]:
-                dim_config = self.project_config.get_dimension(metric_query_name)
-                mapping_records = self.project_config.get_base_to_supplemental_mapping_records(
-                    metric_query_name
+            if metric_query_name not in dim_type_to_base_query_name[DimensionType.METRIC]:
+                to_dim_config = self.project_config.get_dimension_with_records(metric_query_name)
+                mapping_configs = self.project_config.list_base_to_supplemental_mapping_configs(
+                    supplemental_dimension_id=to_dim_config.model.dimension_id,
                 )
-                to_unit_records = dim_config.get_records_dataframe()
-                df = energy.convert_units_unpivoted(
+                if len(mapping_configs) > 1:
+                    msg = (
+                        "More than one base-to-supplemental mapping config for "
+                        f"{to_dim_config.model.dimension_id}"
+                    )
+                    raise NotImplementedError(msg)
+                mapping_config = mapping_configs[0]
+                from_dim_id = mapping_config.model.from_dimension.dimension_id
+                from_records = self.project_config.get_base_dimension_records_by_id(from_dim_id)
+                mapping_records = mapping_config.get_records_dataframe()
+                to_unit_records = to_dim_config.get_records_dataframe()
+                df = convert_units_unpivoted(
                     df,
                     _get_metric_column_name(context, metric_query_name),
-                    self._project_config.get_base_dimension(
-                        DimensionType.METRIC
-                    ).get_records_dataframe(),
+                    from_records,
                     mapping_records,
                     to_unit_records,
                 )

--- a/dsgrid/dimension/dimension_filters.py
+++ b/dsgrid/dimension/dimension_filters.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from enum import Enum
-from typing import Any, Union, Literal
+from typing import Any, Optional, Union, Literal
 
 from pydantic import field_validator, model_validator, Field
 
@@ -56,13 +56,19 @@ class DimensionFilterBaseModel(DSGBaseModel, abc.ABC):
 
 
 class DimensionFilterSingleQueryNameBaseModel(DimensionFilterBaseModel, abc.ABC):
-    """Base model for all filters based on expressions"""
+    """Base model for all filters based on expressions with a single dimension."""
 
     dimension_query_name: str
+    base_dimension_query_name: Optional[str] = Field(
+        default=None,
+        title="base_dimension_query_name",
+        description="Base dimension query name to identify the mapping. This is required if the "
+        "project has multiple base dimensions that map to the same supplemental dimension.",
+    )
 
 
 class DimensionFilterMultipleQueryNameBaseModel(DimensionFilterBaseModel, abc.ABC):
-    """Base model for all filters based on expressions"""
+    """Base model for all filters based on expressions with multiple dimensions."""
 
     dimension_query_names: list[str]
 

--- a/dsgrid/dimension/dimension_filters.py
+++ b/dsgrid/dimension/dimension_filters.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from enum import Enum
-from typing import Any, Optional, Union, Literal
+from typing import Any, Union, Literal
 
 from pydantic import field_validator, model_validator, Field
 
@@ -59,12 +59,6 @@ class DimensionFilterSingleQueryNameBaseModel(DimensionFilterBaseModel, abc.ABC)
     """Base model for all filters based on expressions with a single dimension."""
 
     dimension_query_name: str
-    base_dimension_query_name: Optional[str] = Field(
-        default=None,
-        title="base_dimension_query_name",
-        description="Base dimension query name to identify the mapping. This is required if the "
-        "project has multiple base dimensions that map to the same supplemental dimension.",
-    )
 
 
 class DimensionFilterMultipleQueryNameBaseModel(DimensionFilterBaseModel, abc.ABC):

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -6,6 +6,7 @@ from pydantic import field_validator, model_validator, Field, field_serializer, 
 from semver import VersionInfo
 from typing_extensions import Annotated
 
+from dsgrid.config.project_config import DatasetBaseDimensionQueryNamesModel
 from dsgrid.data_models import DSGBaseModel, make_model_config
 from dsgrid.dataset.models import (
     TableFormatModel,
@@ -255,6 +256,10 @@ class DatasetMetadataModel(DSGBaseModel):
 
     dimensions: DatasetDimensionsMetadataModel = DatasetDimensionsMetadataModel()
     table_format: TableFormatModel
+    # This will be set at the query context level but not per-dataset.
+    base_dimension_query_names: DatasetBaseDimensionQueryNamesModel = (
+        DatasetBaseDimensionQueryNamesModel()
+    )
 
     def get_table_format_type(self) -> TableFormatType:
         """Return the format type of the table."""

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -1,6 +1,6 @@
 import abc
 from enum import Enum
-from typing import Any, Optional, Union, Literal, TypeAlias
+from typing import Any, Generator, Optional, Union, Literal, TypeAlias
 
 from pydantic import field_validator, model_validator, Field, field_serializer, ValidationInfo
 from semver import VersionInfo
@@ -158,13 +158,13 @@ class AggregationModel(DSGBaseModel):
     def serialize_aggregation_function(self, function, _):
         return function.__name__
 
-    def iter_dimensions_to_keep(self):
+    def iter_dimensions_to_keep(self) -> Generator[tuple[DimensionType, ColumnModel], None, None]:
         """Yield the dimension type and ColumnModel for each dimension to keep."""
         for field in DimensionQueryNamesModel.model_fields:
             for val in getattr(self.dimensions, field):
                 yield DimensionType(field), val
 
-    def list_dropped_dimensions(self):
+    def list_dropped_dimensions(self) -> list[DimensionType]:
         """Return a list of dimension types that will be dropped by the aggregation."""
         return [
             DimensionType(x)
@@ -212,19 +212,21 @@ class DatasetDimensionsMetadataModel(DSGBaseModel):
     time: list[DimensionMetadataModel] = []
     weather_year: list[DimensionMetadataModel] = []
 
-    def add_metadata(self, dimension_type: DimensionType, metadata: DimensionMetadataModel):
+    def add_metadata(
+        self, dimension_type: DimensionType, metadata: DimensionMetadataModel
+    ) -> None:
         """Add dimension metadata. Skip duplicates."""
         container = getattr(self, dimension_type.value)
         if metadata.make_key() not in {x.make_key() for x in container}:
             container.append(metadata)
 
-    def get_metadata(self, dimension_type: DimensionType):
+    def get_metadata(self, dimension_type: DimensionType) -> list[DimensionMetadataModel]:
         """Return the dimension metadata."""
         return getattr(self, dimension_type.value)
 
     def replace_metadata(
         self, dimension_type: DimensionType, metadata: list[DimensionMetadataModel]
-    ):
+    ) -> None:
         """Replace the dimension metadata."""
         setattr(self, dimension_type.value, metadata)
 
@@ -235,11 +237,11 @@ class DatasetDimensionsMetadataModel(DSGBaseModel):
             column_names.update(item.column_names)
         return column_names
 
-    def get_dimension_query_names(self, dimension_type: DimensionType):
+    def get_dimension_query_names(self, dimension_type: DimensionType) -> set[str]:
         """Return the dimension query names for the given dimension type."""
         return {x.dimension_query_name for x in getattr(self, dimension_type.value)}
 
-    def remove_metadata(self, dimension_type: DimensionType, dimension_query_name):
+    def remove_metadata(self, dimension_type: DimensionType, dimension_query_name: str) -> None:
         """Remove the dimension metadata for the given dimension query name."""
         container = getattr(self, dimension_type.value)
         for i, metadata in enumerate(container):

--- a/dsgrid/query/query_context.py
+++ b/dsgrid/query/query_context.py
@@ -51,7 +51,7 @@ class QueryContext:
         return self._model
 
     @property
-    def base_dimension_query_names(self) -> DatasetBaseDimensionQueryNamesModel:
+    def base_dimension_query_names(self) -> DatasetMetadataModel:
         return self._metadata.base_dimension_query_names
 
     @property

--- a/dsgrid/registry/dimension_mapping_registry_manager.py
+++ b/dsgrid/registry/dimension_mapping_registry_manager.py
@@ -261,8 +261,10 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
         return config
 
     def load_dimension_mappings(
-        self, dimension_mapping_references, conn: Optional[Connection] = None
-    ):
+        self,
+        dimension_mapping_references: list[DimensionMappingReferenceModel],
+        conn: Optional[Connection] = None,
+    ) -> dict[ConfigKey, MappingTableConfig]:
         """Load dimension_mappings from files.
 
         Parameters
@@ -276,7 +278,7 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
             ConfigKey to DimensionMappingConfig
 
         """
-        mappings = {}
+        mappings: dict[ConfigKey, MappingTableConfig] = {}
         for ref in dimension_mapping_references:
             key = ConfigKey(ref.mapping_id, ref.version)
             mappings[key] = self.get_by_id(key.id, version=key.version, conn=conn)
@@ -285,7 +287,7 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
 
     def make_dimension_mapping_references(
         self, mapping_ids: list[str], conn: Optional[Connection] = None
-    ):
+    ) -> list[DimensionMappingReferenceModel]:
         """Return a list of dimension mapping references from a list of registered mapping IDs.
 
         Parameters
@@ -317,7 +319,6 @@ class DimensionMappingRegistryManager(RegistryManagerBase):
             config = DimensionMappingsConfig.load(config_file)
             return self.register_from_config(config, context)
 
-    @track_timing(timer_stats_collector)
     def register_from_config(
         self,
         config: DimensionMappingsConfig,

--- a/dsgrid/registry/filter_registry_manager.py
+++ b/dsgrid/registry/filter_registry_manager.py
@@ -69,9 +69,11 @@ class FilterRegistryManager(RegistryManager):
                 project_config.model.datasets.pop(index)
                 changed_project = True
             for simple_dim in project.dimensions.base_dimensions:
-                dim = project_config.get_base_dimension(simple_dim.dimension_type)
-                dim.model.records = handle_dimension(simple_dim, dim)
-                self.dimension_manager.db.replace(conn, dim.model)
+                for dim in project_config.list_base_dimensions(
+                    dimension_type=simple_dim.dimension_type
+                ):
+                    dim.model.records = handle_dimension(simple_dim, dim)
+                    self.dimension_manager.db.replace(conn, dim.model)
 
             for simple_dim in project.dimensions.supplemental_dimensions:
                 for dim in project_config.list_supplemental_dimensions(simple_dim.dimension_type):

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -13,9 +13,11 @@ import pandas as pd
 from prettytable import PrettyTable
 from sqlalchemy import Connection
 
+from dsgrid.config.dimension_config import DimensionBaseConfig, DimensionBaseConfigWithFiles
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.exceptions import (
     DSGInvalidDataset,
+    DSGInvalidDimension,
     DSGInvalidDimensionMapping,
     DSGValueNotRegistered,
     DSGDuplicateValueRegistered,
@@ -49,6 +51,7 @@ from dsgrid.config.mapping_tables import (
     DatasetBaseToProjectMappingTableListModel,
 )
 from dsgrid.config.project_config import (
+    DatasetBaseDimensionQueryNamesModel,
     ProjectConfig,
     ProjectConfigModel,
     RequiredDimensionRecordsModel,
@@ -166,6 +169,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         self, project_id: str, version: Optional[str] = None, conn: Optional[Connection] = None
     ):
         if version is None:
+            assert self._db is not None
             version = self._db.get_latest_version(conn, project_id)
 
         key = ConfigKey(project_id, version)
@@ -178,6 +182,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         else:
             model = self.db.get_by_version(conn, project_id, version)
 
+        assert isinstance(model, ProjectConfigModel)
         config = ProjectConfig(model)
         self._update_dimensions_and_mappings(conn, config)
         self._projects[key] = config
@@ -194,11 +199,13 @@ class ProjectRegistryManager(RegistryManagerBase):
             config.model.dimension_mappings.base_to_supplemental_references, conn=conn
         )
         subset_dimensions = self._get_subset_dimensions(conn, config)
-        config.update_dimensions(base_dimensions, subset_dimensions, supplemental_dimensions)
-        config.update_dimension_mappings(base_to_supp_mappings)
+        config.set_dimensions(base_dimensions, subset_dimensions, supplemental_dimensions)
+        config.set_dimension_mappings(base_to_supp_mappings)
 
     def _get_subset_dimensions(self, conn: Optional[Connection], config: ProjectConfig):
-        subset_dimensions = defaultdict(dict)
+        subset_dimensions: dict[
+            DimensionType, dict[str, dict[ConfigKey, DimensionBaseConfig]]
+        ] = defaultdict(dict)
         for subset_dim in config.model.dimensions.subset_dimensions:
             selectors = {
                 ConfigKey(x.dimension_id, x.version): self._dimension_mgr.get_by_id(
@@ -364,17 +371,54 @@ class ProjectRegistryManager(RegistryManagerBase):
         context: RegistrationContext,
     ):
         conn = context.connection
-        base_mapping = {x.dimension_type: x for x in model.dimensions.base_dimension_references}
+        base_dim_mapping = defaultdict(list)
+        base_dim_refs: dict[str, DimensionReferenceModel] = {}
+        for ref in model.dimensions.base_dimension_references:
+            dim = self._dimension_mgr.get_by_id(
+                ref.dimension_id, version=ref.version, conn=context.connection
+            )
+            base_dim_mapping[ref.dimension_type].append(dim)
+            base_dim_refs[dim.model.dimension_id] = ref
+
         mappings = []
         if len(dimensions) != len(dimension_references):
-            raise Exception(f"Bug: mismatch in sizes: {dimensions=} {dimension_references=}")
+            msg = f"Bug: mismatch in sizes: {dimensions=} {dimension_references=}"
+            raise Exception(msg)
 
         for dim, ref in zip(dimensions, dimension_references):
-            base_dim = base_mapping[dim.dimension_type]
+            base_dim: Optional[DimensionBaseConfig] = None
+            if dim.mapping.from_dimension_name is None:
+                base_dims = base_dim_mapping[ref.dimension_type]
+                if len(base_dims) > 1:
+                    msg = (
+                        "If there are multiple base dimenions for a dimension type, each "
+                        "supplemental dimension mapping must supply a from_dimension_name. "
+                        f"{dim.model.dimension_type.value}/{dim.model.name}"
+                    )
+                    raise DSGInvalidDimensionMapping(msg)
+                base_dim = base_dims[0]
+            else:
+                for base_dim_ in base_dim_mapping[dim.dimension_type]:
+                    if base_dim_.model.name == dim.mapping.from_dimension_name:
+                        if base_dim is not None:
+                            msg = (
+                                "A supplemental dimension can only be mapped to one base dimension:"
+                                f" supplemental dimension = {dim.model.label} "
+                                f"base dimensions = {base_dim.model.label} and "
+                                f"{base_dim_.model.label}"
+                            )
+                            raise DSGInvalidDimensionMapping(msg)
+                        base_dim = base_dim_
+                if base_dim is None:
+                    msg = (
+                        f"Bug: unable to find base dimension for {dim.mapping.from_dimension_name}"
+                    )
+                    raise Exception(msg)
             with in_other_dir(src_dir):
+                assert base_dim is not None
                 mapping_model = MappingTableModel.from_pre_registered_model(
                     dim.mapping,
-                    base_dim,
+                    base_dim_refs[base_dim.model.dimension_id],
                     ref,
                 )
                 mappings.append(mapping_model)
@@ -629,6 +673,7 @@ class ProjectRegistryManager(RegistryManagerBase):
 
         config.model.version = "1.0.0"
         model = self.db.insert(context.connection, config.model, context.registration)
+        assert isinstance(model, ProjectConfigModel)
         logger.info(
             "%s Registered project %s with version=%s",
             self._log_offline_mode_prefix(),
@@ -641,15 +686,38 @@ class ProjectRegistryManager(RegistryManagerBase):
         dims = [x for x in config.iter_dimensions()]
         check_uniqueness((x.model.name for x in dims), "dimension name")
         check_uniqueness((x.model.display_name for x in dims), "dimension display name")
-        check_uniqueness(
-            (getattr(x.model, "cls") for x in config.model.dimensions.base_dimensions),
-            "dimension cls",
-        )
+        self._check_base_dimensions(config)
+        self._check_base_dimension_record_uniqueness(config)
+
         for dataset_id in config.list_unregistered_dataset_ids():
             for field in RequiredDimensionRecordsModel.model_fields:
                 # This will check that all dimension record IDs listed in the requirements
                 # exist in the project.
                 config.get_required_dimension_record_ids(dataset_id, DimensionType(field))
+
+    def _check_base_dimensions(self, config: ProjectConfig) -> None:
+        found_time = False
+        for dim in config.list_base_dimensions():
+            if dim.model.dimension_type == DimensionType.TIME:
+                if found_time:
+                    msg = "Only one time dimension is allowed in a project."
+                    raise DSGInvalidDimension(msg)
+                found_time = True
+
+    def _check_base_dimension_record_uniqueness(self, config: ProjectConfig) -> None:
+        for dimension_type in DimensionType:
+            if dimension_type == DimensionType.TIME:
+                continue
+            record_ids: set[str] = set()
+            for dim in config.list_base_dimensions_with_records(dimension_type):
+                ids = get_unique_values(dim.get_records_dataframe(), "id")
+                if intersect := record_ids.intersection(ids):
+                    msg = (
+                        "Record IDs across base dimensions of the same type must be unique: "
+                        f"{sorted(intersect)}"
+                    )
+                    raise DSGInvalidDimension(msg)
+                record_ids.update(ids)
 
     @track_timing(timer_stats_collector)
     def register_and_submit_dataset(
@@ -699,10 +767,10 @@ class ProjectRegistryManager(RegistryManagerBase):
         dataset_id: str,
         submitter: Optional[str] = None,
         log_message: Optional[str] = None,
-        dimension_mapping_file=None,
-        dimension_mapping_references_file=None,
-        autogen_reverse_supplemental_mappings=None,
-        context=None,
+        dimension_mapping_file: Optional[Path] = None,
+        dimension_mapping_references_file: Optional[Path] = None,
+        autogen_reverse_supplemental_mappings: Optional[list[DimensionType]] = None,
+        context: Optional[RegistrationContext] = None,
     ):
         """Registers a dataset with a project. This can only be performed on the
         latest version of the project.
@@ -714,7 +782,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         dimension_mapping_file : Path or None
             Base-to-base dimension mapping file
         dimension_mapping_references_file : Path or None
-        autogen_reverse_supplemental_mappings : set[DimensionType] or None
+        autogen_reverse_supplemental_mappings : list[DimensionType] or None
             Dimensions on which to attempt create reverse mappings from supplemental dimensions.
         submitter : str
             Submitter name
@@ -858,12 +926,12 @@ class ProjectRegistryManager(RegistryManagerBase):
     def _submit_dataset_and_register_mappings(
         self,
         project_config: ProjectConfig,
-        dataset_id,
-        dimension_mapping_file,
-        dimension_mapping_references_file,
-        autogen_reverse_supplemental_mappings,
+        dataset_id: str,
+        dimension_mapping_file: Optional[Path],
+        dimension_mapping_references_file: Optional[Path],
+        autogen_reverse_supplemental_mappings: Optional[list[DimensionType]],
         context: RegistrationContext,
-    ):
+    ) -> None:
         logger.info("Submit dataset=%s to project=%s.", dataset_id, project_config.config_id)
         self._check_if_not_registered(context.connection, project_config.config_id)
         self._raise_if_not_unregistered(project_config, dataset_id)
@@ -895,7 +963,7 @@ class ProjectRegistryManager(RegistryManagerBase):
                 project_config,
                 dataset_config,
                 references,
-                autogen_reverse_supplemental_mappings,
+                set(autogen_reverse_supplemental_mappings),
                 context,
             )
 
@@ -924,16 +992,40 @@ class ProjectRegistryManager(RegistryManagerBase):
             **load_data(dimension_mapping_file)
         ).mappings
         dataset_mapping = {x.dimension_type: x for x in dataset_config.model.dimension_references}
-        project_mapping = {
-            x.dimension_type: x for x in project_config.model.dimensions.base_dimension_references
-        }
+        project_mapping: dict[str, list[DimensionBaseConfig]] = defaultdict(list)
+        project_mapping_refs: dict[str, DimensionReferenceModel] = {}
+        for ref in project_config.model.dimensions.base_dimension_references:
+            dim = self._dimension_mgr.get_by_id(
+                ref.dimension_id, version=ref.version, conn=context.connection
+            )
+            project_mapping[ref.dimension_type].append(dim)
+            project_mapping_refs[dim.model.dimension_id] = ref
         mapping_tables = []
         for mapping in mappings:
+            base_dim: Optional[DimensionBaseConfig] = None
+            if mapping.from_dimension_name is None:
+                base_dims = project_mapping[mapping.dimension_type]
+                if len(base_dims) > 1:
+                    msg = (
+                        "If there are multiple project base dimensions for a dimension type, the "
+                        "dataset dimension mapping must supply a from_dimension_name. "
+                        f"{dim.model.label}"
+                    )
+                    raise DSGInvalidDimensionMapping(msg)
+                base_dim = base_dims[0]
+            else:
+                for base_dim_ in project_mapping[dim.model.dimension_type]:
+                    if base_dim_.model.name == mapping.from_dimension_name:
+                        base_dim = base_dim_
+                if base_dim is None:
+                    msg = f"Bug: unable to find base dimension for {mapping.from_dimension_name}"
+                    raise Exception(msg)
             with in_other_dir(src_dir):
+                assert base_dim is not None
                 mapping_table = MappingTableModel.from_pre_registered_model(
                     mapping,
                     dataset_mapping[mapping.dimension_type],
-                    project_mapping[mapping.dimension_type],
+                    project_mapping_refs[base_dim.model.dimension_id],
                 )
             mapping_tables.append(mapping_table)
 
@@ -1002,9 +1094,14 @@ class ProjectRegistryManager(RegistryManagerBase):
         new_mappings = []
         for from_id, from_version in needs_mapping:
             from_dim = self._dimension_mgr.get_by_id(from_id, version=from_version, conn=conn)
-            to_dim, to_version = project_config.get_base_dimension_and_version(
-                from_dim.model.dimension_type
-            )
+            if from_dim.model.dimension_type == DimensionType.METRIC:
+                to_dim, to_version = project_config.get_base_dimension_and_version(
+                    from_dim.model.dimension_type
+                )
+            else:
+                to_dim, to_version = project_config.get_base_metric_dimension_and_version(
+                    from_dim.model.dimension_type
+                )
             mapping, version = self._try_get_mapping(
                 project_config, from_dim, from_version, to_dim, to_version, context
             )
@@ -1103,6 +1200,12 @@ class ProjectRegistryManager(RegistryManagerBase):
         context: RegistrationContext,
     ):
         project_config.add_dataset_dimension_mappings(dataset_config, mapping_references)
+        project_config.add_dataset_base_dimension_query_names(
+            dataset_config.model.dataset_id,
+            self._id_base_dimension_query_names_in_dataset(
+                project_config, dataset_config, mapping_references
+            ),
+        )
         if os.environ.get("__DSGRID_SKIP_CHECK_DATASET_TO_PROJECT_MAPPING__") is not None:
             logger.warning("Skip dataset-to-project mapping checks")
         else:
@@ -1137,7 +1240,7 @@ class ProjectRegistryManager(RegistryManagerBase):
         self, project_config: ProjectConfig, dataset_config: DatasetConfig
     ):
         dtime = dataset_config.get_dimension(DimensionType.TIME)
-        ptime = project_config.get_base_dimension(DimensionType.TIME)
+        ptime = project_config.get_base_time_dimension()
 
         dataset_id = dataset_config.model.dataset_id
         wrap_time = project_config.get_dataset(dataset_id).wrap_time_allowed
@@ -1161,7 +1264,7 @@ class ProjectRegistryManager(RegistryManagerBase):
             self._dimension_mgr,
             self._dimension_mapping_mgr,
             mapping_references,
-            project_time_dim=project_config.get_base_dimension(DimensionType.TIME),
+            project_time_dim=project_config.get_base_time_dimension(),
         )
         dataset_id = dataset_config.config_id
 
@@ -1175,6 +1278,71 @@ class ProjectRegistryManager(RegistryManagerBase):
                 self._handle_dimension_association_errors(
                     diff, mapped_dataset_table, dataset_config, project_config.config_id
                 )
+
+    def _id_base_dimension_query_names_in_dataset(
+        self,
+        project_config: ProjectConfig,
+        dataset_config: DatasetConfig,
+        mapping_references: list[DimensionMappingReferenceModel],
+    ) -> DatasetBaseDimensionQueryNamesModel:
+        base_dimension_query_names: dict[DimensionType, str] = {}
+        for ref in mapping_references:
+            mapping = self._dimension_mapping_mgr.get_by_id(ref.mapping_id, version=ref.version)
+            base_dim = self._dimension_mgr.get_by_id(
+                mapping.model.from_dimension.dimension_id,
+                version=mapping.model.from_dimension.version,
+            ).model
+            base_dimension_query_names[base_dim.dimension_type] = base_dim.dimension_query_name
+
+        project_base_dims_by_type: dict[DimensionType, list[DimensionBaseConfig]] = defaultdict(
+            list
+        )
+        for dim in project_config.list_base_dimensions():
+            project_base_dims_by_type[dim.model.dimension_type].append(dim)
+
+        dataset_id = dataset_config.model.dataset_id
+        for dim_type in DimensionType:
+            if dim_type == DimensionType.TIME:
+                assert len(project_base_dims_by_type[dim_type]) == 1
+                base_dimension_query_names[dim_type] = project_base_dims_by_type[dim_type][
+                    0
+                ].model.dimension_query_name
+                continue
+            if dim_type not in base_dimension_query_names:
+                project_base_dims = project_base_dims_by_type[dim_type]
+                if len(project_base_dims) > 1:
+                    for project_dim in project_base_dims:
+                        assert isinstance(project_dim, DimensionBaseConfigWithFiles)
+                        project_records = project_dim.get_records_dataframe()
+                        project_record_ids = get_unique_values(project_records, "id")
+                        dataset_dim = dataset_config.get_dimension_with_records(dim_type)
+                        dataset_records = dataset_dim.get_records_dataframe()
+                        dataset_record_ids = get_unique_values(dataset_records, "id")
+                        if dataset_record_ids.issubset(project_record_ids):
+                            project_query_name = project_dim.model.dimension_query_name
+                            if dim_type in base_dimension_query_names:
+                                msg = (
+                                    f"Found multiple project base dimensions for {dataset_id=} "
+                                    f"and {dim_type=}: {base_dimension_query_names[dim_type]} and "
+                                    f"{project_query_name}. Please specify a mapping."
+                                )
+                                raise DSGInvalidDataset(msg)
+
+                            base_dimension_query_names[dim_type] = project_query_name
+                    if dim_type not in base_dimension_query_names:
+                        msg = (
+                            f"Bug: {dim_type} has multiple base dimensions in the project, dataset "
+                            f"{dataset_id} does not specify a mapping, and dsgrid could not "
+                            "discern which base dimension to use."
+                        )
+                        raise DSGInvalidDataset(msg)
+                else:
+                    base_dimension_query_names[dim_type] = project_base_dims[
+                        0
+                    ].model.dimension_query_name
+
+        data = {k.value: v for k, v in base_dimension_query_names.items()}
+        return DatasetBaseDimensionQueryNamesModel(**data)
 
     def _handle_dimension_association_errors(
         self, diff, mapped_dataset_table, dataset_config, project_id

--- a/dsgrid/registry/project_registry_manager.py
+++ b/dsgrid/registry/project_registry_manager.py
@@ -1094,14 +1094,9 @@ class ProjectRegistryManager(RegistryManagerBase):
         new_mappings = []
         for from_id, from_version in needs_mapping:
             from_dim = self._dimension_mgr.get_by_id(from_id, version=from_version, conn=conn)
-            if from_dim.model.dimension_type == DimensionType.METRIC:
-                to_dim, to_version = project_config.get_base_dimension_and_version(
-                    from_dim.model.dimension_type
-                )
-            else:
-                to_dim, to_version = project_config.get_base_metric_dimension_and_version(
-                    from_dim.model.dimension_type
-                )
+            to_dim, to_version = project_config.get_base_dimension_and_version(
+                from_dim.model.dimension_type
+            )
             mapping, version = self._try_get_mapping(
                 project_config, from_dim, from_version, to_dim, to_version, context
             )

--- a/dsgrid/registry/registry_interface.py
+++ b/dsgrid/registry/registry_interface.py
@@ -11,7 +11,7 @@ from dsgrid.config.dimension_mapping_base import DimensionMappingBaseModel
 from dsgrid.config.dimensions import DimensionBaseModel, handle_dimension_union
 from dsgrid.config.mapping_tables import MappingTableModel
 from dsgrid.config.project_config import ProjectConfigModel
-from dsgrid.data_models import DSGBaseDatabaseModel
+from dsgrid.data_models import DSGBaseDatabaseModel, DSGBaseModel
 from dsgrid.registry.common import (
     DatasetRegistryStatus,
     MODEL_TYPE_TO_ID_FIELD_MAPPING,
@@ -69,7 +69,7 @@ class RegistryInterfaceBase(abc.ABC):
         """Return the model by version"""
         return self._make_dsgrid_model(self._get_by_version(conn, model_id, version))
 
-    def get_latest(self, conn: Optional[Connection], model_id) -> DSGBaseDatabaseModel:
+    def get_latest(self, conn: Optional[Connection], model_id) -> DSGBaseModel:
         """Return the model with the latest version."""
         return self._make_dsgrid_model(self._get_latest(conn, model_id))
 
@@ -122,7 +122,7 @@ class RegistryInterfaceBase(abc.ABC):
         conn: Optional[Connection],
         model: DSGBaseDatabaseModel,
         registration: RegistrationModel,
-    ) -> DSGBaseDatabaseModel:
+    ) -> DSGBaseModel:
         """Add a new model in the database."""
         if conn is None:
             with self._db.engine.begin() as conn:
@@ -131,7 +131,7 @@ class RegistryInterfaceBase(abc.ABC):
 
     def _insert(
         self, conn: Connection, model: DSGBaseDatabaseModel, registration: RegistrationModel
-    ) -> DSGBaseDatabaseModel:
+    ) -> DSGBaseModel:
         new_model = self._make_dsgrid_model(
             self._db.insert_model(
                 conn, self._model_type(), model.model_dump(mode="json"), registration

--- a/dsgrid/units/constants.py
+++ b/dsgrid/units/constants.py
@@ -1,0 +1,108 @@
+KILO = 1_000
+MEGA = 1_000_000
+GIGA = 1_000_000_000
+TERA = 1_000_000_000_000
+
+KILO_TO_MEGA = KILO / MEGA
+KILO_TO_GIGA = KILO / GIGA
+KILO_TO_TERA = KILO / TERA
+
+MEGA_TO_KILO = MEGA / KILO
+MEGA_TO_GIGA = MEGA / GIGA
+MEGA_TO_TERA = MEGA / TERA
+
+GIGA_TO_KILO = GIGA / KILO
+GIGA_TO_MEGA = GIGA / MEGA
+GIGA_TO_TERA = GIGA / TERA
+
+TERA_TO_KILO = TERA / KILO
+TERA_TO_MEGA = TERA / MEGA
+TERA_TO_GIGA = TERA / GIGA
+
+KWH = "kWh"
+MWH = "MWh"
+GWH = "GWh"
+TWH = "TWh"
+THERM = "therm"
+MBTU = "MBtu"
+
+KW = "kW"
+MW = "MW"
+GW = "GW"
+TW = "TW"
+
+THERM_TO_KWH = 29.307107017222222
+THERM_TO_MWH = THERM_TO_KWH * KILO_TO_MEGA
+THERM_TO_GWH = THERM_TO_KWH * KILO_TO_GIGA
+THERM_TO_TWH = THERM_TO_KWH * KILO_TO_TERA
+
+KWH_TO_THERM = 1 / THERM_TO_KWH
+MWH_TO_THERM = 1 / THERM_TO_MWH
+GWH_TO_THERM = 1 / THERM_TO_GWH
+TWH_TO_THERM = 1 / THERM_TO_TWH
+
+# BTU conversion is based on EIA. This website says 1 kWh = 3,412 BTU.
+# https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
+# The more precise number below comes from ResStock at
+# https://github.com/NREL/resstock/blob/2e0a82a7bfad0f17ff75a3c66c91a5d72265a847/resources/hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions.rb
+MBTU_TO_KWH = 293.0710701722222
+MBTU_TO_MWH = MBTU_TO_KWH * KILO_TO_MEGA
+MBTU_TO_GWH = MBTU_TO_KWH * KILO_TO_GIGA
+MBTU_TO_TWH = MBTU_TO_KWH * KILO_TO_TERA
+
+KWH_TO_MBTU = 1 / MBTU_TO_KWH
+MWH_TO_MBTU = 1 / MBTU_TO_MWH
+GWH_TO_MBTU = 1 / MBTU_TO_GWH
+TWH_TO_MBTU = 1 / MBTU_TO_TWH
+
+MBTU_TO_THERM = 10.0
+THERM_TO_MBTU = 1 / MBTU_TO_THERM
+
+
+# Constants for unit conversions
+__all__ = (
+    "KILO",
+    "MEGA",
+    "GIGA",
+    "TERA",
+    "KILO_TO_MEGA",
+    "KILO_TO_GIGA",
+    "KILO_TO_TERA",
+    "MEGA_TO_KILO",
+    "MEGA_TO_GIGA",
+    "MEGA_TO_TERA",
+    "GIGA_TO_KILO",
+    "GIGA_TO_MEGA",
+    "GIGA_TO_TERA",
+    "TERA_TO_KILO",
+    "TERA_TO_MEGA",
+    "TERA_TO_GIGA",
+    "KWH",
+    "MWH",
+    "GWH",
+    "TWH",
+    "THERM",
+    "MBTU",
+    "KW",
+    "MW",
+    "GW",
+    "TW",
+    "THERM_TO_KWH",
+    "THERM_TO_MWH",
+    "THERM_TO_GWH",
+    "THERM_TO_TWH",
+    "KWH_TO_THERM",
+    "MWH_TO_THERM",
+    "GWH_TO_THERM",
+    "TWH_TO_THERM",
+    "MBTU_TO_KWH",
+    "MBTU_TO_MWH",
+    "MBTU_TO_GWH",
+    "MBTU_TO_TWH",
+    "KWH_TO_MBTU",
+    "MWH_TO_MBTU",
+    "GWH_TO_MBTU",
+    "TWH_TO_MBTU",
+    "MBTU_TO_THERM",
+    "THERM_TO_MBTU",
+)

--- a/dsgrid/units/constants.py
+++ b/dsgrid/units/constants.py
@@ -58,9 +58,14 @@ TWH_TO_MBTU = 1 / MBTU_TO_TWH
 MBTU_TO_THERM = 10.0
 THERM_TO_MBTU = 1 / MBTU_TO_THERM
 
+ENERGY_UNITS = (KWH, MWH, GWH, TWH, THERM, MBTU)
+POWER_UNITS = (KW, MW, GW, TW)
+
 
 # Constants for unit conversions
 __all__ = (
+    "ENERGY_UNITS",
+    "POWER_UNITS",
     "KILO",
     "MEGA",
     "GIGA",

--- a/dsgrid/units/convert.py
+++ b/dsgrid/units/convert.py
@@ -6,14 +6,11 @@ import dsgrid.units.power as power
 from dsgrid.common import VALUE_COLUMN
 from dsgrid.spark.functions import except_all, is_dataframe_empty, join
 from dsgrid.spark.types import DataFrame, F
-from dsgrid.units.constants import KWH, MWH, GWH, TWH, THERM, MBTU, KW, MW, GW, TW
+from dsgrid.units.constants import ENERGY_UNITS, POWER_UNITS
 from dsgrid.utils.spark import get_unique_values
 
 
 logger = logging.getLogger(__name__)
-
-ENERGY_UNITS = (KWH, MWH, GWH, TWH, THERM, MBTU)
-POWER_UNITS = (KW, MW, GW, TW)
 
 
 def convert_units_unpivoted(

--- a/dsgrid/units/convert.py
+++ b/dsgrid/units/convert.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Optional
+
+import dsgrid.units.energy as energy
+import dsgrid.units.power as power
+from dsgrid.common import VALUE_COLUMN
+from dsgrid.spark.functions import except_all, is_dataframe_empty, join
+from dsgrid.spark.types import DataFrame, F
+from dsgrid.units.constants import KWH, MWH, GWH, TWH, THERM, MBTU, KW, MW, GW, TW
+from dsgrid.utils.spark import get_unique_values
+
+
+logger = logging.getLogger(__name__)
+
+ENERGY_UNITS = (KWH, MWH, GWH, TWH, THERM, MBTU)
+POWER_UNITS = (KW, MW, GW, TW)
+
+
+def convert_units_unpivoted(
+    df: DataFrame,
+    metric_column: str,
+    from_records: DataFrame,
+    from_to_records: Optional[DataFrame],
+    to_unit_records: DataFrame,
+) -> DataFrame:
+    """Convert the value column of the dataframe to the target units.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Load data table
+    metric_column : str
+        Column in dataframe with metric record IDs
+    from_records : DataFrame
+        Metric dimension records for the columns being converted
+    from_to_records : DataFrame | None
+        Records that map the dimension IDs in columns to the target IDs
+        If None, mapping is not required and from_records contain the units.
+    to_unit_records : DataFrame
+        Metric dimension records for the target IDs
+    """
+    unit_col = "unit"  # must match EnergyEndUse.unit
+    tmp1 = from_records.select("id", unit_col).withColumnRenamed(unit_col, "from_unit")
+    if from_to_records is None:
+        unit_df = tmp1.select("id", "from_unit")
+    else:
+        tmp2 = from_to_records.select("from_id", "to_id")
+        unit_df = (
+            join(tmp1, tmp2, "id", "from_id")
+            .select(F.col("to_id").alias("id"), "from_unit")
+            .distinct()
+        )
+    if is_dataframe_empty(
+        except_all(unit_df, to_unit_records.select("id", F.col("unit").alias("from_unit")))
+    ):
+        logger.debug("Return early because the units match.")
+        return df
+
+    df = join(df, unit_df, metric_column, "id").drop("id")
+    tmp3 = to_unit_records.select("id", "unit").withColumnRenamed(unit_col, "to_unit")
+    df = join(df, tmp3, metric_column, "id").drop("id")
+    logger.debug("Converting units from column %s", metric_column)
+
+    units = get_unique_values(to_unit_records, unit_col)
+    if units.issubset(ENERGY_UNITS):
+        func = energy.from_any_to_any
+    elif units.issubset(POWER_UNITS):
+        func = power.from_any_to_any
+    else:
+        raise ValueError(f"Unsupported unit conversion: {units}")
+
+    return df.withColumn(VALUE_COLUMN, func("from_unit", "to_unit", VALUE_COLUMN)).drop(
+        "from_unit", "to_unit"
+    )

--- a/dsgrid/units/energy.py
+++ b/dsgrid/units/energy.py
@@ -1,71 +1,52 @@
-"""Contains functions to convert electricity between units."""
+"""Contains functions to perform unit conversion of energy."""
 
 import logging
 
-from dsgrid.common import VALUE_COLUMN
-from dsgrid.spark.functions import except_all, is_dataframe_empty, join
 from dsgrid.spark.types import DataFrame, F
+from dsgrid.units.constants import (
+    GIGA_TO_KILO,
+    GIGA_TO_MEGA,
+    GIGA_TO_TERA,
+    GWH,
+    GWH_TO_MBTU,
+    GWH_TO_THERM,
+    KILO_TO_GIGA,
+    KILO_TO_MEGA,
+    KILO_TO_TERA,
+    KWH,
+    KWH_TO_MBTU,
+    KWH_TO_THERM,
+    MBTU,
+    MBTU_TO_GWH,
+    MBTU_TO_KWH,
+    MBTU_TO_MWH,
+    MBTU_TO_THERM,
+    MBTU_TO_TWH,
+    MEGA_TO_GIGA,
+    MEGA_TO_KILO,
+    MEGA_TO_TERA,
+    MWH,
+    MWH_TO_MBTU,
+    MWH_TO_THERM,
+    TERA_TO_GIGA,
+    TERA_TO_KILO,
+    TERA_TO_MEGA,
+    THERM,
+    THERM_TO_GWH,
+    THERM_TO_KWH,
+    THERM_TO_MBTU,
+    THERM_TO_MWH,
+    THERM_TO_TWH,
+    TWH,
+    TWH_TO_MBTU,
+    TWH_TO_THERM,
+)
 
-
-KWH = "kWh"
-MWH = "MWh"
-GWH = "GWh"
-TWH = "TWh"
-THERM = "therm"
-MBTU = "MBtu"
-
-KILO = 1_000
-MEGA = 1_000_000
-GIGA = 1_000_000_000
-TERA = 1_000_000_000_000
-
-KILO_TO_MEGA = KILO / MEGA
-KILO_TO_GIGA = KILO / GIGA
-KILO_TO_TERA = KILO / TERA
-
-MEGA_TO_KILO = MEGA / KILO
-MEGA_TO_GIGA = MEGA / GIGA
-MEGA_TO_TERA = MEGA / TERA
-
-GIGA_TO_KILO = GIGA / KILO
-GIGA_TO_MEGA = GIGA / MEGA
-GIGA_TO_TERA = GIGA / TERA
-
-TERA_TO_KILO = TERA / KILO
-TERA_TO_MEGA = TERA / MEGA
-TERA_TO_GIGA = TERA / GIGA
-
-THERM_TO_KWH = 29.307107017222222
-THERM_TO_MWH = THERM_TO_KWH * KILO_TO_MEGA
-THERM_TO_GWH = THERM_TO_KWH * KILO_TO_GIGA
-THERM_TO_TWH = THERM_TO_KWH * KILO_TO_TERA
-
-KWH_TO_THERM = 1 / THERM_TO_KWH
-MWH_TO_THERM = 1 / THERM_TO_MWH
-GWH_TO_THERM = 1 / THERM_TO_GWH
-TWH_TO_THERM = 1 / THERM_TO_TWH
-
-# BTU conversion is based on EIA. This website says 1 kWh = 3,412 BTU.
-# https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
-# The more precise number below comes from ResStock at
-# https://github.com/NREL/resstock/blob/2e0a82a7bfad0f17ff75a3c66c91a5d72265a847/resources/hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions.rb
-MBTU_TO_KWH = 293.0710701722222
-MBTU_TO_MWH = MBTU_TO_KWH * KILO_TO_MEGA
-MBTU_TO_GWH = MBTU_TO_KWH * KILO_TO_GIGA
-MBTU_TO_TWH = MBTU_TO_KWH * KILO_TO_TERA
-
-KWH_TO_MBTU = 1 / MBTU_TO_KWH
-MWH_TO_MBTU = 1 / MBTU_TO_MWH
-GWH_TO_MBTU = 1 / MBTU_TO_GWH
-TWH_TO_MBTU = 1 / MBTU_TO_TWH
-
-MBTU_TO_THERM = 10.0
-THERM_TO_MBTU = 1 / MBTU_TO_THERM
 
 logger = logging.getLogger(__name__)
 
 
-def to_kwh(unit_col, value_col):
+def to_kwh(unit_col: str, value_col: str) -> DataFrame:
     """Convert a column to kWh."""
     return (
         F.when(F.col(unit_col) == KWH, F.col(value_col))
@@ -79,7 +60,7 @@ def to_kwh(unit_col, value_col):
     )
 
 
-def to_mwh(unit_col, value_col):
+def to_mwh(unit_col: str, value_col: str) -> DataFrame:
     """Convert a column to mWh."""
     return (
         F.when(F.col(unit_col) == KWH, (F.col(value_col) * KILO_TO_MEGA))
@@ -93,7 +74,7 @@ def to_mwh(unit_col, value_col):
     )
 
 
-def to_gwh(unit_col, value_col):
+def to_gwh(unit_col: str, value_col: str) -> DataFrame:
     """Convert a column to gWh."""
     return (
         F.when(F.col(unit_col) == KWH, (F.col(value_col) * KILO_TO_GIGA))
@@ -107,7 +88,7 @@ def to_gwh(unit_col, value_col):
     )
 
 
-def to_twh(unit_col, value_col):
+def to_twh(unit_col: str, value_col: str) -> DataFrame:
     """Convert a column to tWh."""
     return (
         F.when(F.col(unit_col) == KWH, (F.col(value_col) * KILO_TO_TERA))
@@ -121,7 +102,7 @@ def to_twh(unit_col, value_col):
     )
 
 
-def to_therm(unit_col, value_col):
+def to_therm(unit_col: str, value_col: str) -> DataFrame:
     """Convert a column to therm."""
     return (
         F.when(F.col(unit_col) == KWH, (F.col(value_col) * KWH_TO_THERM))
@@ -135,7 +116,7 @@ def to_therm(unit_col, value_col):
     )
 
 
-def to_mbtu(unit_col, value_col):
+def to_mbtu(unit_col: str, value_col: str) -> DataFrame:
     """Convert a column to MBtu."""
     return (
         F.when(F.col(unit_col) == KWH, (F.col(value_col) * KWH_TO_MBTU))
@@ -149,8 +130,8 @@ def to_mbtu(unit_col, value_col):
     )
 
 
-def from_any_to_any(from_unit_col, to_unit_col, value_col):
-    """Convert a column based on from/to columns."""
+def from_any_to_any(from_unit_col: str, to_unit_col: str, value_col: str) -> DataFrame:
+    """Convert a column of energy based on from/to columns."""
     return (
         F.when(F.col(from_unit_col) == F.col(to_unit_col), F.col(value_col))
         .when(F.col(from_unit_col) == "", F.col(value_col))
@@ -161,49 +142,4 @@ def from_any_to_any(from_unit_col, to_unit_col, value_col):
         .when(F.col(to_unit_col) == THERM, to_therm(from_unit_col, value_col))
         .when(F.col(to_unit_col) == MBTU, to_mbtu(from_unit_col, value_col))
         .otherwise(None)
-    )
-
-
-def convert_units_unpivoted(
-    df, metric_column, from_records, from_to_records, to_unit_records
-) -> DataFrame:
-    """Convert the value column of the dataframe to the target units.
-
-    Parameters
-    ----------
-    df : DataFrame
-        Load data table
-    metric_column : str
-        Column in dataframe with metric record IDs
-    from_records : DataFrame
-        Metric dimension records for the columns being converted
-    from_to_records : DataFrame | None
-        Records that map the dimension IDs in columns to the target IDs
-        If None, mapping is not required and from_records contain the units.
-    to_unit_records : DataFrame
-        Metric dimension records for the target IDs
-    """
-    unit_col = "unit"  # must match EnergyEndUse.unit
-    tmp1 = from_records.select("id", unit_col).withColumnRenamed(unit_col, "from_unit")
-    if from_to_records is None:
-        unit_df = tmp1.select("id", "from_unit")
-    else:
-        tmp2 = from_to_records.select("from_id", "to_id")
-        unit_df = (
-            join(tmp1, tmp2, "id", "from_id")
-            .select(F.col("to_id").alias("id"), "from_unit")
-            .distinct()
-        )
-    if is_dataframe_empty(
-        except_all(unit_df, to_unit_records.select("id", F.col("unit").alias("from_unit")))
-    ):
-        logger.debug("Return early because the units match.")
-        return df
-
-    df = join(df, unit_df, metric_column, "id").drop("id")
-    tmp3 = to_unit_records.select("id", "unit").withColumnRenamed(unit_col, "to_unit")
-    df = join(df, tmp3, metric_column, "id").drop("id")
-    logger.debug("Converting units from column %s", metric_column)
-    return df.withColumn(VALUE_COLUMN, from_any_to_any("from_unit", "to_unit", VALUE_COLUMN)).drop(
-        "from_unit", "to_unit"
     )

--- a/dsgrid/units/power.py
+++ b/dsgrid/units/power.py
@@ -1,0 +1,87 @@
+"""Contains functions to perform unit conversion of power."""
+
+import logging
+
+from dsgrid.spark.types import DataFrame, F
+from dsgrid.units.constants import (
+    GIGA_TO_KILO,
+    GIGA_TO_MEGA,
+    GIGA_TO_TERA,
+    GW,
+    KILO_TO_GIGA,
+    KILO_TO_MEGA,
+    KILO_TO_TERA,
+    KW,
+    MEGA_TO_GIGA,
+    MEGA_TO_KILO,
+    MEGA_TO_TERA,
+    MW,
+    TERA_TO_GIGA,
+    TERA_TO_KILO,
+    TERA_TO_MEGA,
+    TW,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def to_kw(unit_col: str, value_col: str) -> DataFrame:
+    """Convert a column to kW."""
+    return (
+        F.when(F.col(unit_col) == KW, F.col(value_col))
+        .when(F.col(unit_col) == MW, (F.col(value_col) * MEGA_TO_KILO))
+        .when(F.col(unit_col) == GW, (F.col(value_col) * GIGA_TO_KILO))
+        .when(F.col(unit_col) == TW, (F.col(value_col) * TERA_TO_KILO))
+        .when(F.col(unit_col) == "", F.col(value_col))
+        .otherwise(None)
+    )
+
+
+def to_mw(unit_col: str, value_col: str) -> DataFrame:
+    """Convert a column to MW."""
+    return (
+        F.when(F.col(unit_col) == KW, (F.col(value_col) * KILO_TO_MEGA))
+        .when(F.col(unit_col) == MW, F.col(value_col))
+        .when(F.col(unit_col) == GW, (F.col(value_col) * GIGA_TO_MEGA))
+        .when(F.col(unit_col) == TW, (F.col(value_col) * TERA_TO_MEGA))
+        .when(F.col(unit_col) == "", F.col(value_col))
+        .otherwise(None)
+    )
+
+
+def to_gw(unit_col: str, value_col: str) -> DataFrame:
+    """Convert a column to GW."""
+    return (
+        F.when(F.col(unit_col) == KW, (F.col(value_col) * KILO_TO_GIGA))
+        .when(F.col(unit_col) == MW, (F.col(value_col) * MEGA_TO_GIGA))
+        .when(F.col(unit_col) == GW, F.col(value_col))
+        .when(F.col(unit_col) == TW, (F.col(value_col) * TERA_TO_GIGA))
+        .when(F.col(unit_col) == "", F.col(value_col))
+        .otherwise(None)
+    )
+
+
+def to_tw(unit_col: str, value_col: str) -> DataFrame:
+    """Convert a column to TW."""
+    return (
+        F.when(F.col(unit_col) == KW, (F.col(value_col) * KILO_TO_TERA))
+        .when(F.col(unit_col) == MW, (F.col(value_col) * MEGA_TO_TERA))
+        .when(F.col(unit_col) == GW, (F.col(value_col) * GIGA_TO_TERA))
+        .when(F.col(unit_col) == TW, F.col(value_col))
+        .when(F.col(unit_col) == "", F.col(value_col))
+        .otherwise(None)
+    )
+
+
+def from_any_to_any(from_unit_col: str, to_unit_col: str, value_col: str) -> DataFrame:
+    """Convert a column of power based on from/to columns."""
+    return (
+        F.when(F.col(from_unit_col) == F.col(to_unit_col), F.col(value_col))
+        .when(F.col(from_unit_col) == "", F.col(value_col))
+        .when(F.col(to_unit_col) == KW, to_kw(from_unit_col, value_col))
+        .when(F.col(to_unit_col) == MW, to_mw(from_unit_col, value_col))
+        .when(F.col(to_unit_col) == GW, to_gw(from_unit_col, value_col))
+        .when(F.col(to_unit_col) == TW, to_tw(from_unit_col, value_col))
+        .otherwise(None)
+    )

--- a/dsgrid/utils/dataset.py
+++ b/dsgrid/utils/dataset.py
@@ -37,7 +37,13 @@ from dsgrid.utils.timing import timer_stats_collector, track_timing
 logger = logging.getLogger(__name__)
 
 
-def map_and_reduce_stacked_dimension(df, records, column, drop_column=True, to_column=None):
+def map_and_reduce_stacked_dimension(
+    df: DataFrame,
+    records: DataFrame,
+    column: str,
+    drop_column: bool = True,
+    to_column: Optional[str] = None,
+) -> DataFrame:
     to_column_ = to_column or column
     if "fraction" not in df.columns:
         df = df.withColumn("fraction", F.lit(1.0))

--- a/dsgrid/utils/spark.py
+++ b/dsgrid/utils/spark.py
@@ -9,7 +9,7 @@ import shutil
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, Iterable, Type, Union, get_origin, get_args
+from typing import Any, Generator, Iterable, Sequence, Type, Union, get_origin, get_args
 
 import duckdb
 import pandas as pd
@@ -313,7 +313,7 @@ def cross_join_dfs(dfs: list[DataFrame]) -> DataFrame:
     return df
 
 
-def get_unique_values(df: DataFrame, columns: str | list[str]) -> set:
+def get_unique_values(df: DataFrame, columns: Sequence[str]) -> set[str]:
     """Return the unique values of a dataframe in one column or a list of columns."""
     dfc = df.select(columns).distinct().collect()
     if isinstance(columns, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # "awscliv2",
     # "boto3",
     # "s3path",
-    "chronify ~= 0.2.0",
+    "chronify ~= 0.2.1",
     "click>=8",
     "dash",
     "dash_bootstrap_components",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "pre-commit",
     "devtools",
     "flake8",
+    "mypy",
     "pyarrow",
 ]
 
@@ -83,6 +84,7 @@ doc = [
     "furo",
     "ghp-import",
     "numpydoc",
+    "pandas-stubs",
     "sphinx~=7.2",
     "sphinx-click~=5.0",
     "sphinx-copybutton~=0.5.2",

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -21,7 +21,7 @@ from dsgrid.utils.id_remappings import (
 )
 
 STANDARD_SCENARIOS_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-StandardScenarios"
-DECARB_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-DECARB"
+IEF_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-IEF"
 
 
 def test_register_dimensions_and_mappings(tmp_registry_db):
@@ -245,7 +245,7 @@ def test_register_dsgrid_projects(tmp_registry_db):
 
     project_configs = (
         STANDARD_SCENARIOS_PROJECT_REPO / "dsgrid_project" / "project.json5",
-        DECARB_PROJECT_REPO / "project" / "project.json5",
+        IEF_PROJECT_REPO / "project" / "project.json5",
     )
 
     # Test these together because they share dimensions and mappings.

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -352,9 +352,9 @@ def test_register_multiple_metric_dimensions(tmp_registry_db):
     base = TEST_PROJECT_PATH / "filtered_registries" / "dgen_multiple_metrics"
     project_dir = base / "dsgrid-project-IEF"
     project_config_file = project_dir / "project" / "project.json5"
-    profiles_config_file = project_dir / "datasets" / "modeled" / "dgen" / "dataset.json5"
+    profiles_config_file = project_dir / "datasets" / "modeled" / "dgen_profiles" / "dataset.json5"
     profiles_mapping_file = (
-        project_dir / "datasets" / "modeled" / "dgen" / "dimension_mappings.json5"
+        project_dir / "datasets" / "modeled" / "dgen_profiles" / "dimension_mappings.json5"
     )
     capacities_config_file = (
         project_dir / "datasets" / "modeled" / "dgen_capacities" / "dataset.json5"

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -418,3 +418,23 @@ def test_register_multiple_metric_dimensions(tmp_registry_db):
     for cmd in cmds:
         result = runner.invoke(cli, cmd)
         assert result.exit_code == 0
+
+    for dataset_id in ("decarb_2023_dgen", "decarb_2023_dgen_capacities"):
+        cmd = [
+            "-u",
+            url,
+            "query",
+            "project",
+            "map-dataset",
+            "US_DOE_DECARB_2023",
+            dataset_id,
+            "-o",
+            str(tmpdir),
+        ]
+        result = runner.invoke(cli, cmd)
+        assert result.exit_code == 0
+        match = re.search(r"Wrote mapped dataset [\w-]+ to (.*parquet)", result.stderr)
+        assert match
+        path = Path(match.group(1))
+        assert path.exists()
+        # Correctness of map_dataset is tested elsewhere.

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -21,7 +21,7 @@ from dsgrid.utils.id_remappings import (
 )
 
 STANDARD_SCENARIOS_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-StandardScenarios"
-IEF_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-IEF"
+IEF_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-DECARB"
 
 
 def test_register_dimensions_and_mappings(tmp_registry_db):

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from datetime import datetime
 
 import pytest
 
@@ -218,9 +217,9 @@ def test_is_noop_mapping_false():
 def test_add_null_rows_from_load_data_lookup():
     df = create_dataframe_from_dicts(
         [
-            {"timestamp": datetime(2018, 1, 1, 1), "model_year": 2030, "geography": "Jefferson"},
-            {"timestamp": datetime(2018, 1, 1, 2), "model_year": 2030, "geography": "Jefferson"},
-            {"timestamp": datetime(2018, 1, 1, 3), "model_year": 2030, "geography": "Jefferson"},
+            {"timestamp": "2018-01-01 01:00:00", "model_year": 2030, "geography": "Jefferson"},
+            {"timestamp": "2018-01-01 02:00:00", "model_year": 2030, "geography": "Jefferson"},
+            {"timestamp": "2018-01-01 03:00:00", "model_year": 2030, "geography": "Jefferson"},
         ]
     )
     lookup = create_dataframe_from_dicts(

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -146,7 +146,7 @@ def test_invalid_multi_dimensional_requirement_base_and_base_missing():
             "subsector": {"base": ["subsector1"]},
         },
     ]
-    with pytest.raises(ValueError, match="base and base_missing cannot both be set"):
+    with pytest.raises(ValueError, match="base and base_missing cannot both contain"):
         RequiredDimensionsModel(
             multi_dimensional=[RequiredDimensionRecordsModel(**x) for x in multi_dim_data],
         )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -446,7 +446,7 @@ def test_transform_unpivoted_dataset(tmp_path):
         DatabaseConnection(url=SIMPLE_STANDARD_SCENARIOS_REGISTRY_DB),
         "dsgrid_conus_2022",
     )
-    path = project.transform_dataset("comstock_conus_2022_projected", tmp_path)
+    path = project.map_dataset("comstock_conus_2022_projected", tmp_path)
     df = read_parquet(path)
     actual = aggregate_single_value(
         df.filter("geography == '06037'").filter(
@@ -464,7 +464,7 @@ def test_transform_pivoted_dataset(tmp_path):
         DatabaseConnection(url=SIMPLE_STANDARD_SCENARIOS_REGISTRY_DB),
         "dsgrid_conus_2022",
     )
-    path = project.transform_dataset("resstock_conus_2022_projected", tmp_path)
+    path = project.map_dataset("resstock_conus_2022_projected", tmp_path)
     df = read_parquet(path).filter("geography == '06037'")
     cooling = aggregate_single_value(
         df.filter("metric = 'electricity_cooling'").select(VALUE_COLUMN),

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -468,14 +468,28 @@ def test_replace_dataset_dimension_requirements(mutable_cached_registry, tmp_pat
     config = project_mgr.get_by_id(project_id)
     requirements_file = tmp_path / "requirements.json5"
     dataset = config.model.datasets[1]
+    com_record_ids = [
+        "FullServiceRestaurant",
+        "Hospital",
+        "LargeHotel",
+        "LargeOffice",
+        "MediumOffice",
+        "Outpatient",
+        "PrimarySchool",
+        "QuickServiceRestaurant",
+        "SmallHotel",
+        "SmallOffice",
+        "StandaloneRetail",
+        "StripMall",
+        "Warehouse",
+    ]
+
     assert dataset.status == DatasetRegistryStatus.REGISTERED
     assert config.model.datasets[0].status == DatasetRegistryStatus.REGISTERED
     reqs = dataset.required_dimensions
-    assert reqs.multi_dimensional[0].subsector.supplemental[0].record_ids == [
-        "commercial_subsectors"
-    ]
-    reqs.multi_dimensional[0].subsector.supplemental[0].record_ids = ["residential_subsectors"]
-    reqs.multi_dimensional[0].subsector.supplemental[0].name = "Residential Subsector"
+    assert reqs.multi_dimensional[0].subsector.subset[0].selectors == ["commercial_subsectors2"]
+    reqs.multi_dimensional[0].subsector.subset.clear()
+    reqs.multi_dimensional[0].subsector.base.record_ids = com_record_ids
     model = InputDatasetDimensionRequirementsListModel(
         dataset_dimension_requirements=[
             InputDatasetDimensionRequirementsModel(
@@ -507,9 +521,7 @@ def test_replace_dataset_dimension_requirements(mutable_cached_registry, tmp_pat
     config = project_mgr.get_by_id(project_id)
     assert config.model.datasets[0].status == DatasetRegistryStatus.REGISTERED
     assert config.model.datasets[1].status == DatasetRegistryStatus.UNREGISTERED
-    assert reqs.multi_dimensional[0].subsector.supplemental[0].record_ids == [
-        "residential_subsectors"
-    ]
+    assert reqs.multi_dimensional[0].subsector.base.record_ids == com_record_ids
 
 
 def test_auto_updates(mutable_cached_registry: tuple[RegistryManager, Path]):

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -2,47 +2,46 @@ import math
 
 import pytest
 
+import dsgrid.units.energy as energy
+import dsgrid.units.power as power
 from dsgrid.common import VALUE_COLUMN
-from dsgrid.units.energy import (
-    KWH,
-    MWH,
-    GWH,
-    TWH,
-    MBTU,
-    THERM,
-    KILO_TO_MEGA,
-    KILO_TO_GIGA,
-    KILO_TO_TERA,
-    MEGA_TO_KILO,
-    MEGA_TO_GIGA,
-    MEGA_TO_TERA,
+from dsgrid.spark.functions import cache, unpersist
+from dsgrid.spark.types import F
+from dsgrid.units.constants import (
     GIGA_TO_KILO,
     GIGA_TO_MEGA,
     GIGA_TO_TERA,
-    TERA_TO_KILO,
-    TERA_TO_MEGA,
-    TERA_TO_GIGA,
-    THERM_TO_KWH,
-    THERM_TO_MWH,
-    THERM_TO_GWH,
-    THERM_TO_TWH,
-    MWH_TO_THERM,
+    GW,
+    GWH,
     GWH_TO_THERM,
-    TWH_TO_THERM,
+    KILO_TO_GIGA,
+    KILO_TO_MEGA,
+    KILO_TO_TERA,
+    KW,
+    KWH,
+    MBTU,
+    MBTU_TO_GWH,
     MBTU_TO_KWH,
     MBTU_TO_MWH,
-    MBTU_TO_GWH,
     MBTU_TO_TWH,
-    to_kwh,
-    to_mwh,
-    to_gwh,
-    to_twh,
-    to_therm,
-    to_mbtu,
-    from_any_to_any,
+    MEGA_TO_GIGA,
+    MEGA_TO_KILO,
+    MEGA_TO_TERA,
+    MW,
+    MWH,
+    MWH_TO_THERM,
+    TERA_TO_GIGA,
+    TERA_TO_KILO,
+    TERA_TO_MEGA,
+    THERM,
+    THERM_TO_GWH,
+    THERM_TO_KWH,
+    THERM_TO_MWH,
+    THERM_TO_TWH,
+    TW,
+    TWH,
+    TWH_TO_THERM,
 )
-from dsgrid.spark.functions import cache, unpersist
-from dsgrid.spark.types import F
 from dsgrid.utils.spark import create_dataframe_from_dicts
 
 
@@ -50,13 +49,18 @@ KWH_VAL = 1234.5
 MWH_VAL = KWH_VAL / 1_000
 GWH_VAL = KWH_VAL / 1_000_000
 TWH_VAL = KWH_VAL / 1_000_000_000
+KW_VAL = 1234.5
+MW_VAL = KW_VAL / 1_000
+GW_VAL = KW_VAL / 1_000_000
+TW_VAL = KW_VAL / 1_000_000_000
 THERM_VAL = KWH_VAL / THERM_TO_KWH
 MBTU_VAL = KWH_VAL / MBTU_TO_KWH
-UNIT_COLUMNS = ("fans", "cooling", "dryer", "ev_l1l2", "ng_heating", "p_heating")
+UNIT_COLUMNS_ENERGY = ("fans", "cooling", "dryer", "ev_l1l2", "ng_heating", "p_heating")
+UNIT_COLUMNS_POWER = ("fans", "cooling", "dryer", "ev_l1l2")
 
 
 @pytest.fixture(scope="module")
-def records_dataframe():
+def records_dataframe_energy():
     data = [
         {"id": "fans", "name": "Fans", "fuel_id": "electricity", "unit": KWH},
         {"id": "cooling", "name": "Space Cooling", "fuel_id": "electricity", "unit": MWH},
@@ -73,7 +77,22 @@ def records_dataframe():
 
 
 @pytest.fixture(scope="module")
-def pivoted_dataframes(records_dataframe):
+def records_dataframe_power():
+    data = [
+        {"id": "fans", "name": "Fans", "unit": KW},
+        {"id": "cooling", "name": "Space Cooling", "unit": MW},
+        {"id": "dryer", "name": "Dryer", "unit": GW},
+        {"id": "ev_l1l2", "name": "EV L1/L2", "unit": TW},
+        {"id": "unitless", "name": "unitless", "unit": ""},
+    ]
+    records = create_dataframe_from_dicts(data)
+    cache(records)
+    yield records
+    unpersist(records)
+
+
+@pytest.fixture(scope="module")
+def pivoted_dataframes(records_dataframe_energy):
     data = [
         {
             "fans": KWH_VAL,
@@ -87,12 +106,12 @@ def pivoted_dataframes(records_dataframe):
     ]
     df = create_dataframe_from_dicts(data)
     cache(df)
-    yield df, records_dataframe
+    yield df, records_dataframe_energy
     unpersist(df)
 
 
 @pytest.fixture(scope="module")
-def unpivoted_dataframes(records_dataframe):
+def unpivoted_dataframes_energy(records_dataframe_energy):
     data = [
         {
             "timestamp": 1,
@@ -132,7 +151,42 @@ def unpivoted_dataframes(records_dataframe):
     ]
     df = create_dataframe_from_dicts(data)
     cache(df)
-    yield df, records_dataframe
+    yield df, records_dataframe_energy
+    unpersist(df)
+
+
+@pytest.fixture(scope="module")
+def unpivoted_dataframes_power(records_dataframe_power):
+    data = [
+        {
+            "timestamp": 1,
+            "metric": "fans",
+            "value": KW_VAL,
+        },
+        {
+            "timestamp": 1,
+            "metric": "cooling",
+            "value": MW_VAL,
+        },
+        {
+            "timestamp": 1,
+            "metric": "dryer",
+            "value": GW_VAL,
+        },
+        {
+            "timestamp": 1,
+            "metric": "ev_l1l2",
+            "value": TW_VAL,
+        },
+        {
+            "timestamp": 1,
+            "metric": "unitless",
+            "value": KW_VAL,
+        },
+    ]
+    df = create_dataframe_from_dicts(data)
+    cache(df)
+    yield df, records_dataframe_power
     unpersist(df)
 
 
@@ -160,8 +214,8 @@ def test_constants():
     assert math.isclose(MBTU_TO_TWH, MBTU_TO_KWH / 1_000_000_000)
 
 
-def check_column_values(row, expected_val):
-    for col in UNIT_COLUMNS:
+def check_column_values(row, expected_val, unit_columns):
+    for col in unit_columns:
         assert math.isclose(row[col], expected_val)
     assert row["unitless"] == KWH_VAL
 
@@ -169,24 +223,24 @@ def check_column_values(row, expected_val):
 @pytest.mark.parametrize(
     "inputs",
     (
-        (to_kwh, KWH_VAL),
-        (to_mwh, MWH_VAL),
-        (to_gwh, GWH_VAL),
-        (to_twh, TWH_VAL),
-        (to_therm, THERM_VAL),
-        (to_mbtu, MBTU_VAL),
+        (energy.to_kwh, KWH_VAL),
+        (energy.to_mwh, MWH_VAL),
+        (energy.to_gwh, GWH_VAL),
+        (energy.to_twh, TWH_VAL),
+        (energy.to_therm, THERM_VAL),
+        (energy.to_mbtu, MBTU_VAL),
     ),
 )
 def test_to_units(pivoted_dataframes, inputs):
     df, records = pivoted_dataframes
     func, expected_val = inputs
     row = _convert_units(df, records, func)
-    check_column_values(row, expected_val)
+    check_column_values(row, expected_val, UNIT_COLUMNS_ENERGY)
 
 
 @pytest.mark.parametrize("to_unit", [KWH, MWH, GWH, TWH, THERM, MBTU])
-def test_from_any_to_any(unpivoted_dataframes, to_unit):
-    df, records = unpivoted_dataframes
+def test_from_any_to_any_energy(unpivoted_dataframes_energy, to_unit):
+    df, records = unpivoted_dataframes_energy
     df_with_units = (
         df.join(records, on=df.metric == records.id)
         .withColumnRenamed("unit", "from_unit")
@@ -194,7 +248,7 @@ def test_from_any_to_any(unpivoted_dataframes, to_unit):
         .select("metric", "timestamp", "from_unit", "to_unit", VALUE_COLUMN)
     )
     res = df_with_units.withColumn(
-        VALUE_COLUMN, from_any_to_any("from_unit", "to_unit", VALUE_COLUMN)
+        VALUE_COLUMN, energy.from_any_to_any("from_unit", "to_unit", VALUE_COLUMN)
     )
 
     unitless = res.filter("metric == 'unitless'").collect()[0][VALUE_COLUMN]
@@ -216,7 +270,40 @@ def test_from_any_to_any(unpivoted_dataframes, to_unit):
         case _:
             assert False, to_unit
 
-    for col in UNIT_COLUMNS:
+    for col in UNIT_COLUMNS_ENERGY:
+        val = res.filter(f"metric == '{col}'").collect()[0][VALUE_COLUMN]
+        assert math.isclose(val, expected_val)
+
+
+@pytest.mark.parametrize("to_unit", [KW, MW, GW, TW])
+def test_from_any_to_any_power(unpivoted_dataframes_power, to_unit):
+    df, records = unpivoted_dataframes_power
+    df_with_units = (
+        df.join(records, on=df.metric == records.id)
+        .withColumnRenamed("unit", "from_unit")
+        .withColumn("to_unit", F.lit(to_unit))
+        .select("metric", "timestamp", "from_unit", "to_unit", VALUE_COLUMN)
+    )
+    res = df_with_units.withColumn(
+        VALUE_COLUMN, power.from_any_to_any("from_unit", "to_unit", VALUE_COLUMN)
+    )
+
+    unitless = res.filter("metric == 'unitless'").collect()[0][VALUE_COLUMN]
+    assert unitless == KWH_VAL
+
+    match to_unit:
+        case "kW":
+            expected_val = KW_VAL
+        case "MW":
+            expected_val = MW_VAL
+        case "GW":
+            expected_val = GW_VAL
+        case "TW":
+            expected_val = TW_VAL
+        case _:
+            assert False, to_unit
+
+    for col in UNIT_COLUMNS_POWER:
         val = res.filter(f"metric == '{col}'").collect()[0][VALUE_COLUMN]
         assert math.isclose(val, expected_val)
 


### PR DESCRIPTION
Add support for multiple base dimensions in a project (excluding time). The primary use case is multiple metric dimensions as shown in the companion PR https://github.com/dsgrid/dsgrid-test-data/pull/46, which splits the dGen dataset into two: one for profiles and one for capacity.

Adding this support required significant changes in the project configuration. While implementing those changes I was challenged by a lack of type annotations and so added them (that means a lot more lines changed). We will be closer to supporting mypy. One big contributor to annotation problems was differences between retrieving a dimension config that does not have records (time) vs one that does. I made some new methods to make this process cleaner.

I added the CLI command `dsgrid query project map-dataset` to help with testing and demonstration of the use cases.

I have noted two cases in the code where trying to identify the appropriate base-to-supplemental dimension mapping was too difficult to achieve here. Ideas welcome.

Unit conversion was previously tied to energy. I did some refactoring to allow conversion of power.