### PR TITLE
Generate project and dataset config files

### DIFF
--- a/dsgrid/cli/dsgrid_admin.py
+++ b/dsgrid/cli/dsgrid_admin.py
@@ -136,7 +136,7 @@ Registry Commands
 
 _create_epilog = """
 Examples:\n
-$ dsgrid-admin registry create sqlite:////projects/dsgrid/my_project/registry.db -p /projects/dsgrid/my_project/registry-data\n
+$ dsgrid-admin create-registry sqlite:////projects/dsgrid/my_project/registry.db -p /projects/dsgrid/my_project/registry-data\n
 """
 
 

--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -1435,8 +1435,8 @@ $ dsgrid registry datasets generate-config-from-dataset \\ \n
     "--project-id",
     required=False,
     type=str,
-    help="Project ID, optional. If provided, generate dimension mapping files based on a "
-    "comparison with the project.",
+    help="Project ID, optional. If provided, prioritize project base dimensions when "
+    "searching for matching dimensions.",
 )
 @click.option(
     "-n",
@@ -1473,9 +1473,8 @@ def generate_dataset_config_from_dataset(
 
     Fill out the dimension record files based on the unique values in the dataset.
 
-    Look for matches for dimensions in the registry, checking for project base dimensions
-    first. Prompt the user for confirmation unless --no-prompts is set. If --no-prompts is
-    set, the first match is automatically accepted.
+    Look for matches for dimensions in the registry. Prompt the user for confirmation unless
+    --no-prompts is set. If --no-prompts is set, the first match is automatically accepted.
     """
     res = handle_dsgrid_exception(
         ctx,

--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -16,6 +16,7 @@ from semver import VersionInfo
 from dsgrid.cli.common import get_value_from_context, handle_dsgrid_exception
 from dsgrid.common import REMOTE_REGISTRY
 from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.config.project_config import ProjectConfig
 from dsgrid.config.registration_models import RegistrationModel, RegistrationJournal
 from dsgrid.registry.common import DatabaseConnection, VersionUpdateType
@@ -1168,6 +1169,15 @@ $ dsgrid registry projects generate-config \\ \n
     help="Project description, optional",
 )
 @click.option(
+    "-t",
+    "--time-type",
+    type=click.Choice([x.value for x in TimeDimensionType]),
+    default=TimeDimensionType.DATETIME.value,
+    show_default=True,
+    help="Type of the time dimension",
+    callback=lambda *x: TimeDimensionType(x[2]),
+)
+@click.option(
     "-o",
     "--output",
     type=click.Path(),
@@ -1191,6 +1201,7 @@ def generate_project_config_from_ids(
     dataset_ids: tuple[str],
     name: str | None,
     description: str | None,
+    time_type: TimeDimensionType,
     output: Path | None,
     overwrite: bool,
 ):
@@ -1202,6 +1213,7 @@ def generate_project_config_from_ids(
         dataset_ids,
         name=name,
         description=description,
+        time_type=time_type,
         output_directory=output,
         overwrite=overwrite,
     )
@@ -1407,12 +1419,21 @@ $ dsgrid registry datasets generate-config-from-dataset \\ \n
     callback=lambda *x: DataSchemaType(x[2]),
 )
 @click.option(
-    "-t",
+    "-p",
     "--pivoted-dimension-type",
     type=click.Choice([x.value for x in DimensionType if x != DimensionType.TIME]),
     default=None,
     callback=lambda *x: None if x[2] is None else DimensionType(x[2]),
     help="Optional, if one dimension has its records pivoted as columns, its type.",
+)
+@click.option(
+    "-t",
+    "--time-type",
+    type=click.Choice([x.value for x in TimeDimensionType]),
+    default=TimeDimensionType.DATETIME.value,
+    show_default=True,
+    help="Type of the time dimension",
+    callback=lambda *x: TimeDimensionType(x[2]),
 )
 @click.option(
     "-T",
@@ -1463,6 +1484,7 @@ def generate_dataset_config_from_dataset(
     dataset_path: Path,
     schema_type: DataSchemaType,
     pivoted_dimension_type: DimensionType | None,
+    time_type: TimeDimensionType,
     time_columns: tuple[str],
     output: Path | None,
     project_id: str | None,
@@ -1484,6 +1506,7 @@ def generate_dataset_config_from_dataset(
         dataset_path,
         schema_type,
         pivoted_dimension_type=pivoted_dimension_type,
+        time_type=time_type,
         time_columns=set(time_columns),
         output_directory=output,
         project_id=project_id,

--- a/dsgrid/cli/registry.py
+++ b/dsgrid/cli/registry.py
@@ -1,3 +1,5 @@
+from dsgrid.config.dataset_config import DataSchemaType
+
 """Manages a dsgrid registry."""
 
 import getpass
@@ -17,6 +19,7 @@ from dsgrid.dimension.base_models import DimensionType
 from dsgrid.config.project_config import ProjectConfig
 from dsgrid.config.registration_models import RegistrationModel, RegistrationJournal
 from dsgrid.registry.common import DatabaseConnection, VersionUpdateType
+from dsgrid.registry.dataset_config_generator import generate_config_from_dataset
 from dsgrid.registry.registry_manager import RegistryManager
 from dsgrid.utils.id_remappings import (
     map_dimension_ids_to_names,
@@ -25,30 +28,31 @@ from dsgrid.utils.id_remappings import (
     replace_dimension_mapping_names_with_current_ids,
     replace_dimension_names_with_current_ids,
 )
+from dsgrid.registry.project_config_generator import generate_project_config
 from dsgrid.utils.filters import ACCEPTED_OPS
 
 
 logger = logging.getLogger(__name__)
 
 
-def _version_info_callback(*args):
+def _version_info_callback(*args) -> VersionInfo:
     val = args[2]
     if val is None:
         return val
     return VersionInfo.parse(val)
 
 
-def _version_info_required_callback(*args):
+def _version_info_required_callback(*args) -> VersionInfo:
     val = args[2]
     return VersionInfo.parse(val)
 
 
-def _version_update_callback(*args):
+def _version_update_callback(*args) -> VersionUpdateType:
     val = args[2]
     return VersionUpdateType(val)
 
 
-def _path_callback(*args):
+def _path_callback(*args) -> Path | None:
     val = args[2]
     if val is None:
         return val
@@ -1140,6 +1144,71 @@ def list_project_dimension_names(
         print(line)
 
 
+_generate_project_config_epilog = """
+Examples:\n
+$ dsgrid registry projects generate-config \\ \n
+    -o "./my-project-dir" \\ \n
+    my-project-id dataset-id1 dataset-id2 dataset-id3\n
+"""
+
+
+@click.command(name="generate-config", epilog=_generate_project_config_epilog)
+@click.argument("project_id")
+@click.argument("dataset_ids", nargs=-1)
+@click.option(
+    "-n",
+    "--name",
+    type=str,
+    help="Project name, optional",
+)
+@click.option(
+    "-d",
+    "--description",
+    type=str,
+    help="Project description, optional",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    default=".",
+    show_default=True,
+    callback=_path_callback,
+    help="Path in which to generate project config files.",
+)
+@click.option(
+    "-O",
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Overwrite files if they exist.",
+)
+@click.pass_context
+def generate_project_config_from_ids(
+    ctx: click.Context,
+    project_id: str,
+    dataset_ids: tuple[str],
+    name: str | None,
+    description: str | None,
+    output: Path | None,
+    overwrite: bool,
+):
+    """Generate project config files from a project ID and one or more dataset IDs."""
+    res = handle_dsgrid_exception(
+        ctx,
+        generate_project_config,
+        project_id,
+        dataset_ids,
+        name=name,
+        description=description,
+        output_directory=output,
+        overwrite=overwrite,
+    )
+    if res[1] != 0:
+        ctx.exit(res[1])
+
+
 """
 Dataset Commands
 """
@@ -1311,6 +1380,116 @@ def update_dataset(
         log_message,
         version,
         dataset_path=dataset_path,
+    )
+    if res[1] != 0:
+        ctx.exit(res[1])
+
+
+_generate_dataset_config_from_dataset_epilog = """
+Examples:\n
+$ dsgrid registry datasets generate-config-from-dataset \\ \n
+    -o "./my-dataset-dir" \\ \n
+    -P my-project-id \\ \n
+    my-dataset-id \\ \n
+    /path/to/table.parquet\n
+"""
+
+
+@click.command(name="generate-config", epilog=_generate_dataset_config_from_dataset_epilog)
+@click.argument("dataset-id")
+@click.argument("dataset-path")
+@click.option(
+    "-s",
+    "--schema-type",
+    type=click.Choice([x.value for x in DataSchemaType]),
+    default=DataSchemaType.ONE_TABLE.value,
+    show_default=True,
+    callback=lambda *x: DataSchemaType(x[2]),
+)
+@click.option(
+    "-t",
+    "--pivoted-dimension-type",
+    type=click.Choice([x.value for x in DimensionType if x != DimensionType.TIME]),
+    default=None,
+    callback=lambda *x: None if x[2] is None else DimensionType(x[2]),
+    help="Optional, if one dimension has its records pivoted as columns, its type.",
+)
+@click.option(
+    "-T",
+    "--time-columns",
+    multiple=True,
+    help="Names of time columns in the table. Required if pivoted_dimension_type is set "
+    "and the time column is not 'timestamp'.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    default=".",
+    show_default=True,
+    callback=_path_callback,
+    help="Path in which to create dataset config files.",
+)
+@click.option(
+    "-P",
+    "--project-id",
+    required=False,
+    type=str,
+    help="Project ID, optional. If provided, generate dimension mapping files based on a "
+    "comparison with the project.",
+)
+@click.option(
+    "-n",
+    "--no-prompts",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Do not prompt for matches. Automatically accept the first one.",
+)
+@click.option(
+    "-O",
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Overwrite files if they exist.",
+)
+@click.pass_obj
+@click.pass_context
+def generate_dataset_config_from_dataset(
+    ctx: click.Context,
+    registry_manager: RegistryManager,
+    dataset_id: str,
+    dataset_path: Path,
+    schema_type: DataSchemaType,
+    pivoted_dimension_type: DimensionType | None,
+    time_columns: tuple[str],
+    output: Path | None,
+    project_id: str | None,
+    no_prompts: bool,
+    overwrite: bool,
+):
+    """Generate dataset config files from a dataset table.
+
+    Fill out the dimension record files based on the unique values in the dataset.
+
+    Look for matches for dimensions in the registry, checking for project base dimensions
+    first. Prompt the user for confirmation unless --no-prompts is set. If --no-prompts is
+    set, the first match is automatically accepted.
+    """
+    res = handle_dsgrid_exception(
+        ctx,
+        generate_config_from_dataset,
+        registry_manager,
+        dataset_id,
+        dataset_path,
+        schema_type,
+        pivoted_dimension_type=pivoted_dimension_type,
+        time_columns=set(time_columns),
+        output_directory=output,
+        project_id=project_id,
+        no_prompts=no_prompts,
+        overwrite=overwrite,
     )
     if res[1] != 0:
         ctx.exit(res[1])
@@ -1538,11 +1717,13 @@ projects.add_command(register_supplemental_dimensions)
 projects.add_command(add_dataset_requirements)
 projects.add_command(replace_dataset_dimension_requirements)
 projects.add_command(list_project_dimension_names)
+projects.add_command(generate_project_config_from_ids)
 
 datasets.add_command(list_datasets)
 datasets.add_command(register_dataset)
 datasets.add_command(dump_dataset)
 datasets.add_command(update_dataset)
+datasets.add_command(generate_dataset_config_from_dataset)
 
 registry.add_command(list_)
 registry.add_command(dimensions)

--- a/dsgrid/config/common.py
+++ b/dsgrid/config/common.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from dsgrid.dimension.base_models import DimensionType
+
+
+def make_base_dimension_template(
+    exclude_dimension_types: set[DimensionType] | None = None,
+) -> list[dict[str, Any]]:
+    exclude: set[DimensionType] = exclude_dimension_types or set()
+    dimensions = [
+        {
+            "type": x.value,
+            "class": x.value.title(),
+            "name": "",
+            "description": "",
+            "file": f"dimensions/{x.value}.csv",
+            "module": "dsgrid.dimension.standard",
+        }
+        for x in DimensionType
+        if x not in exclude
+    ]
+    dimensions.append(
+        {
+            "type": DimensionType.TIME.value,
+            "time_type": "",
+            "class": DimensionType.TIME.value.title(),
+            "name": "",
+            "description": "",
+        }
+    )
+    return dimensions

--- a/dsgrid/config/common.py
+++ b/dsgrid/config/common.py
@@ -1,12 +1,15 @@
 from typing import Any
 
 from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.time import MeasurementType, TimeDimensionType, TimeIntervalType
 
 
 def make_base_dimension_template(
     exclude_dimension_types: set[DimensionType] | None = None,
+    time_type: TimeDimensionType = TimeDimensionType.DATETIME,
 ) -> list[dict[str, Any]]:
     exclude: set[DimensionType] = exclude_dimension_types or set()
+    exclude.add(DimensionType.TIME)
     dimensions = [
         {
             "type": x.value,
@@ -19,13 +22,49 @@ def make_base_dimension_template(
         for x in DimensionType
         if x not in exclude
     ]
-    dimensions.append(
-        {
-            "type": DimensionType.TIME.value,
-            "time_type": "",
-            "class": DimensionType.TIME.value.title(),
-            "name": "",
-            "description": "",
-        }
-    )
+    time_dim = {
+        "type": DimensionType.TIME.value,
+        "time_type": time_type.value,
+        "time_interval_type": TimeIntervalType.PERIOD_BEGINNING.value,
+        "name": "",
+        "description": "",
+        "module": "dsgrid.dimension.standard",
+    }
+    match time_type:
+        case TimeDimensionType.DATETIME:
+            time_dim["class"] = "Time"
+            time_dim["frequency"] = "P0DT1H"
+            time_dim["leap_day_adjustment"] = "none"
+            time_dim["str_format"] = "%Y-%m-%d %H:%M:%S"
+            time_dim["timezone"] = "EasternStandard"
+            time_dim["measurement_type"] = MeasurementType.TOTAL.value
+            time_dim["ranges"] = [
+                {
+                    "start": "2018-01-01 00:00:00",
+                    "end": "2018-12-31 23:00:00",
+                },
+            ]
+        case TimeDimensionType.ANNUAL:
+            time_dim["class"] = "AnnualTime"
+            time_dim["include_leap_day"] = True
+            time_dim["ranges"] = [
+                {
+                    "start": "2010",
+                    "end": "2024",
+                },
+            ]
+            time_dim["str_format"] = "%Y"
+        case TimeDimensionType.INDEX:
+            time_dim["class"] = "IndexTime"
+            time_dim["frequency"] = "P0DT1H"
+            time_dim["starting_timestamps"] = ["2018-01-01 00:00:00"]
+            time_dim["str_format"] = "%Y-%m-%d %H:%M:%S"
+            time_dim["ranges"] = [
+                {
+                    "start": 0,
+                    "end": 8759,
+                },
+            ]
+
+    dimensions.append(time_dim)
     return dimensions

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -12,6 +12,7 @@ from dsgrid.config.dimension_config import DimensionBaseConfig, DimensionBaseCon
 from dsgrid.config.time_dimension_base_config import TimeDimensionBaseConfig
 from dsgrid.dataset.models import PivotedTableFormatModel, TableFormatModel, TableFormatType
 from dsgrid.dimension.base_models import DimensionType, check_timezone_in_geography
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.exceptions import DSGInvalidParameter, DSGValueNotRegistered
 from dsgrid.registry.common import check_config_id_strict
 from dsgrid.data_models import DSGBaseDatabaseModel, DSGBaseModel, DSGEnum, EnumValue
@@ -457,7 +458,8 @@ def make_unvalidated_dataset_config(
     table_format: dict[str, str] | None = None,
     data_classification=DataClassificationType.MODERATE.value,
     dataset_type=InputDatasetType.MODELED,
-    use_project_geography_time_zone=False,
+    time_type: TimeDimensionType = TimeDimensionType.DATETIME,
+    use_project_geography_time_zone: bool = False,
     dimension_references: list[DimensionReferenceModel] | None = None,
     trivial_dimensions: list[DimensionType] | None = None,
 ) -> dict[str, Any]:
@@ -465,8 +467,7 @@ def make_unvalidated_dataset_config(
     table_format_ = table_format or UnpivotedTableFormatModel().model_dump()
     trivial_dimensions_ = trivial_dimensions or []
     exclude_dimension_types = {x.dimension_type for x in dimension_references or []}
-    exclude_dimension_types.add(DimensionType.TIME)
-    dimensions = make_base_dimension_template(exclude_dimension_types)
+    dimensions = make_base_dimension_template(exclude_dimension_types, time_type=time_type)
     return {
         "dataset_id": dataset_id,
         "dataset_type": dataset_type.value,

--- a/dsgrid/config/dataset_config.py
+++ b/dsgrid/config/dataset_config.py
@@ -653,13 +653,13 @@ class DatasetConfig(ConfigBase):
             )
 
 
-def get_unique_dimension_ids(
+def get_unique_dimension_record_ids(
     path: Path,
     schema_type: DataSchemaType,
     pivoted_dimension_type: DimensionType | None,
     time_columns: set[str],
 ) -> dict[DimensionType, list[str]]:
-    """Get the unique dimension IDs from a table."""
+    """Get the unique dimension record IDs from a table."""
     if schema_type == DataSchemaType.STANDARD:
         ld = read_dataframe(check_load_data_filename(path))
         lk = read_dataframe(check_load_data_lookup_filename(path))

--- a/dsgrid/config/dimension_config.py
+++ b/dsgrid/config/dimension_config.py
@@ -19,7 +19,7 @@ class DimensionBaseConfigWithFiles(ConfigWithRecordFileBase, abc.ABC):
     def config_id(self):
         return self.model.dimension_id
 
-    def get_unique_ids(self):
+    def get_unique_ids(self) -> set[str]:
         """Return the unique IDs in a dimension's records.
 
         Returns

--- a/dsgrid/config/dimensions.py
+++ b/dsgrid/config/dimensions.py
@@ -709,23 +709,6 @@ class DimensionReferenceModel(DSGBaseModel):
     )
 
 
-class DimensionReferenceByNameModel(DSGBaseModel):
-    """Reference to a dimension that has yet to be registered."""
-
-    dimension_type: DimensionType = Field(
-        title="dimension_type",
-        alias="type",
-        description="Type of the dimension",
-        json_schema_extra={
-            "options": DimensionType.format_for_docs(),
-        },
-    )
-    name: str = Field(
-        title="name",
-        description="Dimension name",
-    )
-
-
 def handle_dimension_union(values):
     values = copy.deepcopy(values)
     for i, value in enumerate(values):

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -7,6 +7,7 @@ from typing import Any, Generator, Iterable, Optional, Type
 import pandas as pd
 from pydantic import conlist, field_validator, model_validator, Field
 
+from dsgrid.config.common import make_base_dimension_template
 from dsgrid.config.dataset_config import DatasetConfig
 from dsgrid.config.dimension_config import (
     DimensionBaseConfig,
@@ -724,6 +725,34 @@ class ProjectConfigModel(DSGBaseDatabaseModel):
 
         check_config_id_strict(project_id, "Project")
         return project_id
+
+
+def make_unvalidated_project_config(
+    project_id: str,
+    dataset_ids: Iterable[str],
+    name: str | None = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Create a project config as a dictionary, skipping validation."""
+    return {
+        "project_id": project_id,
+        "name": name or "",
+        "description": description or "",
+        "dimensions": {
+            "base_dimensions": make_base_dimension_template(),
+            "subset_dimensions": [],
+            "supplemental_dimensions": [],
+        },
+        "datasets": [
+            {
+                "dataset_id": x,
+                "dataset_type": "",
+                "version": "",
+                "required_dimensions": {},
+            }
+            for x in dataset_ids
+        ],
+    }
 
 
 class DimensionsByCategoryModel(DSGBaseModel):

--- a/dsgrid/config/project_config.py
+++ b/dsgrid/config/project_config.py
@@ -22,6 +22,7 @@ from dsgrid.dimension.base_models import (
     DimensionCategory,
     DimensionType,
 )
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.exceptions import (
     DSGInvalidDataset,
     DSGInvalidField,
@@ -732,6 +733,7 @@ def make_unvalidated_project_config(
     dataset_ids: Iterable[str],
     name: str | None = None,
     description: str | None = None,
+    time_type: TimeDimensionType = TimeDimensionType.DATETIME,
 ) -> dict[str, Any]:
     """Create a project config as a dictionary, skipping validation."""
     return {
@@ -739,7 +741,7 @@ def make_unvalidated_project_config(
         "name": name or "",
         "description": description or "",
         "dimensions": {
-            "base_dimensions": make_base_dimension_template(),
+            "base_dimensions": make_base_dimension_template(time_type=time_type),
             "subset_dimensions": [],
             "supplemental_dimensions": [],
         },

--- a/dsgrid/registry/dataset_config_generator.py
+++ b/dsgrid/registry/dataset_config_generator.py
@@ -11,6 +11,7 @@ from dsgrid.config.dataset_config import (
 )
 from dsgrid.config.project_config import ProjectConfig
 from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.registry.dimension_registry_manager import DimensionRegistryManager
 from dsgrid.registry.registry_manager import RegistryManager
 from dsgrid.utils.files import dump_data
@@ -27,6 +28,7 @@ def generate_config_from_dataset(
     dataset_path: Path,
     schema_type: DataSchemaType,
     pivoted_dimension_type: DimensionType | None = None,
+    time_type: TimeDimensionType = TimeDimensionType.DATETIME,
     time_columns: set[str] | None = None,
     output_directory: Path | None = None,
     project_id: str | None = None,
@@ -72,7 +74,9 @@ def generate_config_from_dataset(
         else:
             dimension_references.append(ref)
 
-    config = make_unvalidated_dataset_config(dataset_id, dimension_references=dimension_references)
+    config = make_unvalidated_dataset_config(
+        dataset_id, dimension_references=dimension_references, time_type=time_type
+    )
     dump_data(config, dataset_file, indent=2)
     logger.info("Wrote dataset config to %s", dataset_file)
 

--- a/dsgrid/registry/dataset_config_generator.py
+++ b/dsgrid/registry/dataset_config_generator.py
@@ -1,0 +1,146 @@
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from chronify.utils.path_utils import check_overwrite
+
+from dsgrid.config.dataset_config import (
+    DataSchemaType,
+    get_unique_dimension_ids,
+    make_unvalidated_dataset_config,
+)
+from dsgrid.config.project_config import ProjectConfig
+from dsgrid.dimension.base_models import DimensionType
+from dsgrid.registry.dimension_registry_manager import DimensionRegistryManager
+from dsgrid.registry.registry_manager import RegistryManager
+from dsgrid.utils.files import dump_data
+from dsgrid.config.dimensions import DimensionReferenceModel
+from dsgrid.config.dimension_config import DimensionBaseConfigWithFiles
+
+
+logger = logging.getLogger(__name__)
+
+
+def generate_config_from_dataset(
+    registry_manager: RegistryManager,
+    dataset_id: str,
+    dataset_path: Path,
+    schema_type: DataSchemaType,
+    pivoted_dimension_type: DimensionType | None = None,
+    time_columns: set[str] | None = None,
+    output_directory: Path | None = None,
+    project_id: str | None = None,
+    overwrite: bool = False,
+    no_prompts: bool = False,
+):
+    """Generate dataset config files from a dataset table.
+
+    Fill out the dimension record files based on the unique values in the dataset.
+
+    Look for matches for dimensions in the registry, checking for project base dimensions
+    first. Prompt the user for confirmation unless --no-prompts is set. If --no-prompts is
+    set, the first match is automatically accepted.
+    """
+    project_config = (
+        None if project_id is None else registry_manager.project_manager.get_by_id(project_id)
+    )
+    output_dir = (output_directory or Path()) / dataset_id
+    check_overwrite(output_dir, overwrite)
+    output_dir.mkdir()
+    dimensions_dir = output_dir / "dimensions"
+    dimensions_dir.mkdir()
+    dataset_file = output_dir / "dataset.json5"
+    time_cols = time_columns or {"timestamp"}
+
+    dimension_references: list[DimensionReferenceModel] = []
+    for dim_type, ids in get_unique_dimension_ids(
+        dataset_path, schema_type, pivoted_dimension_type, time_cols
+    ).items():
+        ref, checked_project_dim_ids = find_matching_project_base_dimension(
+            project_config, ids, dim_type, no_prompts=no_prompts
+        )
+        if ref is None:
+            ref = find_matching_registry_dimensions(
+                registry_manager.dimension_manager,
+                ids,
+                dim_type,
+                checked_project_dim_ids,
+                no_prompts=no_prompts,
+            )
+        if ref is None:
+            write_dimension_records(ids, dimensions_dir / f"{dim_type.value}.csv")
+        else:
+            dimension_references.append(ref)
+
+    config = make_unvalidated_dataset_config(dataset_id, dimension_references=dimension_references)
+    dump_data(config, dataset_file, indent=2)
+    logger.info("Wrote dataset config to %s", dataset_file)
+
+
+def write_dimension_records(ids: Iterable[str], filename: Path) -> None:
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("id,name\n")
+        for id_ in ids:
+            f.write(id_)
+            f.write(",")
+            f.write(id_.title().replace("_", " "))
+            f.write("\n")
+    logger.info("Wrote dimension records to %s", filename)
+
+
+def find_matching_project_base_dimension(
+    project_config: ProjectConfig | None,
+    sorted_record_ids: list[str],
+    dimension_type: DimensionType,
+    no_prompts: bool = False,
+) -> tuple[DimensionReferenceModel | None, set[str]]:
+    """Find matching base dimensions for a dataset in a project."""
+    checked_project_dim_ids: set[str] = set()
+    if project_config is None:
+        return None, checked_project_dim_ids
+
+    for dim_type in (x for x in DimensionType if x != DimensionType.TIME):
+        for dim in project_config.list_base_dimensions_with_records(dimension_type=dim_type):
+            project_records = sorted(dim.get_unique_ids())
+            checked_project_dim_ids.add(dim.model.dimension_id)
+            if sorted_record_ids == project_records and (
+                no_prompts or get_user_input_on_dimension_match(dim, "project base dimension")
+            ):
+                return make_dimension_ref(dim), checked_project_dim_ids
+
+    return None, checked_project_dim_ids
+
+
+def find_matching_registry_dimensions(
+    dimension_manager: DimensionRegistryManager,
+    ids: list[str],
+    dimension_type: DimensionType,
+    checked_project_dim_ids: set[str],
+    no_prompts: bool = False,
+) -> DimensionReferenceModel | None:
+    for dim in dimension_manager.find_matching_dimensions(ids, dimension_type):
+        if dim.model.dimension_id not in checked_project_dim_ids and (
+            no_prompts or get_user_input_on_dimension_match(dim, "dimension from the registry")
+        ):
+            return make_dimension_ref(dim)
+    return None
+
+
+def get_user_input_on_dimension_match(dim: DimensionBaseConfigWithFiles, tag: str) -> bool:
+    value = input(
+        f"Found a {tag} with matching records:\n"
+        f"  Dimension type: {dim.model.dimension_type.value}\n"
+        f"  Name: {dim.model.name}\n"
+        f"  Description: {dim.model.description}\n"
+        f"  Dimension ID: {dim.model.dimension_id}\n"
+        "Do you want to use it? (y/n) >>> "
+    )
+    return value.lower().strip() == "y"
+
+
+def make_dimension_ref(dim: DimensionBaseConfigWithFiles) -> DimensionReferenceModel:
+    return DimensionReferenceModel(
+        dimension_id=dim.model.dimension_id,
+        type=dim.model.dimension_type,
+        version=dim.model.version,
+    )

--- a/dsgrid/registry/dataset_config_generator.py
+++ b/dsgrid/registry/dataset_config_generator.py
@@ -6,7 +6,7 @@ from chronify.utils.path_utils import check_overwrite
 
 from dsgrid.config.dataset_config import (
     DataSchemaType,
-    get_unique_dimension_ids,
+    get_unique_dimension_record_ids,
     make_unvalidated_dataset_config,
 )
 from dsgrid.config.project_config import ProjectConfig
@@ -55,7 +55,7 @@ def generate_config_from_dataset(
     time_cols = time_columns or {"timestamp"}
 
     dimension_references: list[DimensionReferenceModel] = []
-    for dim_type, ids in get_unique_dimension_ids(
+    for dim_type, ids in get_unique_dimension_record_ids(
         dataset_path, schema_type, pivoted_dimension_type, time_cols
     ).items():
         ref, checked_project_dim_ids = find_matching_project_base_dimension(

--- a/dsgrid/registry/project_config_generator.py
+++ b/dsgrid/registry/project_config_generator.py
@@ -1,0 +1,45 @@
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from chronify.utils.path_utils import check_overwrite
+
+from dsgrid.utils.files import dump_data
+from dsgrid.config.project_config import make_unvalidated_project_config
+
+
+logger = logging.getLogger(__name__)
+
+
+def generate_project_config(
+    project_id: str,
+    dataset_ids: Iterable[str],
+    name: str | None = None,
+    description: str | None = None,
+    output_directory: Path | None = None,
+    overwrite: bool = False,
+):
+    """Generate project config files and filesystem skeleton."""
+    output_dir = (output_directory or Path()) / project_id
+    check_overwrite(output_dir, overwrite)
+    output_dir.mkdir()
+    project_dir = output_dir / "project"
+    project_dir.mkdir()
+    project_file = project_dir / "project.json5"
+    datasets_dir = output_dir / "datasets"
+    datasets_dir.mkdir()
+    (datasets_dir / "historical").mkdir()
+    (datasets_dir / "modeled").mkdir()
+    dimensions_dir = project_dir / "dimensions"
+    dimensions_dir.mkdir()
+    (dimensions_dir / "subset").mkdir()
+    (dimensions_dir / "supplemental").mkdir()
+    (project_dir / "dimension_mappings").mkdir()
+
+    config = make_unvalidated_project_config(
+        project_id, dataset_ids, name=name, description=description
+    )
+    dump_data(config, project_file, indent=2)
+    logger.info(
+        "Created project directory structure at %s with config file %s", output_dir, project_file
+    )

--- a/dsgrid/registry/project_config_generator.py
+++ b/dsgrid/registry/project_config_generator.py
@@ -4,6 +4,7 @@ from typing import Iterable
 
 from chronify.utils.path_utils import check_overwrite
 
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.utils.files import dump_data
 from dsgrid.config.project_config import make_unvalidated_project_config
 
@@ -16,6 +17,7 @@ def generate_project_config(
     dataset_ids: Iterable[str],
     name: str | None = None,
     description: str | None = None,
+    time_type: TimeDimensionType = TimeDimensionType.DATETIME,
     output_directory: Path | None = None,
     overwrite: bool = False,
 ):
@@ -37,7 +39,7 @@ def generate_project_config(
     (project_dir / "dimension_mappings").mkdir()
 
     config = make_unvalidated_project_config(
-        project_id, dataset_ids, name=name, description=description
+        project_id, dataset_ids, name=name, description=description, time_type=time_type
     )
     dump_data(config, project_file, indent=2)
     logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # "boto3",
     # "s3path",
     "chronify ~= 0.3.0",
-    "click>=8",
+    "click>=8.2, <9",
     "dash",
     "dash_bootstrap_components",
     "duckdb >= 1, < 2",

--- a/tests/cli/common.py
+++ b/tests/cli/common.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Type
+
+from dsgrid.data_models import DSGBaseModel
+from dsgrid.utils.files import load_data
+
+
+def check_config_fields(config_file: Path, model_cls: Type[DSGBaseModel]) -> None:
+    config = load_data(config_file)
+    actual_fields = set(config.keys())
+    required_fields: set[str] = set()
+    all_fields: set[str] = set()
+    for name, field_info in model_cls.model_fields.items():
+        all_fields.add(name)
+        if field_info.is_required:
+            required_fields.add(name)
+    assert not actual_fields - all_fields
+    assert required_fields - actual_fields

--- a/tests/cli/test_dataset_config_generation.py
+++ b/tests/cli/test_dataset_config_generation.py
@@ -1,11 +1,12 @@
-from dsgrid.dimension.base_models import DimensionType
-
 from click.testing import CliRunner
 
 from dsgrid.cli.dsgrid import cli as cli
+from dsgrid.config.dataset_config import DatasetConfigModel
 from dsgrid.dimension.time import TimeDimensionType
+from dsgrid.dimension.base_models import DimensionType
 from dsgrid.tests.common import TEST_PROJECT_PATH
 from dsgrid.utils.files import load_data
+from common import check_config_fields
 
 
 def test_generate_dataset_config_pivoted_matches(cached_registry, tmp_path):
@@ -88,6 +89,7 @@ def test_generate_dataset_config_unpivoted_matches(cached_registry, tmp_path):
         DimensionType.SUBSECTOR.value,
     ]
     assert not list((output_dir / "dimensions").iterdir())
+    check_config_fields(output_dir / "dataset.json5", DatasetConfigModel)
 
 
 def test_generate_dataset_config_partial_matches(cached_registry, tmp_path):
@@ -136,3 +138,4 @@ def test_generate_dataset_config_partial_matches(cached_registry, tmp_path):
         DimensionType.SECTOR.value + ".csv",
         DimensionType.SUBSECTOR.value + ".csv",
     ]
+    check_config_fields(output_dir / "dataset.json5", DatasetConfigModel)

--- a/tests/cli/test_dataset_config_generation.py
+++ b/tests/cli/test_dataset_config_generation.py
@@ -10,7 +10,7 @@ from dsgrid.utils.files import load_data
 
 def test_generate_dataset_config_pivoted_matches(cached_registry, tmp_path):
     conn = cached_registry
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     dataset_id = "comstock"
     output_dir = tmp_path / dataset_id
     assert not output_dir.exists()
@@ -54,7 +54,7 @@ def test_generate_dataset_config_pivoted_matches(cached_registry, tmp_path):
 
 def test_generate_dataset_config_unpivoted_matches(cached_registry, tmp_path):
     conn = cached_registry
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     dataset_id = "comstock_unpivoted"
     output_dir = tmp_path / dataset_id
     assert not output_dir.exists()
@@ -92,7 +92,7 @@ def test_generate_dataset_config_unpivoted_matches(cached_registry, tmp_path):
 
 def test_generate_dataset_config_partial_matches(cached_registry, tmp_path):
     conn = cached_registry
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     dataset_id = "comstock_conus_2022_projected"
     output_dir = tmp_path / dataset_id
     assert not output_dir.exists()

--- a/tests/cli/test_dataset_config_generation.py
+++ b/tests/cli/test_dataset_config_generation.py
@@ -1,0 +1,135 @@
+from dsgrid.dimension.base_models import DimensionType
+
+from click.testing import CliRunner
+
+from dsgrid.cli.dsgrid import cli as cli
+from dsgrid.tests.common import TEST_PROJECT_PATH
+from dsgrid.utils.files import load_data
+
+
+def test_generate_dataset_config_pivoted_matches(cached_registry, tmp_path):
+    conn = cached_registry
+    runner = CliRunner(mix_stderr=False)
+    dataset_id = "comstock"
+    output_dir = tmp_path / dataset_id
+    assert not output_dir.exists()
+    cmd = [
+        "--url",
+        conn.url,
+        "registry",
+        "datasets",
+        "generate-config",
+        dataset_id,
+        f"dsgrid-test-data/datasets/test_efs_{dataset_id}",
+        "--project-id",
+        "test_efs",
+        "--schema-type",
+        "standard",
+        "--pivoted-dimension-type",
+        "metric",
+        "--time-columns",
+        "timestamp",
+        "--output",
+        str(tmp_path),
+        "--no-prompts",
+    ]
+    result = runner.invoke(cli, cmd)
+    assert result.exit_code == 0
+    assert output_dir.exists()
+    dataset_file = output_dir / "dataset.json5"
+    assert dataset_file.exists()
+    dataset_config = load_data(dataset_file)
+    dim_types = sorted([x["type"] for x in dataset_config["dimension_references"]])
+    assert dim_types == [
+        DimensionType.GEOGRAPHY.value,
+        DimensionType.METRIC.value,
+        DimensionType.SECTOR.value,
+        DimensionType.SUBSECTOR.value,
+    ]
+    assert not list((output_dir / "dimensions").iterdir())
+
+
+def test_generate_dataset_config_unpivoted_matches(cached_registry, tmp_path):
+    conn = cached_registry
+    runner = CliRunner(mix_stderr=False)
+    dataset_id = "comstock_unpivoted"
+    output_dir = tmp_path / dataset_id
+    assert not output_dir.exists()
+    cmd = [
+        "--url",
+        conn.url,
+        "registry",
+        "datasets",
+        "generate-config",
+        dataset_id,
+        f"dsgrid-test-data/datasets/test_efs_{dataset_id}",
+        "--project-id",
+        "test_efs",
+        "--schema-type",
+        "one_table",
+        "--output",
+        str(tmp_path),
+        "--no-prompts",
+    ]
+    result = runner.invoke(cli, cmd)
+    assert result.exit_code == 0
+    assert output_dir.exists()
+    dataset_file = output_dir / "dataset.json5"
+    assert dataset_file.exists()
+    dataset_config = load_data(dataset_file)
+    dim_types = sorted([x["type"] for x in dataset_config["dimension_references"]])
+    assert dim_types == [
+        DimensionType.GEOGRAPHY.value,
+        DimensionType.METRIC.value,
+        DimensionType.SECTOR.value,
+        DimensionType.SUBSECTOR.value,
+    ]
+    assert not list((output_dir / "dimensions").iterdir())
+
+
+def test_generate_dataset_config_partial_matches(cached_registry, tmp_path):
+    conn = cached_registry
+    runner = CliRunner(mix_stderr=False)
+    dataset_id = "comstock_conus_2022_projected"
+    output_dir = tmp_path / dataset_id
+    assert not output_dir.exists()
+    dataset_path = (
+        TEST_PROJECT_PATH
+        / "filtered_registries"
+        / "simple_standard_scenarios"
+        / "data"
+        / dataset_id
+        / "1.0.0"
+    )
+    cmd = [
+        "--url",
+        conn.url,
+        "registry",
+        "datasets",
+        "generate-config",
+        dataset_id,
+        str(dataset_path),
+        "--project-id",
+        "test_efs",
+        "--schema-type",
+        "one_table",
+        "--output",
+        str(tmp_path),
+        "--no-prompts",
+    ]
+    result = runner.invoke(cli, cmd)
+    assert result.exit_code == 0
+    assert output_dir.exists()
+    dataset_file = output_dir / "dataset.json5"
+    assert dataset_file.exists()
+    dataset_config = load_data(dataset_file)
+    dim_types = sorted([x["type"] for x in dataset_config["dimension_references"]])
+    assert dim_types == [DimensionType.WEATHER_YEAR.value]
+    assert sorted((x.name for x in (output_dir / "dimensions").iterdir())) == [
+        DimensionType.GEOGRAPHY.value + ".csv",
+        DimensionType.METRIC.value + ".csv",
+        DimensionType.MODEL_YEAR.value + ".csv",
+        DimensionType.SCENARIO.value + ".csv",
+        DimensionType.SECTOR.value + ".csv",
+        DimensionType.SUBSECTOR.value + ".csv",
+    ]

--- a/tests/cli/test_dataset_config_generation.py
+++ b/tests/cli/test_dataset_config_generation.py
@@ -3,6 +3,7 @@ from dsgrid.dimension.base_models import DimensionType
 from click.testing import CliRunner
 
 from dsgrid.cli.dsgrid import cli as cli
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.tests.common import TEST_PROJECT_PATH
 from dsgrid.utils.files import load_data
 
@@ -27,6 +28,8 @@ def test_generate_dataset_config_pivoted_matches(cached_registry, tmp_path):
         "standard",
         "--pivoted-dimension-type",
         "metric",
+        "--time-type",
+        TimeDimensionType.DATETIME.value,
         "--time-columns",
         "timestamp",
         "--output",

--- a/tests/cli/test_project_config_generation.py
+++ b/tests/cli/test_project_config_generation.py
@@ -7,7 +7,7 @@ from dsgrid.utils.files import load_data
 
 def test_generate_project_config(cached_registry, tmp_path):
     conn = cached_registry
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     project_id = "my_project"
     dataset_ids = ["d1", "d2", "d3"]
     description = "This is a test project"

--- a/tests/cli/test_project_config_generation.py
+++ b/tests/cli/test_project_config_generation.py
@@ -1,8 +1,10 @@
-from dsgrid.dimension.time import TimeDimensionType
 from click.testing import CliRunner
 
 from dsgrid.cli.dsgrid import cli as cli
+from dsgrid.config.project_config import ProjectConfigModel
+from dsgrid.dimension.time import TimeDimensionType
 from dsgrid.utils.files import load_data
+from common import check_config_fields
 
 
 def test_generate_project_config(cached_registry, tmp_path):
@@ -42,3 +44,4 @@ def test_generate_project_config(cached_registry, tmp_path):
     assert (output_dir / "project" / "dimension_mappings").exists()
     assert (output_dir / "datasets" / "historical").exists()
     assert (output_dir / "datasets" / "modeled").exists()
+    check_config_fields(output_dir / "project" / "project.json5", ProjectConfigModel)

--- a/tests/cli/test_project_config_generation.py
+++ b/tests/cli/test_project_config_generation.py
@@ -1,3 +1,4 @@
+from dsgrid.dimension.time import TimeDimensionType
 from click.testing import CliRunner
 
 from dsgrid.cli.dsgrid import cli as cli
@@ -20,6 +21,8 @@ def test_generate_project_config(cached_registry, tmp_path):
         "generate-config",
         "--description",
         description,
+        "--time-type",
+        TimeDimensionType.DATETIME.value,
         "--output",
         str(tmp_path),
         project_id,

--- a/tests/cli/test_project_config_generation.py
+++ b/tests/cli/test_project_config_generation.py
@@ -1,0 +1,41 @@
+from click.testing import CliRunner
+
+from dsgrid.cli.dsgrid import cli as cli
+from dsgrid.utils.files import load_data
+
+
+def test_generate_project_config(cached_registry, tmp_path):
+    conn = cached_registry
+    runner = CliRunner(mix_stderr=False)
+    project_id = "my_project"
+    dataset_ids = ["d1", "d2", "d3"]
+    description = "This is a test project"
+    output_dir = tmp_path / project_id
+    assert not output_dir.exists()
+    cmd = [
+        "--url",
+        conn.url,
+        "registry",
+        "projects",
+        "generate-config",
+        "--description",
+        description,
+        "--output",
+        str(tmp_path),
+        project_id,
+        *dataset_ids,
+    ]
+    result = runner.invoke(cli, cmd)
+    assert result.exit_code == 0
+    assert output_dir.exists()
+    project_file = output_dir / "project" / "project.json5"
+    assert project_file.exists()
+    config = load_data(project_file)
+    assert [x["dataset_id"] for x in config["datasets"]] == dataset_ids
+    assert config["project_id"] == project_id
+    assert config["description"] == description
+    assert config["name"] == ""
+    assert (output_dir / "project" / "dimensions").exists()
+    assert (output_dir / "project" / "dimension_mappings").exists()
+    assert (output_dir / "datasets" / "historical").exists()
+    assert (output_dir / "datasets" / "modeled").exists()

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -25,7 +25,7 @@ from dsgrid.utils.id_remappings import (
 
 def test_register_dimensions_and_mappings(tmp_registry_db):
     src_dir, tmpdir, url = tmp_registry_db
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         admin_cli,
         [
@@ -81,7 +81,7 @@ def test_register_dimensions_and_mappings(tmp_registry_db):
 
 def test_register_project_and_dataset(tmp_registry_db):
     src_dir, tmpdir, url = tmp_registry_db
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         admin_cli,
         [
@@ -208,7 +208,7 @@ def test_register_project_and_dataset(tmp_registry_db):
 
 def test_list_project_dimension_names(cached_registry):
     conn = cached_registry
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     cmd = [
         "--url",
         conn.url,
@@ -232,7 +232,7 @@ def test_list_project_dimension_names(cached_registry):
 def test_register_dsgrid_projects(tmp_registry_db):
     """Test registration of the real dsgrid projects."""
     _, tmpdir, url = tmp_registry_db
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         admin_cli,
         [
@@ -278,7 +278,7 @@ def test_register_dsgrid_projects(tmp_registry_db):
 
 def test_bulk_register(tmp_registry_db):
     test_project_dir, tmp_path, url = tmp_registry_db
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         admin_cli,
         [
@@ -301,7 +301,7 @@ def test_bulk_register(tmp_registry_db):
     registration_file = tmp_path / "registration.json5"
     registration_file.write_text(registration.model_dump_json(indent=2), encoding="utf-8")
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -339,7 +339,7 @@ def test_bulk_register(tmp_registry_db):
 
 def test_register_multiple_metric_dimensions(tmp_registry_db):
     _, tmpdir, url = tmp_registry_db
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         admin_cli,
         [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def cached_registry():
         if TEST_REGISTRY_BASE_PATH.exists():
             shutil.rmtree(TEST_REGISTRY_BASE_PATH)
         TEST_REGISTRY_BASE_PATH.mkdir()
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         result = runner.invoke(
             cli_admin,
             [

--- a/tests/test_derived_datasets.py
+++ b/tests/test_derived_datasets.py
@@ -87,7 +87,7 @@ def test_create_derived_dataset_config(tmp_path):
     conn = DatabaseConnection(url=SIMPLE_STANDARD_SCENARIOS_REGISTRY_DB)
     dataset_id = "resstock_conus_2022_projected"
     query_output_base = tmp_path / "query_output"
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -343,7 +343,7 @@ def test_query_cli_create_validate(tmp_path):
         "projected_dg_conus_2022",
     ]
     shutdown_project()
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     query = ProjectQueryModel.from_file(filename)
@@ -387,7 +387,7 @@ def test_query_cli_run(tmp_path, cached_registry, table_format):
             str(output_dir),
             str(dst),
         ]
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         result = runner.invoke(cli, cmd)
         assert result.exit_code == 0
 

--- a/tests/test_registry_management.py
+++ b/tests/test_registry_management.py
@@ -295,7 +295,7 @@ fans,x
     subset_data_file.write_text(subset_dimensions_data, encoding="utf-8")
 
     url = f"sqlite:///{project_mgr.db.engine.url.database}"
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -368,7 +368,7 @@ def test_add_supplemental_dimension(mutable_cached_registry, tmp_path):
                 f.write(f"{county_id},{region}\n")
 
     url = f"sqlite:///{project_mgr.db.engine.url.database}"
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -403,7 +403,7 @@ def test_remove_dataset(mutable_cached_registry):
     assert config.model.datasets[0].status == DatasetRegistryStatus.REGISTERED
 
     url = f"sqlite:///{project_mgr.db.engine.url.database}"
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli_admin,
         [
@@ -436,7 +436,7 @@ def test_add_dataset_requirements(mutable_cached_registry, tmp_path):
         f.write(model.model_dump_json())
 
     url = f"sqlite:///{project_mgr.db.engine.url.database}"
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -499,7 +499,7 @@ def test_replace_dataset_dimension_requirements(mutable_cached_registry, tmp_pat
         f.write(model.model_dump_json())
 
     url = f"sqlite:///{project_mgr.db.engine.url.database}"
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [


### PR DESCRIPTION
This PR enables a workflow to generate a filesystem layout with starting project and dataset config files. The dataset dimension files are generated from either the dataset itself or matching dimension IDs from the registry.
```bash
$ dsgrid registry projects generate-config my_project comstock resstock
```
```bash
$ tree my_project
my_project
├── datasets
│   ├── historical
│   └── modeled
└── project
    ├── dimension_mappings
    ├── dimensions
    │   ├── subset
    │   └── supplemental
    └── project.json5
```
```bash
$ dsgrid registry datasets generate-config comstock dsgrid-test-data/datasets/test_efs_comstock_unpivoted -o my_project/datasets/modeled
```
```bash
$ tree my_project
my_project
├── datasets
│   ├── historical
│   └── modeled
│       └── comstock
│           ├── dataset.json5
│           └── dimensions
│               ├── geography.csv
│               ├── metric.csv
│               ├── sector.csv
│               └── subsector.csv
└── project
    ├── dimension_mappings
    ├── dimensions
    │   ├── subset
    │   └── supplemental
    └── project.json5
```