### PR TITLE
Standardize aggregation and filter-operator vocabularies behind registries

### DIFF
--- a/docs/source/user_guide/how_tos/how_to_filter.md
+++ b/docs/source/user_guide/how_tos/how_to_filter.md
@@ -231,7 +231,7 @@ dimension_filters=[
 
 ### 5. Time-Based Filter
 
-Filter data between two time columns. This is useful for selecting data within specific time ranges.
+Filter data between two bounds of a time column, inclusive. This is useful for selecting data within specific time ranges.
 
 ::::{tab-set}
 
@@ -241,10 +241,9 @@ dimension_filters: [
   {
     dimension_type: "time",
     dimension_name: "time_est",
-    column1: "timestamp",
-    column2: "timestamp",
-    operator: "between",
-    value: ["2012-01-01 00:00:00", "2012-01-31 23:59:59"],
+    column: "timestamp",
+    lower_bound: "2012-01-01 00:00:00",
+    upper_bound: "2012-01-31 23:59:59",
     filter_type: "between_column_operator",
     negate: false,
   },
@@ -258,10 +257,9 @@ dimension_filters=[
     DimensionFilterBetweenColumnOperatorModel(
         dimension_type=DimensionType.TIME,
         dimension_name="time_est",
-        column1="timestamp",
-        column2="timestamp",
-        operator="between",
-        value=["2012-01-01 00:00:00", "2012-01-31 23:59:59"],
+        column="timestamp",
+        lower_bound="2012-01-01 00:00:00",
+        upper_bound="2012-01-31 23:59:59",
         negate=False,
     ),
 ]
@@ -278,18 +276,23 @@ WHERE timestamp BETWEEN '2012-01-01 00:00:00' AND '2012-01-31 23:59:59'
 
 ## Common Operators
 
+Filters with `filter_type: "column_operator"` (and `"supplemental_column_operator"`) accept
+exactly these operators:
+
 | Operator | Description | Example Value |
 |----------|-------------|---------------|
-| `==` | Equals | `"06037"` |
-| `!=` | Not equals | `"06037"` |
-| `>` | Greater than | `"2020"` |
-| `>=` | Greater than or equal | `"2020"` |
-| `<` | Less than | `"2050"` |
-| `<=` | Less than or equal | `"2050"` |
-| `isin` | In list | `["06037", "06073"]` |
-| `like` | Pattern match | `"%County"` |
+| `contains` | Substring match | `"County"` |
+| `startswith` | Prefix match | `"06"` |
+| `endswith` | Suffix match | `"037"` |
+| `like` | SQL pattern match | `"%County"` |
 | `rlike` | Regex match | `"^06.*"` |
-| `between` | Between two values | `["2020", "2050"]` |
+| `isin` | In list | `["06037", "06073"]` |
+| `isNull` | Value is null | (value is ignored) |
+| `isNotNull` | Value is not null | (value is ignored) |
+| `between` | Between two values, inclusive | `["2020", "2050"]` |
+
+Filters with `filter_type: "expression"` interpolate their operator into SQL, so comparison
+operators such as `==`, `!=`, `>`, `>=`, `<`, and `<=` are written there instead.
 
 ## Negating Filters
 

--- a/docs/source/user_guide/tutorials/query_project.md
+++ b/docs/source/user_guide/tutorials/query_project.md
@@ -63,7 +63,7 @@ There is a CLI command that can generate a query file for your project. Refer to
               "2040",
               "2050",
             ],
-            "filter_type": "DimensionFilterColumnOperatorModel"
+            "filter_type": "column_operator"
           }
         ],
       }
@@ -142,7 +142,7 @@ If you only care about a limited number of fuel types, you could add this filter
             ],
             "operator": "isin",
             "negate": false,
-            "filter_type": "SupplementalDimensionFilterColumnOperatorModel"
+            "filter_type": "supplemental_column_operator"
           }
         ],
       }

--- a/dsgrid/cli/query.py
+++ b/dsgrid/cli/query.py
@@ -127,7 +127,7 @@ $ dsgrid query project create --default-result-aggregation my_query_result_name 
     show_default=True,
     help="Aggregation function for any included default aggregations. "
     f"Registered: {', '.join(sorted(SUPPORTED_AGGREGATIONS))}. Other names are "
-    "forwarded to the backend as-is.",
+    "uppercased and forwarded to the backend.",
 )
 @click.option(
     "-f",

--- a/dsgrid/cli/query.py
+++ b/dsgrid/cli/query.py
@@ -26,6 +26,7 @@ from dsgrid.dimension.dimension_filters import (
     SupplementalDimensionFilterColumnOperatorModel,
 )
 from dsgrid.filesystem.factory import make_filesystem_interface
+from dsgrid.ibis.aggregations import SUPPORTED_AGGREGATIONS
 from dsgrid.query.dataset_mapping_plan import DatasetMappingPlan
 from dsgrid.query.derived_dataset import create_derived_dataset_config_from_query
 from dsgrid.query.models import (
@@ -124,7 +125,9 @@ $ dsgrid query project create --default-result-aggregation my_query_result_name 
     "--aggregation-function",
     default="sum",
     show_default=True,
-    help="Aggregation function for any included default aggregations.",
+    help="Aggregation function for any included default aggregations. "
+    f"Registered: {', '.join(sorted(SUPPORTED_AGGREGATIONS))}. Other names are "
+    "forwarded to the backend as-is.",
 )
 @click.option(
     "-f",

--- a/dsgrid/dataset/unpivoted_table.py
+++ b/dsgrid/dataset/unpivoted_table.py
@@ -129,18 +129,12 @@ def _get_metric_column_name(context: QueryContext, metric_query_name):
 
 
 def _aggregate_value(df: ibis.Table, group_by_cols: list[str], op_name: str) -> ibis.Table:
-    # Fast path: when all group-by entries are bare column references and
-    # ``op_name`` is a registered reduction, dispatch through native Ibis to
-    # keep the chain lazy and let the planner fuse adjacent aggregations.
-    #
-    # Only registered names take this path because ``FunctionReference``
-    # accepts any backend SQL identifier. Without that restriction, names
-    # like ``round`` would resolve to Ibis's scalar column method
-    # ``df[col].round`` instead of a reduction, and
-    # ``df.group_by(...).aggregate(c=df[col].round())`` is a non-aggregate
-    # inside an aggregate — which either errors or silently produces wrong
-    # SQL. Unregistered names fall through to the SQL-string path below,
-    # which forwards them verbatim to the backend.
+    # Fast path: registered reductions over bare group-by columns dispatch
+    # through native Ibis, keeping the chain lazy. Everything else takes the
+    # SQL path below. Unregistered names must not reach the fast path:
+    # resolving an arbitrary identifier against the Ibis column API could
+    # pick a scalar method (e.g. ``round``), which is invalid inside
+    # ``aggregate()``.
     spec = find_aggregation_spec(op_name)
     bare_cols = [col for col in group_by_cols if _looks_like_bare_column(col, df.columns)]
     if spec is not None and len(bare_cols) == len(group_by_cols):

--- a/dsgrid/dataset/unpivoted_table.py
+++ b/dsgrid/dataset/unpivoted_table.py
@@ -5,6 +5,7 @@ import ibis
 
 from dsgrid.common import VALUE_COLUMN
 from dsgrid.dimension.base_models import DimensionType
+from dsgrid.ibis.aggregations import find_aggregation_spec, sql_aggregate_expression
 from dsgrid.ibis.backend import get_runtime_backend
 from dsgrid.ibis.operations import create_temp_view, handle_column_spaces
 from dsgrid.query.models import (
@@ -127,28 +128,23 @@ def _get_metric_column_name(context: QueryContext, metric_query_name):
     return metric_column
 
 
-_AGGREGATE_FAST_PATH_OPS = frozenset(
-    {"sum", "mean", "min", "max", "count", "median", "approx_median", "first", "last"}
-)
-
-
 def _aggregate_value(df: ibis.Table, group_by_cols: list[str], op_name: str) -> ibis.Table:
     # Fast path: when all group-by entries are bare column references and
-    # ``op_name`` is a known reduction, dispatch through native Ibis to keep
-    # the chain lazy and let the planner fuse adjacent aggregations.
+    # ``op_name`` is a registered reduction, dispatch through native Ibis to
+    # keep the chain lazy and let the planner fuse adjacent aggregations.
     #
-    # We allowlist the reductions explicitly because ``FunctionReference``
-    # accepts any backend SQL identifier.
-    # Without the allowlist, names like ``round`` would resolve to Ibis's
-    # scalar column method ``df[col].round`` instead of a reduction, and
+    # Only registered names take this path because ``FunctionReference``
+    # accepts any backend SQL identifier. Without that restriction, names
+    # like ``round`` would resolve to Ibis's scalar column method
+    # ``df[col].round`` instead of a reduction, and
     # ``df.group_by(...).aggregate(c=df[col].round())`` is a non-aggregate
     # inside an aggregate — which either errors or silently produces wrong
-    # SQL. Anything not in the allowlist falls through to the SQL-string
-    # path below, which forwards the name verbatim to the backend.
-    ibis_op = "mean" if op_name == "mean" else op_name
+    # SQL. Unregistered names fall through to the SQL-string path below,
+    # which forwards them verbatim to the backend.
+    spec = find_aggregation_spec(op_name)
     bare_cols = [col for col in group_by_cols if _looks_like_bare_column(col, df.columns)]
-    if ibis_op in _AGGREGATE_FAST_PATH_OPS and len(bare_cols) == len(group_by_cols):
-        agg_method = getattr(df[VALUE_COLUMN], ibis_op)
+    if spec is not None and len(bare_cols) == len(group_by_cols):
+        agg_method = getattr(df[VALUE_COLUMN], spec.ibis_method)
         return df.group_by(bare_cols).aggregate(**{VALUE_COLUMN: agg_method()})
 
     # SQL-string fallback for group-by entries that carry function calls or
@@ -157,10 +153,9 @@ def _aggregate_value(df: ibis.Table, group_by_cols: list[str], op_name: str) -> 
     view = create_temp_view(df)
     select_cols = ", ".join(_select_expr(x) for x in group_by_cols)
     group_cols = ", ".join(_group_by_expr(x) for x in group_by_cols)
-    agg_func = "AVG" if op_name == "mean" else op_name.upper()
+    agg_expr = sql_aggregate_expression(op_name, handle_column_spaces(VALUE_COLUMN))
     query = (
-        f"SELECT {select_cols}, {agg_func}({handle_column_spaces(VALUE_COLUMN)}) "
-        f"AS {handle_column_spaces(VALUE_COLUMN)} FROM {view}"
+        f"SELECT {select_cols}, {agg_expr} " f"AS {handle_column_spaces(VALUE_COLUMN)} FROM {view}"
     )
     if group_cols:
         query += f" GROUP BY {group_cols}"

--- a/dsgrid/dimension/dimension_filters.py
+++ b/dsgrid/dimension/dimension_filters.py
@@ -8,6 +8,10 @@ from pydantic import field_validator, model_validator, Field
 
 from dsgrid.data_models import DSGBaseModel
 from dsgrid.dimension.base_models import DimensionType
+from dsgrid.dimension.filter_operators import (
+    FILTER_OPERATOR_NAMES,
+    apply_filter_operator,
+)
 from dsgrid.exceptions import DSGInvalidField, DSGInvalidParameter
 from dsgrid.ibis.operations import filter_sql
 
@@ -133,21 +137,17 @@ class DimensionFilterExpressionRawModel(_DimensionFilterWithWhereClauseModel):
         return text
 
 
-DIMENSION_COLUMN_FILTER_OPERATORS = {
-    "contains",
-    "endswith",
-    "isNotNull",
-    "isNull",
-    "isin",
-    "like",
-    "rlike",
-    "startswith",
-}
+# Derived from the registry in dsgrid.dimension.filter_operators; kept under
+# its historical name for backward compatibility.
+DIMENSION_COLUMN_FILTER_OPERATORS = FILTER_OPERATOR_NAMES
 
 
 def check_operator(operator):
     if operator not in DIMENSION_COLUMN_FILTER_OPERATORS:
-        msg = f"operator={operator} is not supported. Allowed={DIMENSION_COLUMN_FILTER_OPERATORS}"
+        msg = (
+            f"operator={operator} is not supported. "
+            f"Allowed={sorted(DIMENSION_COLUMN_FILTER_OPERATORS)}"
+        )
         raise ValueError(msg)
     return operator
 
@@ -159,47 +159,6 @@ def _make_sql_value(value: Any) -> str:
         return str(value)
     msg = f"Unsupported type: {type(value)}"
     raise DSGInvalidField(msg)
-
-
-def _apply_column_operator(
-    df: ibis.Table, column: str, operator: str, value: Any, negate: bool
-) -> ibis.Table:
-    col = df[column]
-    match operator:
-        case "contains":
-            expr = col.contains(value)
-        case "endswith":
-            expr = col.endswith(value)
-        case "isNotNull":
-            expr = col.notnull()
-        case "isNull":
-            expr = col.isnull()
-        case "isin":
-            if not isinstance(value, list | tuple | set):
-                msg = f"value must be a list, tuple, or set for {operator=}"
-                raise DSGInvalidField(msg)
-            expr = col.isin(list(value))
-        case "like":
-            expr = col.like(value)
-        case "rlike":
-            expr = col.re_search(value)
-        case "startswith":
-            expr = col.startswith(value)
-        case _:
-            msg = f"{operator=} is not supported"
-            raise DSGInvalidField(msg)
-    if negate:
-        expr = ~expr
-    return df.filter(expr)
-
-
-def _apply_between(
-    df: ibis.Table, column: str, lower_bound: Any, upper_bound: Any, negate: bool
-) -> ibis.Table:
-    expr = df[column].between(lower_bound, upper_bound)
-    if negate:
-        expr = ~expr
-    return df.filter(expr)
 
 
 class DimensionFilterColumnOperatorModel(DimensionFilterSingleQueryNameBaseModel):
@@ -230,7 +189,7 @@ class DimensionFilterColumnOperatorModel(DimensionFilterSingleQueryNameBaseModel
 
     def apply_filter(self, df, column=None):
         column = column or self.column
-        return _apply_column_operator(df, column, self.operator, self.value, self.negate)
+        return apply_filter_operator(df, column, self.operator, self.value, self.negate)
 
 
 class DimensionFilterBetweenColumnOperatorModel(DimensionFilterSingleQueryNameBaseModel):
@@ -258,7 +217,9 @@ class DimensionFilterBetweenColumnOperatorModel(DimensionFilterSingleQueryNameBa
 
     def apply_filter(self, df, column=None):
         column = column or self.column
-        return _apply_between(df, column, self.lower_bound, self.upper_bound, self.negate)
+        return apply_filter_operator(
+            df, column, "between", (self.lower_bound, self.upper_bound), self.negate
+        )
 
 
 class SubsetDimensionFilterModel(DimensionFilterMultipleQueryNameBaseModel):
@@ -333,4 +294,4 @@ class SupplementalDimensionFilterColumnOperatorModel(DimensionFilterSingleQueryN
 
     def apply_filter(self, df, column=None):
         column = column or self.column
-        return _apply_column_operator(df, column, self.operator, self.value, self.negate)
+        return apply_filter_operator(df, column, self.operator, self.value, self.negate)

--- a/dsgrid/dimension/dimension_filters.py
+++ b/dsgrid/dimension/dimension_filters.py
@@ -8,7 +8,7 @@ from pydantic import field_validator, model_validator, Field
 
 from dsgrid.data_models import DSGBaseModel
 from dsgrid.dimension.base_models import DimensionType
-from dsgrid.dimension.filter_operators import (
+from dsgrid.ibis.filter_operators import (
     FILTER_OPERATOR_NAMES,
     apply_filter_operator,
 )
@@ -137,7 +137,7 @@ class DimensionFilterExpressionRawModel(_DimensionFilterWithWhereClauseModel):
         return text
 
 
-# Derived from the registry in dsgrid.dimension.filter_operators; kept under
+# Derived from the registry in dsgrid.ibis.filter_operators; kept under
 # its historical name for backward compatibility.
 DIMENSION_COLUMN_FILTER_OPERATORS = FILTER_OPERATOR_NAMES
 

--- a/dsgrid/dimension/filter_operators.py
+++ b/dsgrid/dimension/filter_operators.py
@@ -1,0 +1,135 @@
+"""Filter-operator definitions for dsgrid dimension filters.
+
+This module is the single source of truth for the column-filter operator
+vocabulary that may appear in a dimension filter's ``operator`` field. Every
+per-operator representation (the Ibis expression it builds, the shape of
+value it expects, its family bucket) lives on a :class:`FilterOperatorSpec`,
+and the operator set, the pydantic validator, and the dispatch all derive
+from :data:`FILTER_OPERATOR_SPECS`.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import ibis
+
+from dsgrid.exceptions import DSGInvalidField
+
+
+@dataclass(frozen=True)
+class FilterOperatorSpec:
+    """A column-filter operator that dsgrid users may name in a dimension filter.
+
+    Parameters
+    ----------
+    name
+        The user-facing token written in ``operator`` (e.g. ``"startswith"``).
+    family
+        Coarse bucket: ``"string"``, ``"null"``, ``"membership"``, or
+        ``"range"``.
+    value_kind
+        Expected shape of ``value``: ``"scalar"`` (one value), ``"none"``
+        (value ignored), ``"list"`` (list/tuple/set of values), or
+        ``"bounds"`` (two-element lower/upper pair).
+    apply
+        Builds the boolean Ibis expression from ``(column, checked_value)``.
+    """
+
+    name: str
+    family: str
+    value_kind: str
+    apply: Callable[[Any, Any], Any]
+
+
+FILTER_OPERATOR_SPECS: tuple[FilterOperatorSpec, ...] = (
+    FilterOperatorSpec("contains", "string", "scalar", lambda col, v: col.contains(v)),
+    FilterOperatorSpec("startswith", "string", "scalar", lambda col, v: col.startswith(v)),
+    FilterOperatorSpec("endswith", "string", "scalar", lambda col, v: col.endswith(v)),
+    FilterOperatorSpec("like", "string", "scalar", lambda col, v: col.like(v)),
+    FilterOperatorSpec("rlike", "string", "scalar", lambda col, v: col.re_search(v)),
+    FilterOperatorSpec("isNull", "null", "none", lambda col, v: col.isnull()),
+    FilterOperatorSpec("isNotNull", "null", "none", lambda col, v: col.notnull()),
+    FilterOperatorSpec("isin", "membership", "list", lambda col, v: col.isin(list(v))),
+    FilterOperatorSpec("between", "range", "bounds", lambda col, v: col.between(v[0], v[1])),
+)
+
+
+_BY_NAME: dict[str, FilterOperatorSpec] = {spec.name: spec for spec in FILTER_OPERATOR_SPECS}
+
+FILTER_OPERATOR_NAMES: frozenset[str] = frozenset(_BY_NAME)
+
+
+def spec_for_filter_operator(name: str) -> FilterOperatorSpec:
+    """Look up a :class:`FilterOperatorSpec` by user-facing name.
+
+    Raises
+    ------
+    DSGInvalidField
+        If ``name`` is not a supported filter operator.
+    """
+    spec = _BY_NAME.get(name)
+    if spec is None:
+        msg = f"operator={name} is not supported. Allowed={sorted(FILTER_OPERATOR_NAMES)}"
+        raise DSGInvalidField(msg)
+    return spec
+
+
+def check_filter_value(spec: FilterOperatorSpec, value: Any) -> Any:
+    """Validate ``value`` against the shape ``spec`` expects and return it.
+
+    Raises
+    ------
+    DSGInvalidField
+        If ``value`` does not have the shape the operator requires.
+    """
+    match spec.value_kind:
+        case "scalar":
+            return value
+        case "none":
+            return None
+        case "list":
+            if not isinstance(value, list | tuple | set):
+                msg = f"value must be a list, tuple, or set for operator={spec.name!r}"
+                raise DSGInvalidField(msg)
+            return value
+        case "bounds":
+            if not isinstance(value, list | tuple) or len(value) != 2:
+                msg = (
+                    "value must be a two-element list or tuple of (lower, upper) for "
+                    f"operator={spec.name!r}"
+                )
+                raise DSGInvalidField(msg)
+            return value
+        case _:
+            msg = f"Bug: unhandled value_kind={spec.value_kind!r} for operator={spec.name!r}"
+            raise NotImplementedError(msg)
+
+
+def apply_filter_operator(
+    df: ibis.Table, column: str, operator: str, value: Any, negate: bool
+) -> ibis.Table:
+    """Filter ``df`` where ``column`` matches ``operator`` applied to ``value``.
+
+    Parameters
+    ----------
+    df : ibis.Table
+    column : str
+        Name of the column to filter on.
+    operator : str
+        A name in :data:`FILTER_OPERATOR_NAMES`.
+    value : Any
+        The operator's operand, in the shape its ``value_kind`` requires.
+    negate : bool
+        If True, keep the rows the operator would reject.
+
+    Raises
+    ------
+    DSGInvalidField
+        If ``operator`` is not supported or ``value`` has the wrong shape.
+    """
+    spec = spec_for_filter_operator(operator)
+    checked = check_filter_value(spec, value)
+    expr = spec.apply(df[column], checked)
+    if negate:
+        expr = ~expr
+    return df.filter(expr)

--- a/dsgrid/ibis/aggregations.py
+++ b/dsgrid/ibis/aggregations.py
@@ -9,8 +9,10 @@ Spark SQL expressions for the raw-SQL fallback) lives on an
 
 dsgrid deliberately does not reject unregistered names: any plain SQL
 identifier accepted by :class:`~dsgrid.query.models.FunctionReference` is
-forwarded verbatim to the backend, which may reject it at execution time.
-Registered names get the native fast path and backend-correct SQL spellings;
+uppercased and forwarded to the backend, which may reject it at execution
+time. (SQL function names are case-insensitive on both backends, so the
+uppercasing does not change which function runs.) Registered names get the
+native fast path and backend-correct SQL spellings;
 :func:`sql_aggregate_expression` implements both rules in one place.
 """
 
@@ -98,9 +100,9 @@ def sql_aggregate_expression(op_name: str, column: str) -> str:
     """Build the SQL aggregation expression for ``op_name`` over ``column``.
 
     Registered names use their per-backend template. Unregistered names are
-    uppercased and forwarded verbatim, preserving dsgrid's passthrough
-    contract for any backend function a user cares to name; the backend
-    rejects names it does not know at execution time.
+    uppercased and forwarded otherwise unchanged, preserving dsgrid's
+    passthrough contract for any backend function a user cares to name; the
+    backend rejects names it does not know at execution time.
 
     Parameters
     ----------

--- a/dsgrid/ibis/aggregations.py
+++ b/dsgrid/ibis/aggregations.py
@@ -1,0 +1,116 @@
+"""Aggregation-function definitions for the dsgrid Ibis abstraction layer.
+
+This module is the single source of truth for the aggregation-function
+vocabulary that may appear in a query's
+:class:`~dsgrid.query.models.AggregationModel`. Every per-function
+representation (Ibis reduction method for the native fast path, DuckDB and
+Spark SQL expressions for the raw-SQL fallback) lives on an
+:class:`AggregationSpec`.
+
+dsgrid deliberately does not reject unregistered names: any plain SQL
+identifier accepted by :class:`~dsgrid.query.models.FunctionReference` is
+forwarded verbatim to the backend, which may reject it at execution time.
+Registered names get the native fast path and backend-correct SQL spellings;
+:func:`sql_aggregate_expression` implements both rules in one place.
+"""
+
+from dataclasses import dataclass
+
+from dsgrid.ibis.types import use_duckdb
+
+
+@dataclass(frozen=True)
+class AggregationSpec:
+    """An aggregation function that dsgrid users may name in a query.
+
+    Parameters
+    ----------
+    name
+        The user-facing token written in ``aggregation_function``
+        (e.g. ``"mean"``).
+    ibis_method
+        The Ibis ``Column`` reduction method used on the native fast path.
+        It must be a reduction; scalar methods (e.g. ``round``) are not
+        valid inside ``aggregate()``.
+    duckdb_sql
+        DuckDB SQL expression template for the raw-SQL fallback, with a
+        ``{column}`` placeholder for the (already quoted) value column.
+    spark_sql
+        The same, for Spark SQL.
+    """
+
+    name: str
+    ibis_method: str
+    duckdb_sql: str
+    spark_sql: str
+
+
+# The first value of each AggregationSpec is the user-facing name to use in
+# ``aggregation_function``. first/last are order-dependent on both backends,
+# and their raw-SQL forms do not skip nulls while the Ibis reductions do.
+AGGREGATION_SPECS: tuple[AggregationSpec, ...] = (
+    AggregationSpec("sum", "sum", "SUM({column})", "SUM({column})"),
+    AggregationSpec("mean", "mean", "AVG({column})", "AVG({column})"),
+    AggregationSpec("min", "min", "MIN({column})", "MIN({column})"),
+    AggregationSpec("max", "max", "MAX({column})", "MAX({column})"),
+    AggregationSpec("count", "count", "COUNT({column})", "COUNT({column})"),
+    AggregationSpec("median", "median", "MEDIAN({column})", "MEDIAN({column})"),
+    AggregationSpec(
+        "approx_median",
+        "approx_median",
+        "APPROX_QUANTILE({column}, 0.5)",
+        "PERCENTILE_APPROX({column}, 0.5)",
+    ),
+    AggregationSpec("first", "first", "FIRST({column})", "FIRST({column})"),
+    AggregationSpec("last", "last", "LAST({column})", "LAST({column})"),
+)
+
+
+_BY_NAME: dict[str, AggregationSpec] = {spec.name: spec for spec in AGGREGATION_SPECS}
+
+SUPPORTED_AGGREGATIONS: frozenset[str] = frozenset(_BY_NAME)
+
+
+def find_aggregation_spec(name: str) -> AggregationSpec | None:
+    """Return the :class:`AggregationSpec` for ``name``, or None if unregistered."""
+    return _BY_NAME.get(name)
+
+
+def spec_for_aggregation(name: str) -> AggregationSpec:
+    """Look up an :class:`AggregationSpec` by user-facing name.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered dsgrid aggregation function.
+    """
+    spec = find_aggregation_spec(name)
+    if spec is None:
+        msg = (
+            f"Unregistered dsgrid aggregation function {name!r}; "
+            f"registered: {sorted(SUPPORTED_AGGREGATIONS)}"
+        )
+        raise KeyError(msg)
+    return spec
+
+
+def sql_aggregate_expression(op_name: str, column: str) -> str:
+    """Build the SQL aggregation expression for ``op_name`` over ``column``.
+
+    Registered names use their per-backend template. Unregistered names are
+    uppercased and forwarded verbatim, preserving dsgrid's passthrough
+    contract for any backend function a user cares to name; the backend
+    rejects names it does not know at execution time.
+
+    Parameters
+    ----------
+    op_name : str
+        The user-facing aggregation-function name.
+    column : str
+        The value column, already quoted for the active backend.
+    """
+    spec = find_aggregation_spec(op_name)
+    if spec is None:
+        return f"{op_name.upper()}({column})"
+    template = spec.duckdb_sql if use_duckdb() else spec.spark_sql
+    return template.format(column=column)

--- a/dsgrid/ibis/aggregations.py
+++ b/dsgrid/ibis/aggregations.py
@@ -78,24 +78,6 @@ def find_aggregation_spec(name: str) -> AggregationSpec | None:
     return _BY_NAME.get(name)
 
 
-def spec_for_aggregation(name: str) -> AggregationSpec:
-    """Look up an :class:`AggregationSpec` by user-facing name.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` is not a registered dsgrid aggregation function.
-    """
-    spec = find_aggregation_spec(name)
-    if spec is None:
-        msg = (
-            f"Unregistered dsgrid aggregation function {name!r}; "
-            f"registered: {sorted(SUPPORTED_AGGREGATIONS)}"
-        )
-        raise KeyError(msg)
-    return spec
-
-
 def sql_aggregate_expression(op_name: str, column: str) -> str:
     """Build the SQL aggregation expression for ``op_name`` over ``column``.
 

--- a/dsgrid/ibis/filter_operators.py
+++ b/dsgrid/ibis/filter_operators.py
@@ -1,7 +1,8 @@
-"""Filter-operator definitions for dsgrid dimension filters.
+"""Filter-operator definitions for the dsgrid Ibis abstraction layer.
 
 This module is the single source of truth for the column-filter operator
-vocabulary that may appear in a dimension filter's ``operator`` field. Every
+vocabulary that may appear in a dimension filter's ``operator`` field
+(see :mod:`dsgrid.dimension.dimension_filters`). Every
 per-operator representation (the Ibis expression it builds, the shape of
 value it expects, its family bucket) lives on a :class:`FilterOperatorSpec`,
 and the operator set, the pydantic validator, and the dispatch all derive

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -184,7 +184,8 @@ class AggregationModel(DSGBaseModel):
             if aggregation_function not in SUPPORTED_AGGREGATIONS:
                 logger.warning(
                     "aggregation_function=%r is not a registered dsgrid aggregation; it will "
-                    "be forwarded verbatim to the backend, which may reject it. Registered: %s",
+                    "be uppercased and forwarded to the backend, which may reject it. "
+                    "Registered: %s",
                     aggregation_function,
                     sorted(SUPPORTED_AGGREGATIONS),
                 )

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -95,17 +95,24 @@ class ColumnModel(DSGBaseModel):
     """Defines one column in a SQL aggregation statement."""
 
     dimension_name: str
-    function: Any = Field(default=None, description="Function or name of an aggregation function.")
+    function: Any = Field(
+        default=None,
+        description="Name of a SQL function to apply to the column (e.g. 'hour'), or a "
+        "FunctionReference.",
+    )
     alias: str | None = Field(default=None, description="Name of the resulting column.")
 
     @field_validator("function")
     @classmethod
     def handle_function(cls, function_name):
-        if function_name is None:
+        if function_name is None or isinstance(function_name, FunctionReference):
             return function_name
         if not isinstance(function_name, str):
-            return function_name
-
+            msg = (
+                "function must be a function name (str), a FunctionReference, or None; "
+                f"got {type(function_name).__name__}"
+            )
+            raise ValueError(msg)
         return FunctionReference(function_name)
 
     @field_validator("alias")
@@ -180,20 +187,26 @@ class AggregationModel(DSGBaseModel):
     @field_validator("aggregation_function")
     @classmethod
     def check_aggregation_function(cls, aggregation_function):
-        if isinstance(aggregation_function, str):
-            if aggregation_function not in SUPPORTED_AGGREGATIONS:
-                logger.warning(
-                    "aggregation_function=%r is not a registered dsgrid aggregation; it will "
-                    "be uppercased and forwarded to the backend, which may reject it. "
-                    "Registered: %s",
-                    aggregation_function,
-                    sorted(SUPPORTED_AGGREGATIONS),
-                )
-            aggregation_function = FunctionReference(aggregation_function)
-        elif aggregation_function is None:
+        if aggregation_function is None:
             msg = "aggregation_function cannot be None"
             raise ValueError(msg)
-        return aggregation_function
+        if isinstance(aggregation_function, FunctionReference):
+            return aggregation_function
+        if not isinstance(aggregation_function, str):
+            msg = (
+                "aggregation_function must be a function name (str) or a FunctionReference; "
+                f"got {type(aggregation_function).__name__}"
+            )
+            raise ValueError(msg)
+        if aggregation_function not in SUPPORTED_AGGREGATIONS:
+            logger.warning(
+                "aggregation_function=%r is not a registered dsgrid aggregation; it will "
+                "be uppercased and forwarded to the backend, which may reject it. "
+                "Registered: %s",
+                aggregation_function,
+                sorted(SUPPORTED_AGGREGATIONS),
+            )
+        return FunctionReference(aggregation_function)
 
     @field_validator("dimensions")
     @classmethod

--- a/dsgrid/query/models.py
+++ b/dsgrid/query/models.py
@@ -1,5 +1,6 @@
 import abc
 import itertools
+import logging
 import re
 from enum import StrEnum
 from typing import Any, Generator, Union, Literal, Self, TypeAlias
@@ -26,10 +27,13 @@ from dsgrid.dimension.dimension_filters import (
     SupplementalDimensionFilterColumnOperatorModel,
 )
 from dsgrid.dimension.time import TimeBasedDataAdjustmentModel
+from dsgrid.ibis.aggregations import SUPPORTED_AGGREGATIONS
 from dsgrid.query.dataset_mapping_plan import (
     DatasetMappingPlan,
 )
 from dsgrid.utils.files import compute_hash
+
+logger = logging.getLogger(__name__)
 
 DimensionFilters: TypeAlias = Annotated[
     Union[
@@ -61,8 +65,9 @@ class FunctionReference:
     fragments to be injected into the interpolated query string the
     aggregation/column-expression builders produce.
 
-    The special-case name ``"mean"`` is translated to SQL ``AVG`` inside
-    :func:`dsgrid.dataset.unpivoted_table._aggregate_value`. All other
+    Names registered in :data:`dsgrid.ibis.aggregations.AGGREGATION_SPECS`
+    (see :data:`~dsgrid.ibis.aggregations.SUPPORTED_AGGREGATIONS`) carry
+    backend-correct SQL spellings and a native Ibis fast path. All other
     names are uppercased and passed through unchanged.
     """
 
@@ -176,6 +181,13 @@ class AggregationModel(DSGBaseModel):
     @classmethod
     def check_aggregation_function(cls, aggregation_function):
         if isinstance(aggregation_function, str):
+            if aggregation_function not in SUPPORTED_AGGREGATIONS:
+                logger.warning(
+                    "aggregation_function=%r is not a registered dsgrid aggregation; it will "
+                    "be forwarded verbatim to the backend, which may reject it. Registered: %s",
+                    aggregation_function,
+                    sorted(SUPPORTED_AGGREGATIONS),
+                )
             aggregation_function = FunctionReference(aggregation_function)
         elif aggregation_function is None:
             msg = "aggregation_function cannot be None"

--- a/tests/test_dimension_filters.py
+++ b/tests/test_dimension_filters.py
@@ -8,6 +8,7 @@ from dsgrid.dimension.dimension_filters import (
     SupplementalDimensionFilterColumnOperatorModel,
     _make_sql_value,
 )
+from dsgrid.dimension.filter_operators import FILTER_OPERATOR_NAMES, apply_filter_operator
 from dsgrid.exceptions import DSGInvalidField
 from dsgrid.ibis.session import create_dataframe_from_dicts
 
@@ -154,6 +155,61 @@ def test_supplemental_column_operator_defaults(name_table):
 def test_unknown_operator_rejected():
     with pytest.raises(ValidationError, match="is not supported"):
         _model("cont", "lph")
+
+
+@pytest.fixture
+def year_table():
+    return create_dataframe_from_dicts(
+        [
+            {"id": "a", "year": 2019},
+            {"id": "b", "year": 2020},
+            {"id": "c", "year": 2021},
+        ]
+    )
+
+
+def test_between_via_column_operator(year_table):
+    """The column-operator model accepts the two-element form its ``value``
+    field description has always promised."""
+    model = _model("between", [2020, 2021], column="year")
+    assert _filter_ids(model, year_table) == ["b", "c"]
+
+
+def test_between_via_column_operator_negate(year_table):
+    model = _model("between", [2020, 2021], negate=True, column="year")
+    assert _filter_ids(model, year_table) == ["a"]
+
+
+@pytest.mark.parametrize("value", [2020, [2020], [2019, 2020, 2021]])
+def test_between_value_arity_error(year_table, value):
+    with pytest.raises(DSGInvalidField, match="two-element"):
+        _filter_ids(_model("between", value, column="year"), year_table)
+
+
+# One (value, expected ids) sample per registered operator, evaluated against
+# name_table. Paired with test_every_operator_has_a_dispatch_case, this makes
+# it impossible to register an operator without a working applier.
+DISPATCH_CASES = [
+    ("contains", "lph", ["a"]),
+    ("startswith", "Be", ["b"]),
+    ("endswith", "ta", ["b", "c"]),
+    ("like", "A%", ["a"]),
+    ("rlike", "^B", ["b"]),
+    ("isNull", None, ["d"]),
+    ("isNotNull", None, ["a", "b", "c"]),
+    ("isin", ["Alpha", "Delta"], ["a", "c"]),
+    ("between", ["A", "C"], ["a", "b"]),
+]
+
+
+def test_every_operator_has_a_dispatch_case():
+    assert {case[0] for case in DISPATCH_CASES} == set(FILTER_OPERATOR_NAMES)
+
+
+@pytest.mark.parametrize("operator,value,expected", DISPATCH_CASES)
+def test_registry_drives_dispatch(name_table, operator, value, expected):
+    df = apply_filter_operator(name_table, "name", operator, value, negate=False)
+    assert [row.id for row in df.execute().itertuples()] == expected
 
 
 def test_make_sql_value():

--- a/tests/test_dimension_filters.py
+++ b/tests/test_dimension_filters.py
@@ -8,7 +8,7 @@ from dsgrid.dimension.dimension_filters import (
     SupplementalDimensionFilterColumnOperatorModel,
     _make_sql_value,
 )
-from dsgrid.dimension.filter_operators import FILTER_OPERATOR_NAMES, apply_filter_operator
+from dsgrid.ibis.filter_operators import FILTER_OPERATOR_NAMES, apply_filter_operator
 from dsgrid.exceptions import DSGInvalidField
 from dsgrid.ibis.session import create_dataframe_from_dicts
 

--- a/tests/test_dimension_filters.py
+++ b/tests/test_dimension_filters.py
@@ -1,9 +1,11 @@
 import pytest
+from pydantic import ValidationError
 
 from dsgrid.dimension.base_models import DimensionType
 from dsgrid.dimension.dimension_filters import (
     DimensionFilterBetweenColumnOperatorModel,
     DimensionFilterColumnOperatorModel,
+    SupplementalDimensionFilterColumnOperatorModel,
     _make_sql_value,
 )
 from dsgrid.exceptions import DSGInvalidField
@@ -126,6 +128,32 @@ def test_between_negate():
         negate=True,
     )
     assert _filter_ids(model, table) == ["a"]
+
+
+def test_supplemental_column_operator_apply_filter(name_table):
+    model = SupplementalDimensionFilterColumnOperatorModel(
+        dimension_type=DimensionType.GEOGRAPHY,
+        dimension_name="county",
+        column="name",
+        operator="startswith",
+        value="B",
+    )
+    assert _filter_ids(model, name_table) == ["b"]
+
+
+def test_supplemental_column_operator_defaults(name_table):
+    """The default filter (``like "%"``) matches every non-null record."""
+    model = SupplementalDimensionFilterColumnOperatorModel(
+        dimension_type=DimensionType.GEOGRAPHY,
+        dimension_name="county",
+        column="name",
+    )
+    assert _filter_ids(model, name_table) == ["a", "b", "c"]
+
+
+def test_unknown_operator_rejected():
+    with pytest.raises(ValidationError, match="is not supported"):
+        _model("cont", "lph")
 
 
 def test_make_sql_value():

--- a/tests/test_query_models.py
+++ b/tests/test_query_models.py
@@ -1,5 +1,7 @@
 """Tests for the open-ended ``FunctionReference`` set in dsgrid.query.models."""
 
+import logging
+
 import pytest
 
 from dsgrid.query.models import (
@@ -8,6 +10,22 @@ from dsgrid.query.models import (
     DimensionNamesModel,
     FunctionReference,
 )
+
+
+def _aggregation_model(name: str) -> AggregationModel:
+    return AggregationModel(
+        aggregation_function=name,
+        dimensions=DimensionNamesModel(
+            geography=[],
+            metric=["end_use"],
+            model_year=[],
+            scenario=[],
+            sector=[],
+            subsector=[],
+            time=[],
+            weather_year=[],
+        ),
+    )
 
 
 def test_function_reference_accepts_arbitrary_name():
@@ -23,19 +41,7 @@ def test_function_reference_accepts_arbitrary_name():
 )
 def test_aggregation_model_accepts_common_aggregations(name: str):
     """Aggregations that DuckDB/Spark know about should pass model validation."""
-    model = AggregationModel(
-        aggregation_function=name,
-        dimensions=DimensionNamesModel(
-            geography=[],
-            metric=["end_use"],
-            model_year=[],
-            scenario=[],
-            sector=[],
-            subsector=[],
-            time=[],
-            weather_year=[],
-        ),
-    )
+    model = _aggregation_model(name)
     assert model.aggregation_function.name == name
 
 
@@ -66,21 +72,33 @@ def test_aggregation_model_still_rejects_none():
         )
 
 
+def test_unregistered_aggregation_warns(caplog):
+    """Unregistered names are still accepted but flagged for discoverability."""
+    with caplog.at_level(logging.WARNING, logger="dsgrid.query.models"):
+        model = _aggregation_model("stddev")
+    assert model.aggregation_function.name == "stddev"
+    messages = [r.message for r in caplog.records if "stddev" in r.message]
+    assert messages, "expected a warning naming the unregistered aggregation"
+    assert "mean" in messages[0]  # the warning lists the registered names
+
+
+def test_registered_aggregation_does_not_warn(caplog):
+    with caplog.at_level(logging.WARNING, logger="dsgrid.query.models"):
+        _aggregation_model("mean")
+    assert not caplog.records
+
+
+def test_column_model_scalar_function_does_not_warn(caplog):
+    """ColumnModel functions are scalar extractions, not aggregations; names
+    outside the aggregation registry are the norm there and must not warn."""
+    with caplog.at_level(logging.WARNING, logger="dsgrid.query.models"):
+        ColumnModel(dimension_name="timestamp", function="hour")
+    assert not caplog.records
+
+
 def test_aggregation_model_serialization_round_trip():
     """Serializing the model emits the bare function name (string), not the object."""
-    model = AggregationModel(
-        aggregation_function="count",
-        dimensions=DimensionNamesModel(
-            geography=[],
-            metric=["end_use"],
-            model_year=[],
-            scenario=[],
-            sector=[],
-            subsector=[],
-            time=[],
-            weather_year=[],
-        ),
-    )
+    model = _aggregation_model("count")
     dumped = model.model_dump()
     assert dumped["aggregation_function"] == "count"
     # Round-trip back through validation.

--- a/tests/test_query_models.py
+++ b/tests/test_query_models.py
@@ -54,6 +54,36 @@ def test_column_model_accepts_scalar_extractions(name: str):
     assert col.alias == f"{name}__timestamp"
 
 
+def test_aggregation_model_accepts_function_reference(caplog):
+    """A pre-built FunctionReference passes through unwrapped and unwarned."""
+    ref = FunctionReference("sum")
+    with caplog.at_level(logging.WARNING, logger="dsgrid.query.models"):
+        model = _aggregation_model(ref)
+    assert model.aggregation_function is ref
+    assert not caplog.records
+
+
+@pytest.mark.parametrize("value", [123, sum, ["sum"]])
+def test_aggregation_model_rejects_other_types(value):
+    """Anything but a name or FunctionReference used to fall through untouched
+    and die later with an AttributeError on ``.name``; now it fails at
+    validation with a clear message."""
+    with pytest.raises(ValueError, match="must be a function name"):
+        _aggregation_model(value)
+
+
+def test_column_model_accepts_function_reference():
+    ref = FunctionReference("hour")
+    col = ColumnModel(dimension_name="timestamp", function=ref)
+    assert col.function is ref
+
+
+@pytest.mark.parametrize("value", [123, sum, ["hour"]])
+def test_column_model_rejects_other_types(value):
+    with pytest.raises(ValueError, match="must be a function name"):
+        ColumnModel(dimension_name="timestamp", function=value)
+
+
 def test_aggregation_model_still_rejects_none():
     """None remains explicitly disallowed."""
     with pytest.raises(ValueError, match="aggregation_function cannot be None"):

--- a/tests/test_unpivoted_table_aggregation.py
+++ b/tests/test_unpivoted_table_aggregation.py
@@ -25,6 +25,8 @@ import pytest
 
 from dsgrid.common import VALUE_COLUMN
 from dsgrid.dataset.unpivoted_table import _aggregate_value
+from dsgrid.ibis import aggregations
+from dsgrid.ibis.aggregations import AggregationSpec
 from dsgrid.ibis.session import create_dataframe_from_dicts
 
 from tests._helpers import collect as _collect
@@ -79,12 +81,14 @@ def test_sql_fallback_pinned_results(load_table, op):
         assert math.isclose(result[geography], expected), (op, geography)
 
 
-@pytest.mark.parametrize("op", sorted(EXPECTED))
+@pytest.mark.parametrize("op", [*sorted(EXPECTED), "approx_median"])
 def test_paths_agree(load_table, op):
     """The same logical query must not change its answer with the engine.
 
     A group-by column that carries an alias or function takes the raw-SQL
     fallback instead of the native-Ibis fast path; the results must match.
+    approx_median qualifies because both paths now use the same approximate
+    function, and the approximation is exact on a table this small.
     """
     fast = _by_group(_aggregate_value(load_table, ["geography"], op))
     fallback = _by_group(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, op))
@@ -114,12 +118,17 @@ def test_approx_median_fast_path(load_table):
     assert 5.0 <= result["NM"] <= 7.0
 
 
-def test_approx_median_sql_fallback_broken(load_table):
-    """Known bug: the SQL fallback interpolates ``APPROX_MEDIAN(value)``, a
-    function that exists on neither backend (DuckDB spells it
-    ``approx_quantile(x, 0.5)``; Spark SQL ``percentile_approx(x, 0.5)``)."""
-    with pytest.raises(Exception, match="(?i)approx_median"):
-        _collect(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, "approx_median"))
+def test_approx_median_sql_fallback(load_table):
+    """The registry supplies backend-correct spellings for approx_median.
+
+    Before the registry, this path uppercased the name into
+    ``APPROX_MEDIAN(value)``, a function that exists on neither backend
+    (DuckDB spells it ``approx_quantile(x, 0.5)``; Spark SQL
+    ``percentile_approx(x, 0.5)``), so this query always raised.
+    """
+    result = _by_group(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, "approx_median"))
+    assert 1.0 <= result["CO"] <= 6.0
+    assert 5.0 <= result["NM"] <= 7.0
 
 
 def test_group_by_expression_fallback(load_table):
@@ -135,3 +144,20 @@ def test_unregistered_op_passes_through(load_table):
     result = _by_group(_aggregate_value(load_table, ["geography"], "stddev"))
     assert math.isclose(result["CO"], math.sqrt(7.0))  # sample stddev of {1, 2, 6}
     assert math.isclose(result["NM"], math.sqrt(2.0))  # sample stddev of {5, 7}
+
+
+def test_registry_drives_both_paths(load_table, monkeypatch):
+    """Both execution paths must read the registry, not private tables.
+
+    Redefine ``sum`` to compute a max; if either path stops consulting the
+    registry (say, a hard-coded allowlist or ``.upper()`` passthrough comes
+    back), it keeps summing and this test fails.
+    """
+    monkeypatch.setitem(
+        aggregations._BY_NAME,
+        "sum",
+        AggregationSpec("sum", "max", "MAX({column})", "MAX({column})"),
+    )
+    for group_by in (["geography"], FORCED_SQL_GROUP_BY):
+        result = _by_group(_aggregate_value(load_table, group_by, "sum"))
+        assert result == EXPECTED["max"], group_by

--- a/tests/test_unpivoted_table_aggregation.py
+++ b/tests/test_unpivoted_table_aggregation.py
@@ -1,0 +1,137 @@
+"""Characterization tests for :func:`dsgrid.dataset.unpivoted_table._aggregate_value`.
+
+``_aggregate_value`` has two code paths that must produce identical results: a
+native-Ibis fast path (bare group-by columns and a known reduction) and a
+raw-SQL fallback (anything else). These tests pin the behavior of both paths
+over a small hand-verifiable table, so that a refactor of the dispatch logic
+must reproduce today's results exactly.
+
+The input table is small enough to check by eye:
+
+    geography  values           sum   mean  min  max  count  median
+    CO         1.0, 2.0, 6.0    9.0   3.0   1.0  6.0  3      2.0
+    NM         5.0, 7.0         12.0  6.0   5.0  7.0  2      6.0
+
+The fallback is forced with an aliased group-by (``"geography AS geography"``):
+``_looks_like_bare_column`` rejects anything containing ``" AS "``, so the
+semantics are identical to the bare column and the two paths can be compared
+directly.
+"""
+
+import math
+from typing import Any
+
+import pytest
+
+from dsgrid.common import VALUE_COLUMN
+from dsgrid.dataset.unpivoted_table import _aggregate_value
+from dsgrid.ibis.session import create_dataframe_from_dicts
+
+from tests._helpers import collect as _collect
+
+LOAD_ROWS: list[dict[str, Any]] = [
+    {"id": "co1", "geography": "CO", "value": 1.0},
+    {"id": "co2", "geography": "CO", "value": 2.0},
+    {"id": "co3", "geography": "CO", "value": 6.0},
+    {"id": "nm1", "geography": "NM", "value": 5.0},
+    {"id": "nm2", "geography": "NM", "value": 7.0},
+]
+
+GROUP_VALUES: dict[str, set[float]] = {"CO": {1.0, 2.0, 6.0}, "NM": {5.0, 7.0}}
+
+# Expected results for the ops whose value does not depend on row order.
+EXPECTED: dict[str, dict[str, float]] = {
+    "sum": {"CO": 9.0, "NM": 12.0},
+    "mean": {"CO": 3.0, "NM": 6.0},
+    "min": {"CO": 1.0, "NM": 5.0},
+    "max": {"CO": 6.0, "NM": 7.0},
+    "count": {"CO": 3, "NM": 2},
+    "median": {"CO": 2.0, "NM": 6.0},
+}
+
+# first/last are order-dependent on both backends; only membership is stable.
+ORDER_DEPENDENT_OPS = ("first", "last")
+
+# Group-by entries that force the raw-SQL fallback with unchanged semantics.
+FORCED_SQL_GROUP_BY = ["geography AS geography"]
+
+
+@pytest.fixture
+def load_table():
+    return create_dataframe_from_dicts(LOAD_ROWS)
+
+
+def _by_group(df) -> dict[str, Any]:
+    return {row.geography: getattr(row, VALUE_COLUMN) for row in _collect(df)}
+
+
+@pytest.mark.parametrize("op", sorted(EXPECTED))
+def test_fast_path_pinned_results(load_table, op):
+    result = _by_group(_aggregate_value(load_table, ["geography"], op))
+    for geography, expected in EXPECTED[op].items():
+        assert math.isclose(result[geography], expected), (op, geography)
+
+
+@pytest.mark.parametrize("op", sorted(EXPECTED))
+def test_sql_fallback_pinned_results(load_table, op):
+    result = _by_group(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, op))
+    for geography, expected in EXPECTED[op].items():
+        assert math.isclose(result[geography], expected), (op, geography)
+
+
+@pytest.mark.parametrize("op", sorted(EXPECTED))
+def test_paths_agree(load_table, op):
+    """The same logical query must not change its answer with the engine.
+
+    A group-by column that carries an alias or function takes the raw-SQL
+    fallback instead of the native-Ibis fast path; the results must match.
+    """
+    fast = _by_group(_aggregate_value(load_table, ["geography"], op))
+    fallback = _by_group(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, op))
+    assert fast.keys() == fallback.keys()
+    for geography in fast:
+        assert math.isclose(fast[geography], fallback[geography]), (op, geography)
+
+
+@pytest.mark.parametrize("op", ORDER_DEPENDENT_OPS)
+def test_fast_path_order_dependent_ops(load_table, op):
+    result = _by_group(_aggregate_value(load_table, ["geography"], op))
+    for geography, values in GROUP_VALUES.items():
+        assert result[geography] in values, (op, geography)
+
+
+@pytest.mark.parametrize("op", ORDER_DEPENDENT_OPS)
+def test_sql_fallback_order_dependent_ops(load_table, op):
+    result = _by_group(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, op))
+    for geography, values in GROUP_VALUES.items():
+        assert result[geography] in values, (op, geography)
+
+
+def test_approx_median_fast_path(load_table):
+    """Approximate medians vary by backend; pin only the possible range."""
+    result = _by_group(_aggregate_value(load_table, ["geography"], "approx_median"))
+    assert 1.0 <= result["CO"] <= 6.0
+    assert 5.0 <= result["NM"] <= 7.0
+
+
+def test_approx_median_sql_fallback_broken(load_table):
+    """Known bug: the SQL fallback interpolates ``APPROX_MEDIAN(value)``, a
+    function that exists on neither backend (DuckDB spells it
+    ``approx_quantile(x, 0.5)``; Spark SQL ``percentile_approx(x, 0.5)``)."""
+    with pytest.raises(Exception, match="(?i)approx_median"):
+        _collect(_aggregate_value(load_table, FORCED_SQL_GROUP_BY, "approx_median"))
+
+
+def test_group_by_expression_fallback(load_table):
+    """A function group-by takes the SQL path and aliases the derived column."""
+    result = _aggregate_value(load_table, ["substr(id, 1, 1) AS g1", "geography"], "sum")
+    by_group = {row.g1: getattr(row, VALUE_COLUMN) for row in _collect(result)}
+    assert by_group == {"c": 9.0, "n": 12.0}
+
+
+def test_unregistered_op_passes_through(load_table):
+    """A name outside the fast-path allowlist is forwarded verbatim to the
+    backend, even when every group-by column is bare."""
+    result = _by_group(_aggregate_value(load_table, ["geography"], "stddev"))
+    assert math.isclose(result["CO"], math.sqrt(7.0))  # sample stddev of {1, 2, 6}
+    assert math.isclose(result["NM"], math.sqrt(2.0))  # sample stddev of {5, 7}


### PR DESCRIPTION
Addresses the design flagged in dsgrid/dsgrid#414 [comment 4675630295](https://github.com/dsgrid/dsgrid/pull/414#issuecomment-4675630295): the aggregation and filter-operator vocabularies were scattered across hard-coded sets, special cases, and `match` arms, while data types had a single source of truth in `ibis/types.py:TYPE_SPECS`. This PR gives both vocabularies the same treatment.

## What changed

**Aggregations — `dsgrid/ibis/aggregations.py` (new).** Each `AggregationSpec` carries the user-facing name, the Ibis reduction method for the native fast path, and per-backend SQL templates for the raw-SQL fallback. `_aggregate_value` derives both its fast-path allowlist and its fallback SQL from the registry; the `mean→AVG` special case and the no-op `ibis_op = "mean" if op_name == "mean" else op_name` are gone (both are now the `mean` row's data).

*Policy: registry + passthrough.* Unregistered identifiers are still forwarded verbatim to the backend, preserving current flexibility, but `AggregationModel` now logs a warning listing the registered names — so "what can a user invoke and how do they discover it?" is answered at query-build time, in the CLI `--aggregation-function` help, and in the module docstring. `ColumnModel` scalar extractions (`hour`, `year`, …) deliberately do not warn.

**Operators — `dsgrid/dimension/filter_operators.py` (new).** Each `FilterOperatorSpec` carries the name, a family bucket (string/null/membership/range), the value shape it expects, and the callable building its Ibis expression. The operator set, the pydantic validator, and the dispatch all derive from the registry, replacing the three manually-synced copies (`DIMENSION_COLUMN_FILTER_OPERATORS`, `check_operator`, the `match` arms) plus the standalone `_apply_between`. `between` is now a registered operator; `DimensionFilterBetweenColumnOperatorModel` keeps its exact shape for saved-query compatibility and routes through the same dispatcher.

## Testing strategy: characterize first

The first commit adds characterization tests that pass against **unmodified** production code on both backends (43 tests), pinning both `_aggregate_value` paths for every op, path agreement for the same logical query (the dual-engine concern from r3453966621), verbatim passthrough of unregistered names, and unit-level coverage gaps in the filter tests. The refactor commits were then required to keep those tests green verbatim, with one documented exception (below). A mutation-style test (`test_registry_drives_both_paths`) redefines `sum` in the registry and asserts both execution paths follow it.

## Behavior changes (all additive or bug fixes)

- **Bug fix:** the SQL fallback used to uppercase `approx_median` into `APPROX_MEDIAN(value)`, which exists on **neither** backend (DuckDB: `Scalar Function with name approx_median does not exist`; Spark SQL has `percentile_approx`). The registry emits `APPROX_QUANTILE(x, 0.5)` / `PERCENTILE_APPROX(x, 0.5)`. The characterization test pinning the old failure was flipped to pin the fix — the only Phase-0 test the refactor touched. Every other registered name produces byte-identical SQL to the old `.upper()` path.
- `operator="between"` with a two-element value now validates on the column-operator models — exactly what `DimensionFilterColumnOperatorModel.value`'s field description and the how-to docs have promised all along (that documented usage previously raised `ValidationError`).
- `check_operator`'s error message sorts the allowed names (was nondeterministic set ordering).
- Docs: the `between_column_operator` example in `how_to_filter.md` used fields the model doesn't have (`column1`/`column2`/`operator`/`value`); fixed to `column`/`lower_bound`/`upper_bound`.

Out of scope, deliberately: the expression models' raw-SQL operator interpolation (deferred separately in r3453966647) and chronify (no aggregation names cross that boundary; `MeasurementType` is a data-semantics tag, not a reduction dsgrid runs).

## Verification

- DuckDB: 108 passed (`test_unpivoted_table_aggregation`, `test_dimension_filters`, `test_query_models`, `test_ibis_operations`)
- Spark: 104 passed, 4 skipped (pre-existing DuckDB-only relocation tests)
- `pre-commit` and `ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)