### PR TITLE
Don't let dataset_id start with a number

### DIFF
--- a/dsgrid/registry/common.py
+++ b/dsgrid/registry/common.py
@@ -22,8 +22,10 @@ REGEX_VALID_REGISTRY_NAME = re.compile(r"^[\w -]+$")
 REGEX_VALID_REGISTRY_DISPLAY_NAME = re.compile(r"^[\w -]+$")
 # Allows letters, numbers, underscores, dashes
 REGEX_VALID_REGISTRY_CONFIG_ID_LOOSE = re.compile(r"^[\w/-]+$")
-# Allows letters, numbers, underscores
-REGEX_VALID_REGISTRY_CONFIG_ID_STRICT = re.compile(r"^[\w]+$")
+# Allows letters, numbers, underscores.
+# dataset_id cannot start with a number because of uses in DatasetExpressionHandler
+# It's likely a good rule everywhere else.
+REGEX_VALID_REGISTRY_CONFIG_ID_STRICT = re.compile(r"^[a-zA-Z][\w]+$")
 
 REGISTRY_ID_DELIMITER = "__"
 
@@ -42,7 +44,8 @@ def check_config_id_strict(config_id, tag):
     # Raises ValueError because this is used in Pydantic models.
     if not REGEX_VALID_REGISTRY_CONFIG_ID_STRICT.search(config_id):
         raise ValueError(
-            f"{tag} ID={config_id} is invalid. Restricted to letters, numbers, and underscores."
+            f"{tag} ID={config_id} is invalid. Restricted to letters, numbers, and underscores. "
+            "Cannot start with a number."
         )
 
 

--- a/dsgrid/tests/common.py
+++ b/dsgrid/tests/common.py
@@ -23,6 +23,8 @@ TEST_EFS_REGISTRATION_FILE = Path("tests/data/test_efs_registration.json5")
 # AWS_PROFILE_NAME = "nrel-aws-dsgrid"
 TEST_REMOTE_REGISTRY = "s3://nrel-dsgrid-registry-test"
 CACHED_TEST_REGISTRY_DB = f"sqlite:///{TEST_REGISTRY_BASE_PATH}/cached_registry.db"
+STANDARD_SCENARIOS_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-StandardScenarios"
+IEF_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-IEF"
 SIMPLE_STANDARD_SCENARIOS_REGISTRY_DB = (
     f"sqlite:///{TEST_PROJECT_PATH}/filtered_registries/simple_standard_scenarios/registry.db"
 )

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -9,6 +9,8 @@ from dsgrid.config.registration_models import RegistrationModel
 from dsgrid.registry.common import DatabaseConnection
 from dsgrid.registry.registry_manager import RegistryManager
 from dsgrid.tests.common import (
+    IEF_PROJECT_REPO,
+    STANDARD_SCENARIOS_PROJECT_REPO,
     TEST_DATASET_DIRECTORY,
     TEST_EFS_REGISTRATION_FILE,
     TEST_PROJECT_PATH,
@@ -19,9 +21,6 @@ from dsgrid.utils.id_remappings import (
     map_dimension_names_to_ids,
     replace_dimension_names_with_current_ids,
 )
-
-STANDARD_SCENARIOS_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-StandardScenarios"
-IEF_PROJECT_REPO = Path(__file__).parents[2] / "dsgrid-project-IEF"
 
 
 def test_register_dimensions_and_mappings(tmp_registry_db):


### PR DESCRIPTION
Letting dataset_ids start with a number caused a problem today when running queries on the new IEF datasets. The dataset expression code tripped over them.