### PR TITLE
Install pyhive in a dependency group

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -23,11 +23,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install '.[dev,spark]'
-        python -m pip install git+https://github.com/apache/kyuubi.git#egg=pyhive&subdirectory=python
-        wget https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz
-        tar -xzf spark-3.5.4-bin-hadoop3.tgz
-        export SPARK_HOME=$(pwd)/spark-3.5.4-bin-hadoop3
+        python -m pip install '.[dev,spark]' --group=pyhive
+        wget https://archive.apache.org/dist/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz
+        tar -xzf spark-4.0.0-bin-hadoop3.tgz
+        export SPARK_HOME=$(pwd)/spark-4.0.0-bin-hadoop3
         ${SPARK_HOME}/sbin/start-thriftserver.sh
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Python API for contributing to and accessing demand-side grid model (dsgrid) pro
 Create a virtual environment in which to install dsgrid. Anaconda or miniconda is recommended.
 
 ```
-conda create -n dsgrid python=3.10
+conda create -n dsgrid python=3.11
 conda activate dsgrid
 ```
 
@@ -26,7 +26,7 @@ conda activate dsgrid
 dsgrid uses [Apache Spark](#https://spark.apache.org/) to manage big data. There are no separate installation steps for Apache Spark beyond installing the dsgrid package and installing:
 
 ```
-pip install git+https://github.com/apache/kyuubi.git#egg=pyhive&subdirectory=python
+pip install "dsgrid-toolkit[spark]" --group=pyhive
 ```
 
 Otherwise installing the pyspark Python dependency handles it.
@@ -51,7 +51,11 @@ To install Apache Spark on Windows, follow [these instructions](https://towardsd
 
 ### From PIPY/pip
 
-*Not yet available*
+pip install dsgrid-toolkit
+
+or
+
+pip install "dsgrid-toolkit[spark]" --group=pyhive
 
 ### From pip+git
 
@@ -88,12 +92,12 @@ cloned repository.
 
 **Users:**
 ```
-pip install -e .
+pip install -e . --group=pyhive
 ```
 
 **Developers:**
 ```
-pip install -e '.[dev]'
+pip install -e '.[dev,spark]' --group=pyhive
 ```
 
 ## Usage

--- a/dev/README.md
+++ b/dev/README.md
@@ -17,8 +17,8 @@ pip install -e .[tests]
 
 # or
 
-pip install -e .[dev,spark] # includes what is needed for tests and code development
-(Leave off `spark` if you don't need/want to use it.)
+pip install -e .[dev,spark] --group=pyhive # includes what is needed for tests and code development
+(Leave off `spark` and `pyhive` if you don't need/want to use spark.)
 
 # or
 

--- a/docs/source/how_tos/installation.rst
+++ b/docs/source/how_tos/installation.rst
@@ -6,8 +6,8 @@ Installation
 
 Python Environment
 ==================
-dsgrid requires python=3.10 or later. If you do not already have a python environment with
-python>=3.10, we recommend using `Conda <https://conda.io/projects/conda/en/latest/index.html>`_ to
+dsgrid requires python=3.11 or later. If you do not already have a python environment with
+python>=3.11, we recommend using `Conda <https://conda.io/projects/conda/en/latest/index.html>`_ to
 help manage your python packages and environments.
 
 Steps to make a dsgrid Conda environment:
@@ -56,20 +56,17 @@ Both of these commands must work:
 
 Package Installation
 =====================
+To use DuckDB as the backend:
 
-With ssh keys:
+.. code-block:: console
 
-.. code-block:: bash
+    $ pip install dsgrid-toolkit
 
-    pip install git+ssh://git@github.com/dsgrid/dsgrid.git@main
+To use Apache Spark as the backend:
 
-Or from http:
+.. code-block:: console
 
-.. code-block:: bash
-
-    pip install git+https://github.com/dsgrid/dsgrid.git@main
-
-.. todo:: pipy.org/pip installation not available yet.
+    $ pip install "dsgrid-toolkit[spark]" --group=pyhive
 
 
 Registry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # "awscliv2",
     # "boto3",
     # "s3path",
-    "chronify ~= 0.3.1",
+    "chronify ~= 0.4.0",
     "click>=8.2, < 9",
     "dash",
     "dash_bootstrap_components",
@@ -50,6 +50,15 @@ dependencies = [
     "sqlalchemy >= 2, < 3",
     "uvicorn",
     "tzdata",  # time zone stuff
+]
+
+[dependency-groups]
+# This can be removed when the Apache Kyuubi project releases a new version of pyhive.
+# This is currently synced with chronify.
+pyhive = [
+    "pyhive @ git+https://github.com/apache/kyuubi.git@3b205a3924e0e3a75c425de1396089729cf22ee5#subdirectory=python",
+    "thrift",
+    "thrift_sasl",
 ]
 
 [project.urls]


### PR DESCRIPTION
This allows users to install dsgrid from pypi.org with the correct version of pyhive.